### PR TITLE
fix: validate holiday API URL scheme

### DIFF
--- a/test/test_attendance_analyzer.py
+++ b/test/test_attendance_analyzer.py
@@ -51,6 +51,19 @@ class TestHolidayLoading(unittest.TestCase):
         self.assertFalse(success)
         self.assertEqual(len(analyzer.holidays), 0)
 
+    def test_try_load_from_gov_api_rejects_non_http_scheme(self) -> None:
+        analyzer = AttendanceAnalyzer()
+        from urllib.parse import ParseResult
+
+        def fake_urlparse(_url: str) -> ParseResult:
+            return ParseResult(scheme='file', netloc='', path='', params='', query='', fragment='')
+
+        with patch('attendance_analyzer.urlparse', side_effect=fake_urlparse), \
+                patch('urllib.request.urlopen') as mock_urlopen:
+            success = analyzer._try_load_from_gov_api(2025)
+            mock_urlopen.assert_not_called()
+        self.assertFalse(success)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- harden holiday API loader by restricting URL schemes and using secure SSL context
- add regression test for rejecting non-HTTP holiday API URLs

## Testing
- `python3 -m unittest test.test_attendance_analyzer -v`
- `bandit -r .`


------
https://chatgpt.com/codex/tasks/task_e_68c472bed344832e90db1336156969a3