### PR TITLE
feat: add retry/backoff for holiday API

### DIFF
--- a/attendance_analyzer.py
+++ b/attendance_analyzer.py
@@ -11,6 +11,8 @@ import os
 import logging
 import time
 import ssl
+import random
+import socket
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import List, Dict, Tuple, Optional
@@ -422,22 +424,41 @@ class AttendanceAnalyzer:
             bool: 是否成功載入
         """
         import urllib.request
+        import urllib.error
         import json as _json
-        from urllib.error import URLError
+        from urllib.error import URLError, HTTPError
 
-        url = f"https://data.gov.tw/api/v1/rest/datastore_search?resource_id=W2&filters={{\"date\":\"{year}\"}}"
+        # API設定
+        url = "https://data.gov.tw/api/v1/rest/datastore_search?resource_id=W2&filters={\"date\":\"%s\"}" % year
         parsed = urlparse(url)
         if parsed.scheme not in {"http", "https"}:
             logger.warning("不支援的 URL scheme: %s", parsed.scheme)
             return False
         context = ssl.create_default_context()
 
-        for attempt in range(3):
+        # 重試與退避參數
+        try:
+            max_retries = int(os.getenv("HOLIDAY_API_MAX_RETRIES", "3"))
+        except ValueError:
+            max_retries = 3
+        try:
+            base_backoff = float(os.getenv("HOLIDAY_API_BACKOFF_BASE", "0.5"))
+        except ValueError:
+            base_backoff = 0.5
+        try:
+            max_backoff = float(os.getenv("HOLIDAY_API_MAX_BACKOFF", "8"))
+        except ValueError:
+            max_backoff = 8.0
+
+        attempt = 0
+        while attempt <= max_retries:
+            attempt += 1
             try:
+                logger.info("資訊: 嘗試載入 %d 年假日 (第 %d/%d 次)...", year, attempt, max_retries)
                 with urllib.request.urlopen(url, timeout=10, context=context) as response:  # nosec B310
                     data = _json.loads(response.read().decode('utf-8'))
                     if 'result' in data and 'records' in data['result']:
-                        valid_found = False
+                        added = 0
                         for record in data['result']['records']:
                             if record.get('isHoliday', 0) == 1:
                                 date_str = record.get('date', '')
@@ -445,18 +466,38 @@ class AttendanceAnalyzer:
                                     try:
                                         holiday_date = datetime.strptime(date_str, "%Y-%m-%d").date()
                                         self.holidays.add(holiday_date)
-                                        valid_found = True
+                                        added += 1
                                     except ValueError as e:
                                         logger.warning("跳過無效的日期格式 %r: %s", date_str, e)
-                        if valid_found:
+                        if added > 0:
                             return True
                         logger.warning("API 回傳資料但沒有有效的假日記錄")
-            except (URLError, _json.JSONDecodeError, ValueError) as e:
-                logger.warning("載入 %d 年假日資料失敗(%d/3): %s", year, attempt + 1, e)
-                time.sleep(1)
+                        # 視為可重試
+                        raise RuntimeError("empty holiday records")
+            except HTTPError as e:
+                status = getattr(e, 'code', None)
+                if status in (429, 500, 502, 503, 504):
+                    err_desc = f"HTTP {status}"
+                else:
+                    logger.warning("無法從API載入 %d 年假日資料: HTTP %s — 不重試。", year, status)
+                    return False
+            except (URLError, socket.timeout, TimeoutError, _json.JSONDecodeError, ValueError) as e:
+                err_desc = f"連線/解析錯誤: {e}"
+            except Exception as e:
+                err_desc = f"一般錯誤: {e}"
+
+            if attempt > max_retries:
+                logger.error("錯誤: 嘗試 %d 次後仍無法載入 %d 年假日資料。回退到基本假日。", max_retries, year)
+                break
+
+            sleep_s = min(max_backoff, base_backoff * (2 ** (attempt - 1)))
+            jitter = sleep_s * random.uniform(-0.1, 0.1)
+            wait_s = max(0.0, sleep_s + jitter)
+            logger.warning("%s，%.2f 秒後重試...", err_desc, wait_s)
+            time.sleep(wait_s)
 
         return False
-    
+
     def _load_basic_holidays(self, year: int) -> None:
         """載入基本固定假日（當API不可用時的備案）
         Args:

--- a/test/test_holiday_api_retry.py
+++ b/test/test_holiday_api_retry.py
@@ -1,0 +1,98 @@
+import os
+import json
+import unittest
+from datetime import datetime
+from unittest import mock
+
+from attendance_analyzer import AttendanceAnalyzer
+
+
+class DummyHTTPResponse:
+    def __init__(self, payload: dict, status: int = 200):
+        self._payload = payload
+        self.status = status
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestHolidayApiRetry(unittest.TestCase):
+    def setUp(self):
+        self._orig_env = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._orig_env)
+
+    def test_success_after_retries(self):
+        os.environ["HOLIDAY_API_MAX_RETRIES"] = "3"
+        calls = {"count": 0}
+
+        def flaky_urlopen(url, timeout=10, context=None):
+            calls["count"] += 1
+            if calls["count"] < 3:
+                raise Exception("temporary failure")
+            payload = {
+                "result": {
+                    "records": [
+                        {"isHoliday": 1, "date": "2026-01-01"},
+                        {"isHoliday": 0, "date": "2026-01-02"},
+                    ]
+                }
+            }
+            return DummyHTTPResponse(payload)
+
+        analyzer = AttendanceAnalyzer()
+
+        with mock.patch("urllib.request.urlopen", side_effect=flaky_urlopen):
+            ok = analyzer._try_load_from_gov_api(2026)
+
+        self.assertTrue(ok)
+        self.assertGreaterEqual(calls["count"], 3)
+        self.assertIn(datetime.strptime("2026/01/01", "%Y/%m/%d").date(), analyzer.holidays)
+
+    def test_retry_exhaustion_then_fallback(self):
+        os.environ["HOLIDAY_API_MAX_RETRIES"] = "2"
+
+        calls = {"count": 0}
+
+        def always_fail(url, timeout=10, context=None):
+            calls["count"] += 1
+            raise Exception("network down")
+
+        analyzer = AttendanceAnalyzer()
+
+        with mock.patch("urllib.request.urlopen", side_effect=always_fail):
+            ok = analyzer._try_load_from_gov_api(2027)
+
+        self.assertFalse(ok)
+        self.assertGreaterEqual(calls["count"], 1)
+
+    def test_timeout_then_success(self):
+        os.environ["HOLIDAY_API_MAX_RETRIES"] = "2"
+        import socket as _socket
+
+        seq = [
+            _socket.timeout("timed out"),
+            DummyHTTPResponse({
+                "result": {"records": [{"isHoliday": 1, "date": "2027-10-10"}]}
+            })
+        ]
+
+        def seq_urlopen(url, timeout=10, context=None):
+            v = seq.pop(0)
+            if isinstance(v, Exception):
+                raise v
+            return v
+
+        analyzer = AttendanceAnalyzer()
+        with mock.patch("urllib.request.urlopen", side_effect=seq_urlopen):
+            ok = analyzer._try_load_from_gov_api(2027)
+        self.assertTrue(ok)
+


### PR DESCRIPTION
Fixes #3

- Exponential backoff + jitter; env knobs HOLIDAY_API_MAX_RETRIES, HOLIDAY_API_BACKOFF_BASE, HOLIDAY_API_MAX_BACKOFF
- Retries on timeouts/429/5xx; graceful fallback
- Tests: success-after-retry, exhaustion, timeout→success