### PR TITLE
feat(cli): clearer --reset-state message with timestamp

### DIFF
--- a/attendance_analyzer.py
+++ b/attendance_analyzer.py
@@ -1127,7 +1127,7 @@ def main():
             if user_name in state_manager.state_data.get("users", {}):
                 del state_manager.state_data["users"][user_name]
                 state_manager.save_state()
-                logger.info("🗑️  已清除 %s 的處理狀態", user_name)
+                logger.info("🗑️  狀態檔 'attendance_state.json' 已清除使用者 %s 的記錄 @ %s", user_name, datetime.now().isoformat())
             else:
                 logger.info("ℹ️  使用者 %s 沒有現有狀態需要清除", user_name)
         else:

--- a/test/test_cli_reset_state.py
+++ b/test/test_cli_reset_state.py
@@ -1,0 +1,39 @@
+import os
+import json
+import tempfile
+import unittest
+from unittest import mock
+
+import attendance_analyzer as mod
+
+
+class TestCliResetState(unittest.TestCase):
+    def test_reset_state_logs_confirmation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = os.path.join(tmpdir, 'attendance_state.json')
+            user_name = '阿明'
+            state = {"users": {user_name: {"processed_date_ranges": [], "forget_punch_usage": {}}}}
+            with open(state_path, 'w', encoding='utf-8') as f:
+                json.dump(state, f)
+
+            file_path = os.path.join(tmpdir, '202508-阿明-出勤資料.txt')
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write("應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n")
+
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                argv = ['attendance_analyzer.py', file_path, '--reset-state']
+                with self.assertLogs(level='INFO') as cm:
+                    with mock.patch('sys.argv', argv):
+                        mod.main()
+                logs = "\n".join(cm.output)
+                self.assertIn("狀態檔 'attendance_state.json' 已清除使用者", logs)
+                self.assertIn(user_name, logs)
+                self.assertIn("@ ", logs)
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #9

- Prints state filename and ISO timestamp (logger.info)
- Test uses assertLogs to verify message