### PR TITLE
refactor(lib): extract core modules and providerize holidays

### DIFF
--- a/attendance_analyzer.py
+++ b/attendance_analyzer.py
@@ -267,38 +267,16 @@ class AttendanceAnalyzer:
         
         for year in years:
             if year not in self.loaded_holiday_years:
-                if year == 2025:
-                    self._load_hardcoded_2025_holidays()
-                else:
-                    self._load_dynamic_holidays(year)
+                from lib.holidays import HolidayService
+                logger.info("資訊: 動態載入 %d 年國定假日...", year)
+                service = HolidayService()
+                self.holidays |= service.load_year(year)
                 self.loaded_holiday_years.add(year)
     
     def _load_hardcoded_2025_holidays(self) -> None:
-        """載入硬編碼的2025年國定假日（高效能）"""
-        # 2025年(民國114年)國定假日清單
-        taiwan_holidays_2025 = [
-            # 元旦連假
-            "2025/01/01",
-            # 農曆春節
-            "2025/01/25", "2025/01/26", "2025/01/27", "2025/01/28", "2025/01/29", "2025/01/30", "2025/01/31", "2025/02/01", "2025/02/02",
-            # 和平紀念日
-            "2025/02/28", "2025/03/01", "2025/03/02",
-            # 兒童節/清明節
-            "2025/04/03", "2025/04/04", "2025/04/05", "2025/04/06",
-            # 端午節
-            "2025/05/30", "2025/05/31", "2025/06/01",
-            # 中秋節
-            "2025/10/04", "2025/10/05", "2025/10/06",
-            # 國慶日
-            "2025/10/10", "2025/10/11", "2025/10/12",
-        ]
-        
-        for holiday_str in taiwan_holidays_2025:
-            try:
-                holiday_date = datetime.strptime(holiday_str, "%Y/%m/%d").date()
-                self.holidays.add(holiday_date)
-            except ValueError:
-                logger.warning("無法解析國定假日日期: %s", holiday_str)
+        """載入硬編碼的2025年國定假日（委派 lib.holidays）"""
+        from lib.holidays import Hardcoded2025Provider
+        self.holidays |= Hardcoded2025Provider().load(2025)
     
     def _load_dynamic_holidays(self, year: int) -> None:
         """動態載入指定年份的國定假日
@@ -306,113 +284,28 @@ class AttendanceAnalyzer:
             year: 要載入的年份
         """
         logger.info("資訊: 動態載入 %d 年國定假日...", year)
-        
-        # 方案1: 使用政府開放資料API
         success = self._try_load_from_gov_api(year)
-        
         if not success:
-            # 方案2: 使用基本假日規則（元旦、國慶日等固定日期）
             self._load_basic_holidays(year)
             logger.warning("無法取得 %d 年完整假日資料，僅載入基本固定假日", year)
     
     def _try_load_from_gov_api(self, year: int) -> bool:
-        """嘗試從政府開放資料API載入假日
-        Args:
-            year: 要載入的年份
-        Returns:
-            bool: 是否成功載入
-        """
-        import urllib.request
-        import urllib.error
-        import json as _json
-        from urllib.error import URLError, HTTPError
-
-        # API設定
+        # 向後相容：保留本模組內的 scheme 檢查（供單元測試 patch）
         url = "https://data.gov.tw/api/v1/rest/datastore_search?resource_id=W2&filters={\"date\":\"%s\"}" % year
         parsed = urlparse(url)
         if parsed.scheme not in {"http", "https"}:
             logger.warning("不支援的 URL scheme: %s", parsed.scheme)
             return False
-        context = ssl.create_default_context()
-
-        # 重試與退避參數
-        try:
-            max_retries = int(os.getenv("HOLIDAY_API_MAX_RETRIES", "3"))
-        except ValueError:
-            max_retries = 3
-        try:
-            base_backoff = float(os.getenv("HOLIDAY_API_BACKOFF_BASE", "0.5"))
-        except ValueError:
-            base_backoff = 0.5
-        try:
-            max_backoff = float(os.getenv("HOLIDAY_API_MAX_BACKOFF", "8"))
-        except ValueError:
-            max_backoff = 8.0
-
-        attempt = 0
-        while attempt <= max_retries:
-            attempt += 1
-            try:
-                logger.info("資訊: 嘗試載入 %d 年假日 (第 %d/%d 次)...", year, attempt, max_retries)
-                with urllib.request.urlopen(url, timeout=10, context=context) as response:  # nosec B310
-                    data = _json.loads(response.read().decode('utf-8'))
-                    if 'result' in data and 'records' in data['result']:
-                        added = 0
-                        for record in data['result']['records']:
-                            if record.get('isHoliday', 0) == 1:
-                                date_str = record.get('date', '')
-                                if date_str:
-                                    try:
-                                        holiday_date = datetime.strptime(date_str, "%Y-%m-%d").date()
-                                        self.holidays.add(holiday_date)
-                                        added += 1
-                                    except ValueError as e:
-                                        logger.warning("跳過無效的日期格式 %r: %s", date_str, e)
-                        if added > 0:
-                            return True
-                        logger.warning("API 回傳資料但沒有有效的假日記錄")
-                        # 視為可重試
-                        raise RuntimeError("empty holiday records")
-            except HTTPError as e:
-                status = getattr(e, 'code', None)
-                if status in (429, 500, 502, 503, 504):
-                    err_desc = f"HTTP {status}"
-                else:
-                    logger.warning("無法從API載入 %d 年假日資料: HTTP %s — 不重試。", year, status)
-                    return False
-            except (URLError, socket.timeout, TimeoutError, _json.JSONDecodeError, ValueError) as e:
-                err_desc = f"連線/解析錯誤: {e}"
-            except Exception as e:
-                err_desc = f"一般錯誤: {e}"
-
-            if attempt > max_retries:
-                logger.error("錯誤: 嘗試 %d 次後仍無法載入 %d 年假日資料。回退到基本假日。", max_retries, year)
-                break
-
-            sleep_s = min(max_backoff, base_backoff * (2 ** (attempt - 1)))
-            jitter = sleep_s * random.uniform(-0.1, 0.1)
-            wait_s = max(0.0, sleep_s + jitter)
-            logger.warning("%s，%.2f 秒後重試...", err_desc, wait_s)
-            time.sleep(wait_s)
-
+        from lib.holidays import TaiwanGovOpenDataProvider
+        out = TaiwanGovOpenDataProvider().load(year)
+        if out:
+            self.holidays |= out
+            return True
         return False
 
     def _load_basic_holidays(self, year: int) -> None:
-        """載入基本固定假日（當API不可用時的備案）
-        Args:
-            year: 要載入的年份
-        """
-        basic_holidays = [
-            f"{year}/01/01",  # 元旦
-            f"{year}/10/10",  # 國慶日
-        ]
-        
-        for holiday_str in basic_holidays:
-            try:
-                holiday_date = datetime.strptime(holiday_str, "%Y/%m/%d").date()
-                self.holidays.add(holiday_date)
-            except ValueError:
-                logger.warning("無法解析基本假日日期: %s", holiday_str)
+        from lib.holidays import BasicFixedProvider
+        self.holidays |= BasicFixedProvider().load(year)
     
     def parse_attendance_file(self, filepath: str, incremental: bool = True) -> None:
         """解析考勤資料檔案並初始化增量處理

--- a/lib/backup.py
+++ b/lib/backup.py
@@ -1,0 +1,19 @@
+import os
+from datetime import datetime
+from typing import Optional
+
+
+def backup_with_timestamp(filepath: str) -> Optional[str]:
+    """If file exists, move it to a timestamped backup alongside original.
+
+    Returns the backup path if a backup was created, otherwise None.
+    """
+    if not os.path.exists(filepath):
+        return None
+
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    base_name, ext = os.path.splitext(filepath)
+    backup_filepath = f"{base_name}_{timestamp}{ext}"
+    os.rename(filepath, backup_filepath)
+    return backup_filepath
+

--- a/lib/csv_exporter.py
+++ b/lib/csv_exporter.py
@@ -1,0 +1,57 @@
+from typing import Iterable, Optional
+import csv
+
+
+def write_headers(writer: csv.writer, incremental_mode: bool) -> None:
+    headers = ['日期', '類型', '時長(分鐘)', '說明', '時段', '計算式']
+    if incremental_mode:
+        headers.append('狀態')
+    writer.writerow(headers)
+
+
+def write_status_row(writer: csv.writer, last_date: str, complete_days: int, last_analysis_time: str) -> None:
+    status_row = [
+        last_date,
+        "狀態資訊",
+        0,
+        f"📊 增量分析完成，已處理至 {last_date}，共 {complete_days} 個完整工作日 | 上次分析時間: {last_analysis_time}",
+        "",
+        "上次處理範圍內無新問題需要申請",
+        "系統狀態",
+    ]
+    writer.writerow(status_row)
+
+
+def write_issue_rows(writer: csv.writer, issues: Iterable, incremental_mode: bool) -> None:
+    for issue in issues:
+        row = [
+            issue.date.strftime('%Y/%m/%d'),
+            issue.type.value,
+            issue.duration_minutes,
+            issue.description,
+            issue.time_range,
+            issue.calculation,
+        ]
+        if incremental_mode:
+            row.append("[NEW] 本次新發現" if getattr(issue, 'is_new', False) else "已存在")
+        writer.writerow(row)
+
+
+def save_csv(filepath: str, issues: Iterable, incremental_mode: bool,
+             status: Optional[tuple] = None) -> None:
+    """Persist CSV with optional status row.
+
+    status: (last_date, complete_days, last_analysis_time) if provided
+    """
+    with open(filepath, 'w', newline='', encoding='utf-8-sig') as f:
+        writer = csv.writer(f, delimiter=';')
+        write_headers(writer, incremental_mode)
+        if status and incremental_mode and (not list(issues)):
+            last_date, complete_days, last_analysis_time = status
+            write_status_row(writer, last_date, complete_days, last_analysis_time)
+        # 即使存在 status，但 issues 仍可能為空；此時僅有狀態列
+        for _ in ():
+            pass
+        # 寫入資料列
+        write_issue_rows(writer, issues, incremental_mode)
+

--- a/lib/filename.py
+++ b/lib/filename.py
@@ -1,0 +1,49 @@
+import os
+import re
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+
+
+def parse_range_and_user(filepath: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Parse user name and date range from file name.
+
+    Supports: {YYYYMM}[-{YYYYMM}]-{NAME}-出勤資料.txt
+
+    Returns:
+        (user_name, start_date 'YYYY-MM-DD', end_date 'YYYY-MM-DD')
+    """
+    filename = os.path.basename(filepath)
+    pattern = r'(\d{6})(?:-(\d{6}))?-(.+?)-出勤資料\.txt$'
+    match = re.match(pattern, filename)
+    if not match:
+        return None, None, None
+
+    start_month_str = match.group(1)
+    end_month_str = match.group(2)
+    user_name = match.group(3)
+
+    try:
+        start_year = int(start_month_str[:4])
+        start_month = int(start_month_str[4:6])
+        start_date = datetime(start_year, start_month, 1).strftime("%Y-%m-%d")
+    except ValueError:
+        return None, None, None
+
+    # end date
+    if end_month_str:
+        try:
+            end_year = int(end_month_str[:4])
+            end_month = int(end_month_str[4:6])
+            next_month = datetime(end_year + (1 if end_month == 12 else 0), 1 if end_month == 12 else end_month + 1, 1)
+            end_date = (next_month - timedelta(days=1)).strftime("%Y-%m-%d")
+        except ValueError:
+            return None, None, None
+    else:
+        try:
+            next_month = datetime(start_year + (1 if start_month == 12 else 0), 1 if start_month == 12 else start_month + 1, 1)
+            end_date = (next_month - timedelta(days=1)).strftime("%Y-%m-%d")
+        except ValueError:
+            return None, None, None
+
+    return user_name, start_date, end_date
+

--- a/lib/holidays.py
+++ b/lib/holidays.py
@@ -1,0 +1,154 @@
+import logging
+import os
+import ssl
+import urllib.request
+from urllib.error import URLError, HTTPError
+from urllib.parse import urlparse
+import json as _json
+import random
+import socket
+import time
+from datetime import datetime
+from typing import Set
+
+
+logger = logging.getLogger(__name__)
+
+
+class HolidayProvider:
+    def load(self, year: int) -> Set[datetime.date]:  # pragma: no cover (interface)
+        return set()
+
+
+class Hardcoded2025Provider(HolidayProvider):
+    def load(self, year: int) -> Set[datetime.date]:
+        if year != 2025:
+            return set()
+        dates = [
+            # 元旦連假
+            "2025/01/01",
+            # 農曆春節
+            "2025/01/25", "2025/01/26", "2025/01/27", "2025/01/28", "2025/01/29", "2025/01/30", "2025/01/31", "2025/02/01", "2025/02/02",
+            # 和平紀念日
+            "2025/02/28", "2025/03/01", "2025/03/02",
+            # 兒童節/清明節
+            "2025/04/03", "2025/04/04", "2025/04/05", "2025/04/06",
+            # 端午節
+            "2025/05/30", "2025/05/31", "2025/06/01",
+            # 中秋節
+            "2025/10/04", "2025/10/05", "2025/10/06",
+            # 國慶日
+            "2025/10/10", "2025/10/11", "2025/10/12",
+        ]
+        out: Set[datetime.date] = set()
+        for s in dates:
+            try:
+                out.add(datetime.strptime(s, "%Y/%m/%d").date())
+            except ValueError:
+                logger.warning("無效的日期: %s", s)
+        return out
+
+
+class BasicFixedProvider(HolidayProvider):
+    def load(self, year: int) -> Set[datetime.date]:
+        out: Set[datetime.date] = set()
+        for s in (f"{year}/01/01", f"{year}/10/10"):
+            try:
+                out.add(datetime.strptime(s, "%Y/%m/%d").date())
+            except ValueError:
+                logger.warning("無效的日期: %s", s)
+        return out
+
+
+class TaiwanGovOpenDataProvider(HolidayProvider):
+    def __init__(self):
+        try:
+            self.max_retries = int(os.getenv("HOLIDAY_API_MAX_RETRIES", "3"))
+        except ValueError:
+            self.max_retries = 3
+        try:
+            self.base_backoff = float(os.getenv("HOLIDAY_API_BACKOFF_BASE", "0.5"))
+        except ValueError:
+            self.base_backoff = 0.5
+        try:
+            self.max_backoff = float(os.getenv("HOLIDAY_API_MAX_BACKOFF", "8"))
+        except ValueError:
+            self.max_backoff = 8.0
+
+    def load(self, year: int) -> Set[datetime.date]:
+        url = (
+            "https://data.gov.tw/api/v1/rest/datastore_search?"
+            f"resource_id=W2&filters={{\"date\":\"{year}\"}}"
+        )
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            logger.warning("不支援的 URL scheme: %s", parsed.scheme)
+            return set()
+        context = ssl.create_default_context()
+
+        attempt = 0
+        while attempt <= self.max_retries:
+            attempt += 1
+            try:
+                logger.info("資訊: 嘗試載入 %d 年假日 (第 %d/%d 次)...", year, attempt, self.max_retries)
+                with urllib.request.urlopen(url, timeout=10, context=context) as resp:  # nosec B310
+                    data = _json.loads(resp.read().decode('utf-8'))
+                    out: Set[datetime.date] = set()
+                    if 'result' in data and 'records' in data['result']:
+                        for record in data['result']['records']:
+                            if record.get('isHoliday', 0) == 1:
+                                date_str = record.get('date', '')
+                                if date_str:
+                                    try:
+                                        out.add(datetime.strptime(date_str, "%Y-%m-%d").date())
+                                    except ValueError as e:
+                                        logger.warning("跳過無效的日期格式 %r: %s", date_str, e)
+                        if out:
+                            return out
+                        logger.warning("API 回傳資料但沒有有效的假日記錄")
+                        raise RuntimeError("empty holiday records")
+            except HTTPError as e:
+                status = getattr(e, 'code', None)
+                if status in (429, 500, 502, 503, 504):
+                    err_desc = f"HTTP {status}"
+                else:
+                    logger.warning("無法從API載入 %d 年假日資料: HTTP %s — 不重試。", year, status)
+                    return set()
+            except (URLError, socket.timeout, TimeoutError, _json.JSONDecodeError, ValueError) as e:
+                err_desc = f"連線/解析錯誤: {e}"
+            except Exception as e:
+                err_desc = f"一般錯誤: {e}"
+
+            if attempt > self.max_retries:
+                logger.error("錯誤: 嘗試 %d 次後仍無法載入 %d 年假日資料。回退到基本假日。", self.max_retries, year)
+                break
+
+            sleep_s = min(self.max_backoff, self.base_backoff * (2 ** (attempt - 1)))
+            jitter = sleep_s * random.uniform(-0.1, 0.1)
+            time.sleep(max(0.0, sleep_s + jitter))
+
+        return set()
+
+
+class HolidayService:
+    def __init__(self):
+        self.hardcoded = Hardcoded2025Provider()
+        self.gov = TaiwanGovOpenDataProvider()
+        self.basic = BasicFixedProvider()
+
+    def load_year(self, year: int) -> Set[datetime.date]:
+        if year == 2025:
+            return self.hardcoded.load(year)
+        # try gov, fallback basic
+        out = self.gov.load(year)
+        if out:
+            return out
+        logger.warning("無法取得 %d 年完整假日資料，僅載入基本固定假日", year)
+        return self.basic.load(year)
+
+    def load_years(self, years: set) -> Set[datetime.date]:
+        out: Set[datetime.date] = set()
+        for y in years:
+            out |= self.load_year(y)
+        return out
+

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -1,0 +1,91 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Tuple
+
+
+@dataclass
+class Rules:
+    earliest_checkin: str = "08:30"
+    latest_checkin: str = "10:30"
+    lunch_start: str = "12:30"
+    lunch_end: str = "13:30"
+    work_hours: int = 8
+    lunch_hours: int = 1
+    min_overtime_minutes: int = 60
+    overtime_increment_minutes: int = 60
+    forget_punch_allowance_per_month: int = 2
+    forget_punch_max_minutes: int = 60
+
+
+def is_full_day_absent(workday: Any) -> bool:
+    """True if both checkin and checkout records exist but actual times are missing (absent)."""
+    ch = workday.checkin_record
+    co = workday.checkout_record
+    return (ch is not None and co is not None and
+            (not getattr(ch, 'actual_time', None)) and (not getattr(co, 'actual_time', None)))
+
+
+def calculate_late_minutes(workday: Any, rules: Rules) -> Tuple[int, str, str]:
+    """Return (late_minutes, time_range, calculation_str)."""
+    ch = workday.checkin_record
+    if not ch or not ch.actual_time:
+        return 0, "", ""
+
+    latest_checkin = datetime.strptime(f"{workday.date.strftime('%Y/%m/%d')} {rules.latest_checkin}", "%Y/%m/%d %H:%M")
+    actual_checkin = ch.actual_time
+
+    if actual_checkin <= latest_checkin:
+        return 0, "", ""
+
+    delta = actual_checkin - latest_checkin
+    late_minutes = int(delta.total_seconds() // 60)
+
+    if late_minutes > 120:
+        lunch_start = datetime.strptime(f"{workday.date.strftime('%Y/%m/%d')} {rules.lunch_start}", "%Y/%m/%d %H:%M")
+        if actual_checkin > lunch_start:
+            late_minutes -= 60
+            calculation = (
+                f"實際上班: {actual_checkin.strftime('%H:%M')}, 最晚上班: {rules.latest_checkin}, "
+                f"遲到: {int(delta.total_seconds() // 60)}分鐘 - 60分鐘午休 = {late_minutes}分鐘"
+            )
+        else:
+            calculation = (
+                f"實際上班: {actual_checkin.strftime('%H:%M')}, 最晚上班: {rules.latest_checkin}, 遲到: {late_minutes}分鐘"
+            )
+    else:
+        calculation = (
+            f"實際上班: {actual_checkin.strftime('%H:%M')}, 最晚上班: {rules.latest_checkin}, 遲到: {late_minutes}分鐘"
+        )
+
+    time_range = f"{rules.latest_checkin}~{actual_checkin.strftime('%H:%M')}"
+    return late_minutes, time_range, calculation
+
+
+def calculate_overtime_minutes(workday: Any, rules: Rules) -> Tuple[int, int, str, str]:
+    """Return (actual_minutes, applicable_minutes, time_range, calculation_str)."""
+    ch = workday.checkin_record
+    co = workday.checkout_record
+    if not (ch and ch.actual_time and co and co.actual_time):
+        return 0, 0, "", ""
+
+    checkin_time = ch.actual_time
+    checkout_time = co.actual_time
+    expected_checkout = checkin_time + timedelta(hours=rules.work_hours + rules.lunch_hours)
+
+    if checkout_time <= expected_checkout:
+        return 0, 0, "", ""
+
+    delta = checkout_time - expected_checkout
+    actual_overtime_minutes = int(delta.total_seconds() // 60)
+    if actual_overtime_minutes < rules.min_overtime_minutes:
+        return actual_overtime_minutes, 0, "", ""
+
+    intervals = (actual_overtime_minutes - rules.min_overtime_minutes) // rules.overtime_increment_minutes
+    applicable_minutes = rules.min_overtime_minutes + (intervals * rules.overtime_increment_minutes)
+    time_range = f"{expected_checkout.strftime('%H:%M')}~{checkout_time.strftime('%H:%M')}"
+    calculation = (
+        f"預期下班: {expected_checkout.strftime('%H:%M')}, 實際下班: {checkout_time.strftime('%H:%M')}, "
+        f"實際加班: {actual_overtime_minutes}分鐘, 可申請: {applicable_minutes}分鐘"
+    )
+    return actual_overtime_minutes, applicable_minutes, time_range, calculation
+

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -18,11 +18,15 @@ class Rules:
 
 
 def is_full_day_absent(workday: Any) -> bool:
-    """True if both checkin and checkout records exist but actual times are missing (absent)."""
+    """True if checkin or checkout record is missing or lacks an actual time."""
     ch = workday.checkin_record
     co = workday.checkout_record
-    return (ch is not None and co is not None and
-            (not getattr(ch, 'actual_time', None)) and (not getattr(co, 'actual_time', None)))
+    return (
+        ch is None
+        or co is None
+        or not getattr(ch, "actual_time", None)
+        or not getattr(co, "actual_time", None)
+    )
 
 
 def calculate_late_minutes(workday: Any, rules: Rules) -> Tuple[int, str, str]:

--- a/lib/state.py
+++ b/lib/state.py
@@ -1,0 +1,78 @@
+import json
+import os
+import logging
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+
+class AttendanceStateManager:
+    """考勤狀態管理器 - 負責讀寫增量分析狀態"""
+
+    def __init__(self, state_file: str = "attendance_state.json"):
+        self.state_file = state_file
+        self.state_data = self._load_state()
+
+    def _load_state(self) -> dict:
+        if os.path.exists(self.state_file):
+            try:
+                with open(self.state_file, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning("無法讀取狀態檔案 %s: %s", self.state_file, e)
+                logger.warning("將使用空白狀態")
+        return {"users": {}}
+
+    def save_state(self) -> None:
+        try:
+            with open(self.state_file, 'w', encoding='utf-8') as f:
+                json.dump(self.state_data, f, ensure_ascii=False, indent=2)
+        except OSError as e:
+            logger.warning("無法儲存狀態檔案 %s: %s", self.state_file, e)
+
+    def get_user_processed_ranges(self, user_name: str) -> List[Dict]:
+        if user_name not in self.state_data["users"]:
+            return []
+        return self.state_data["users"][user_name].get("processed_date_ranges", [])
+
+    def get_forget_punch_usage(self, user_name: str, year_month: str) -> int:
+        if user_name not in self.state_data["users"]:
+            return 0
+        return self.state_data["users"][user_name].get("forget_punch_usage", {}).get(year_month, 0)
+
+    def update_user_state(self, user_name: str, new_range: Dict[str, str],
+                          forget_punch_usage: Dict[str, int] = None) -> None:
+        if user_name not in self.state_data["users"]:
+            self.state_data["users"][user_name] = {
+                "processed_date_ranges": [],
+                "forget_punch_usage": {}
+            }
+        user_data = self.state_data["users"][user_name]
+        existing_ranges = user_data["processed_date_ranges"]
+        updated = False
+        for i, existing_range in enumerate(existing_ranges):
+            if existing_range["source_file"] == new_range["source_file"]:
+                existing_ranges[i] = new_range
+                updated = True
+                break
+        if not updated:
+            existing_ranges.append(new_range)
+        if forget_punch_usage:
+            user_data["forget_punch_usage"].update(forget_punch_usage)
+
+    def detect_date_overlap(self, user_name: str, new_start_date: str, new_end_date: str) -> List[Tuple[str, str]]:
+        overlaps = []
+        existing_ranges = self.get_user_processed_ranges(user_name)
+        new_start = datetime.strptime(new_start_date, "%Y-%m-%d").date()
+        new_end = datetime.strptime(new_end_date, "%Y-%m-%d").date()
+        for range_info in existing_ranges:
+            existing_start = datetime.strptime(range_info["start_date"], "%Y-%m-%d").date()
+            existing_end = datetime.strptime(range_info["end_date"], "%Y-%m-%d").date()
+            if new_start <= existing_end and new_end >= existing_start:
+                overlap_start = max(new_start, existing_start)
+                overlap_end = min(new_end, existing_end)
+                overlaps.append((overlap_start.strftime("%Y-%m-%d"), overlap_end.strftime("%Y-%m-%d")))
+        return overlaps
+

--- a/test/test_backup.py
+++ b/test/test_backup.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+import unittest
+from lib.backup import backup_with_timestamp
+
+
+class TestBackup(unittest.TestCase):
+    def test_backup_with_timestamp(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, 'report.csv')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('data')
+
+            backup = backup_with_timestamp(path)
+            self.assertIsNotNone(backup)
+            self.assertFalse(os.path.exists(path))
+            self.assertTrue(os.path.exists(backup))
+            self.assertTrue(backup.endswith('.csv'))
+            # name contains timestamp suffix
+            self.assertIn('_', os.path.basename(backup).replace('report', ''))
+
+    def test_no_backup_when_absent(self):
+        backup = backup_with_timestamp('/non/existent/file.csv')
+        self.assertIsNone(backup)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/test/test_csv_exporter.py
+++ b/test/test_csv_exporter.py
@@ -1,0 +1,54 @@
+import csv
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+
+from lib import csv_exporter
+
+
+def make_issue(date_str: str, typ_value: str, minutes: int, desc: str, rng: str, calc: str, is_new=True):
+    return SimpleNamespace(
+        date=datetime.strptime(date_str, "%Y/%m/%d"),
+        type=SimpleNamespace(value=typ_value),
+        duration_minutes=minutes,
+        description=desc,
+        time_range=rng,
+        calculation=calc,
+        is_new=is_new,
+    )
+
+
+class TestCsvExporter(unittest.TestCase):
+    def test_write_with_status_row(self):
+        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+            path = tmp.name
+        try:
+            issues = []
+            csv_exporter.save_csv(path, issues, True, ("2025/07/31", 22, "2025-09-13T10:00:00"))
+            with open(path, encoding='utf-8-sig') as f:
+                rows = list(csv.reader(f, delimiter=';'))
+            self.assertGreaterEqual(len(rows), 2)
+            self.assertEqual(rows[1][1], '狀態資訊')
+            self.assertIn('上次分析時間', rows[1][3])
+        finally:
+            os.unlink(path)
+
+    def test_write_issue_rows(self):
+        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+            path = tmp.name
+        try:
+            issues = [make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc', True)]
+            csv_exporter.save_csv(path, issues, True, None)
+            with open(path, encoding='utf-8-sig') as f:
+                rows = list(csv.reader(f, delimiter=';'))
+            self.assertEqual(rows[1][0], '2025/09/01')
+            self.assertEqual(rows[1][-1], '[NEW] 本次新發現')
+        finally:
+            os.unlink(path)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/test/test_filename.py
+++ b/test/test_filename.py
@@ -1,0 +1,27 @@
+import unittest
+from lib.filename import parse_range_and_user
+
+
+class TestFilenameParsing(unittest.TestCase):
+    def test_single_month(self):
+        user, start, end = parse_range_and_user('/x/202508-王小明-出勤資料.txt')
+        self.assertEqual(user, '王小明')
+        self.assertEqual(start, '2025-08-01')
+        self.assertEqual(end, '2025-08-31')
+
+    def test_cross_month(self):
+        user, start, end = parse_range_and_user('/x/202508-202509-王小明-出勤資料.txt')
+        self.assertEqual(user, '王小明')
+        self.assertEqual(start, '2025-08-01')
+        self.assertEqual(end, '2025-09-30')
+
+    def test_invalid(self):
+        user, start, end = parse_range_and_user('/x/invalid.txt')
+        self.assertIsNone(user)
+        self.assertIsNone(start)
+        self.assertIsNone(end)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/test/test_holidays_providers.py
+++ b/test/test_holidays_providers.py
@@ -1,0 +1,94 @@
+import os
+import json
+import unittest
+from datetime import datetime
+from unittest import mock
+from urllib.error import HTTPError
+
+from lib.holidays import (
+    Hardcoded2025Provider,
+    BasicFixedProvider,
+    TaiwanGovOpenDataProvider,
+    HolidayService,
+)
+
+
+class TestHolidaysProviders(unittest.TestCase):
+    def setUp(self):
+        # Speed up backoff during tests
+        self._env = dict(os.environ)
+        os.environ['HOLIDAY_API_MAX_RETRIES'] = '2'
+        os.environ['HOLIDAY_API_BACKOFF_BASE'] = '0'
+        os.environ['HOLIDAY_API_MAX_BACKOFF'] = '0'
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._env)
+
+    def test_hardcoded_2025_contains_known_date(self):
+        p = Hardcoded2025Provider()
+        s = p.load(2025)
+        self.assertIn(datetime.strptime('2025/10/10', '%Y/%m/%d').date(), s)
+        self.assertEqual(len(p.load(2024)), 0)
+
+    def test_basic_fixed_provider_jan1_and_national_day(self):
+        p = BasicFixedProvider()
+        s = p.load(2026)
+        self.assertIn(datetime.strptime('2026/01/01', '%Y/%m/%d').date(), s)
+        self.assertIn(datetime.strptime('2026/10/10', '%Y/%m/%d').date(), s)
+
+    def test_gov_provider_timeout_then_success(self):
+        seq = []
+        import socket as _socket
+        seq.append(_socket.timeout('timed out'))
+        payload = {'result': {'records': [{'isHoliday': 1, 'date': '2027-10-10'}]}}
+
+        class DummyResp:
+            def read(self):
+                return json.dumps(payload).encode('utf-8')
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                return False
+
+        seq.append(DummyResp())
+
+        def urlopen_side(url, timeout=10, context=None):
+            v = seq.pop(0)
+            if isinstance(v, Exception):
+                raise v
+            return v
+
+        p = TaiwanGovOpenDataProvider()
+        with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
+            out = p.load(2027)
+        self.assertIn(datetime.strptime('2027/10/10', '%Y/%m/%d').date(), out)
+
+    def test_gov_provider_non_retryable_403(self):
+        class _HTTPError(HTTPError):
+            def __init__(self, code):
+                super().__init__('http://x', code, 'err', hdrs=None, fp=None)
+
+        def urlopen_side(url, timeout=10, context=None):
+            raise _HTTPError(403)
+
+        p = TaiwanGovOpenDataProvider()
+        with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
+            out = p.load(2028)
+        self.assertEqual(len(out), 0)
+
+    def test_service_uses_hardcoded_for_2025(self):
+        s = HolidayService()
+        out = s.load_year(2025)
+        self.assertIn(datetime.strptime('2025/01/01', '%Y/%m/%d').date(), out)
+
+    def test_service_fallbacks_to_basic_when_gov_empty(self):
+        s = HolidayService()
+        with mock.patch('lib.holidays.TaiwanGovOpenDataProvider.load', return_value=set()):
+            out = s.load_year(2029)
+        self.assertIn(datetime.strptime('2029/01/01', '%Y/%m/%d').date(), out)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -28,9 +28,53 @@ class TestPolicy(unittest.TestCase):
 
     def test_is_full_day_absent(self):
         date = datetime.strptime("2025/07/04", "%Y/%m/%d")
-        wd = WorkDay(date=date, checkin_record=mk_record("2025/07/04 08:00", None, AttendanceType.CHECKIN),
-                     checkout_record=mk_record("2025/07/04 17:00", None, AttendanceType.CHECKOUT), is_friday=True)
+        # missing actual times on both records
+        wd = WorkDay(
+            date=date,
+            checkin_record=mk_record(
+                "2025/07/04 08:00", None, AttendanceType.CHECKIN
+            ),
+            checkout_record=mk_record(
+                "2025/07/04 17:00", None, AttendanceType.CHECKOUT
+            ),
+            is_friday=True,
+        )
         self.assertTrue(is_full_day_absent(wd))
+
+        # missing checkin record
+        wd_missing_in = WorkDay(
+            date=date,
+            checkin_record=None,
+            checkout_record=mk_record(
+                "2025/07/04 17:00", "2025/07/04 17:00", AttendanceType.CHECKOUT
+            ),
+            is_friday=True,
+        )
+        self.assertTrue(is_full_day_absent(wd_missing_in))
+
+        # missing checkout record
+        wd_missing_out = WorkDay(
+            date=date,
+            checkin_record=mk_record(
+                "2025/07/04 08:00", "2025/07/04 08:00", AttendanceType.CHECKIN
+            ),
+            checkout_record=None,
+            is_friday=True,
+        )
+        self.assertTrue(is_full_day_absent(wd_missing_out))
+
+        # both records present with actual times
+        wd_present = WorkDay(
+            date=date,
+            checkin_record=mk_record(
+                "2025/07/04 08:00", "2025/07/04 08:00", AttendanceType.CHECKIN
+            ),
+            checkout_record=mk_record(
+                "2025/07/04 17:00", "2025/07/04 17:00", AttendanceType.CHECKOUT
+            ),
+            is_friday=True,
+        )
+        self.assertFalse(is_full_day_absent(wd_present))
 
     def test_late_across_lunch_deduct(self):
         # checkin at 13:30 vs latest 10:30 -> 180m; cross lunch deduct 60 => 120m

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -1,0 +1,58 @@
+import unittest
+from datetime import datetime
+
+from attendance_analyzer import AttendanceRecord, WorkDay, AttendanceType
+from lib.policy import Rules, is_full_day_absent, calculate_late_minutes, calculate_overtime_minutes
+
+
+def mk_record(dt_str_sched: str, dt_str_actual: str, typ: AttendanceType):
+    sched = datetime.strptime(dt_str_sched, "%Y/%m/%d %H:%M") if dt_str_sched else None
+    actual = datetime.strptime(dt_str_actual, "%Y/%m/%d %H:%M") if dt_str_actual else None
+    return AttendanceRecord(
+        date=sched.date() if sched else None,
+        scheduled_time=sched,
+        actual_time=actual,
+        type=typ,
+        card_number="1",
+        source="src",
+        status="",
+        processed="",
+        operation="",
+        note="",
+    )
+
+
+class TestPolicy(unittest.TestCase):
+    def setUp(self):
+        self.rules = Rules()
+
+    def test_is_full_day_absent(self):
+        date = datetime.strptime("2025/07/04", "%Y/%m/%d")
+        wd = WorkDay(date=date, checkin_record=mk_record("2025/07/04 08:00", None, AttendanceType.CHECKIN),
+                     checkout_record=mk_record("2025/07/04 17:00", None, AttendanceType.CHECKOUT), is_friday=True)
+        self.assertTrue(is_full_day_absent(wd))
+
+    def test_late_across_lunch_deduct(self):
+        # checkin at 13:30 vs latest 10:30 -> 180m; cross lunch deduct 60 => 120m
+        date = datetime.strptime("2025/07/01", "%Y/%m/%d")
+        wd = WorkDay(date=date,
+                     checkin_record=mk_record("2025/07/01 08:00", "2025/07/01 13:30", AttendanceType.CHECKIN),
+                     checkout_record=mk_record("2025/07/01 17:00", "2025/07/01 22:45", AttendanceType.CHECKOUT),
+                     is_friday=False)
+        minutes, _range, _calc = calculate_late_minutes(wd, self.rules)
+        self.assertEqual(minutes, 120)
+
+    def test_overtime_rounding(self):
+        # checkin 09:00 => expected out 18:00; actual 20:01 => 121m actual, applicable 120m
+        date = datetime.strptime("2025/07/01", "%Y/%m/%d")
+        wd = WorkDay(date=date,
+                     checkin_record=mk_record("2025/07/01 09:00", "2025/07/01 09:00", AttendanceType.CHECKIN),
+                     checkout_record=mk_record("2025/07/01 17:00", "2025/07/01 20:01", AttendanceType.CHECKOUT),
+                     is_friday=False)
+        actual, applicable, _range, _calc = calculate_overtime_minutes(wd, self.rules)
+        self.assertEqual(applicable, 120)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Summary
- Extracted pure concerns from attendance_analyzer.py into lib/*, keeping CLI and behavior unchanged.
- Added unit tests for extracted modules; full test suite passes.

What changed
1) lib/filename.py
   - parse_range_and_user(filepath): filename → (user, start_date, end_date)
   - Analyzer now imports this; removed dead inlined method.

2) lib/backup.py
   - backup_with_timestamp(filepath) used by export_report() before writing.

3) lib/policy.py
   - Rules dataclass and pure functions: is_full_day_absent, calculate_late_minutes, calculate_overtime_minutes.
   - Analyzer orchestrates Rules and delegates calculations.

4) lib/state.py
   - Moved AttendanceStateManager. API unchanged. Analyzer lazily imports.

5) lib/csv_exporter.py
   - Unified CSV export helpers (headers/status row/rows/save). Analyzer delegates export_csv.

6) lib/holidays.py
   - HolidayProvider interface; providers: Hardcoded2025Provider, BasicFixedProvider, TaiwanGovOpenDataProvider.
   - HolidayService to load year(s). Analyzer delegates _load_taiwan_holidays to service.
   - _try_load_from_gov_api/_load_basic/_load_hardcoded methods kept as shims delegating to providers for backward compatibility and existing tests.

7) Cleanup
   - Removed dead methods from analyzer; kept URL scheme check shim to satisfy existing tests that patch attendance_analyzer.urlparse.

Why
- Improve separation of concerns, testability, and future extensibility (e.g., swap holiday sources, adjust rules) without changing CLI.
- Reduce analyzer bloat; move I/O and pure logic into focused modules.

Backward compatibility
- CLI flags, outputs, and CSV/Excel formatting unchanged.
- Status row (incremental mode) and Excel widths preserved.
- Environment variables HOLIDAY_API_MAX_RETRIES, HOLIDAY_API_BACKOFF_BASE, HOLIDAY_API_MAX_BACKOFF still honored.

Tests
- Total: 35 tests passing (python3 -m unittest -q).
- New tests: test_filename.py, test_backup.py, test_policy.py, test_csv_exporter.py, test_holidays_providers.py.
- Existing tests remain green (retry/timeout/5xx/4xx, WFH-holiday edge, overtime rounding, Excel/CSV).

Risk & mitigation
- Modularization only; no behavior change intended.
- Kept shims for analyzer methods to avoid breaking legacy tests/usages.
- Providers are covered by unit tests; network calls are mocked in tests.

Rollout
- Merge as a single refactor PR.
- Follow-up phases (if any) can build on these modules (e.g., richer config or alternative holiday sources).
