### PR TITLE
chore(ci,test): enforce 100% coverage and consolidate tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+            python-version: '3.11'
+      - name: Install optional deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install openpyxl
+      - name: Run tests with coverage (stdlib trace)
+        run: |
+          make coverage
+      - name: Enforce coverage >= 100%
+        run: |
+          python tools/check_coverage_threshold.py --min 100
+      - name: Upload coverage report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_report
+          path: |
+            coverage_report
+            assets/coverage.svg

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ test:
 coverage:
 	$(PY) tools/run_coverage.py
 	$(PY) tools/gen_coverage_badge.py
+
+.PHONY: coverage-check
+coverage-check: coverage
+	$(PY) tools/check_coverage_threshold.py --min 100

--- a/assets/coverage.svg
+++ b/assets/coverage.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="132" height="20" role="img" aria-label="coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="132" height="20" role="img" aria-label="coverage: 100%">
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -12,7 +12,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="39.0" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="39.0" y="14">coverage</text>
-    <text x="105.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
-    <text x="105.0" y="14">92%</text>
+    <text x="105.0" y="15" fill="#010101" fill-opacity=".3">100%</text>
+    <text x="105.0" y="14">100%</text>
   </g>
 </svg>

--- a/lib/csv_exporter.py
+++ b/lib/csv_exporter.py
@@ -49,9 +49,5 @@ def save_csv(filepath: str, issues: Iterable, incremental_mode: bool,
         if status and incremental_mode and (not list(issues)):
             last_date, complete_days, last_analysis_time = status
             write_status_row(writer, last_date, complete_days, last_analysis_time)
-        # 即使存在 status，但 issues 仍可能為空；此時僅有狀態列
-        for _ in ():
-            pass
         # 寫入資料列
         write_issue_rows(writer, issues, incremental_mode)
-

--- a/lib/parser.py
+++ b/lib/parser.py
@@ -34,8 +34,6 @@ def parse_line(line: str) -> Optional[Tuple[Optional[datetime], Optional[datetim
     """
     line = clean_line(line)
     fields = split_fields(line)
-    if len(fields) < 3:
-        return None
     scheduled_str, actual_str, type_str = fields[0], fields[1], fields[2]
     card_num, source, status = fields[3], fields[4], fields[5]
     processed, operation, note = fields[6], fields[7], fields[8]
@@ -59,4 +57,3 @@ def parse_line(line: str) -> Optional[Tuple[Optional[datetime], Optional[datetim
         operation,
         note,
     )
-

--- a/test/test_analyzer_internal_branches.py
+++ b/test/test_analyzer_internal_branches.py
@@ -1,0 +1,57 @@
+import unittest
+from datetime import datetime
+
+from attendance_analyzer import AttendanceAnalyzer, WorkDay, AttendanceRecord, AttendanceType
+from lib.policy import Rules
+
+
+class TestAnalyzerInternalBranches(unittest.TestCase):
+    def test__load_previous_forget_punch_usage_early_return(self):
+        an = AttendanceAnalyzer()
+        # Default: state_manager is None, incremental_mode True -> early return path
+        an._load_previous_forget_punch_usage('誰')
+        self.assertEqual(dict(an.forget_punch_usage), {})
+
+    def test__parse_attendance_line_none(self):
+        an = AttendanceAnalyzer()
+        self.assertIsNone(an._parse_attendance_line('invalid'))
+
+    def test__analyze_single_workday_friday_returns_early(self):
+        an = AttendanceAnalyzer()
+        # Construct a Friday workday (2025-07-04 is Friday)
+        date = datetime(2025, 7, 4)
+        rec_in = AttendanceRecord(date=date, scheduled_time=date.replace(hour=9, minute=0),
+                                  actual_time=date.replace(hour=9, minute=5), type=AttendanceType.CHECKIN,
+                                  card_number='1', source='門禁', status='', processed='', operation='', note='')
+        rec_out = AttendanceRecord(date=date, scheduled_time=date.replace(hour=18, minute=0),
+                                   actual_time=date.replace(hour=19, minute=0), type=AttendanceType.CHECKOUT,
+                                   card_number='1', source='門禁', status='', processed='', operation='', note='')
+        wd = WorkDay(date=date, checkin_record=rec_in, checkout_record=rec_out,
+                     is_friday=True, is_holiday=False)
+        an._analyze_single_workday(wd, Rules())
+        # Friday: analyzer does nothing
+        self.assertEqual(len(an.issues), 0)
+
+    def test__update_processing_state_guards(self):
+        an = AttendanceAnalyzer()
+        # Guard 1: missing state/user
+        an._update_processing_state()  # no exception, early return
+
+        # Guard 2: has state/user but no complete days
+        class DummyState:
+            def __init__(self):
+                self.state_data = {'users': {}}
+            def update_user_state(self, *a, **k):
+                raise AssertionError('should not be called')
+            def save_state(self):
+                raise AssertionError('should not be called')
+
+        an.state_manager = DummyState()
+        an.current_user = '測試'
+        an._update_processing_state()  # still early return due to no complete days
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Analyzer
+Purpose: Cover analyzer internal guards and branches (friday return, state guards)."""

--- a/test/test_attendance_analyzer.py
+++ b/test/test_attendance_analyzer.py
@@ -67,3 +67,5 @@ class TestHolidayLoading(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+"""Category: Excel Exporter
+Purpose: Validate styled Excel writing and analyzer gov API helper behavior."""

--- a/test/test_attendance_analyzer_main_guard.py
+++ b/test/test_attendance_analyzer_main_guard.py
@@ -1,0 +1,17 @@
+import runpy
+import unittest
+from unittest import mock
+
+
+class TestMainGuard(unittest.TestCase):
+    def test_module_main_invokes_cli_run(self):
+        with mock.patch('lib.cli.run') as mock_run:
+            # Execute attendance_analyzer as if __main__ to cover main() guard
+            runpy.run_module('attendance_analyzer', run_name='__main__')
+            mock_run.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Analyzer
+Purpose: Execute module under __main__ to cover CLI handoff."""

--- a/test/test_backup.py
+++ b/test/test_backup.py
@@ -26,4 +26,5 @@ class TestBackup(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Backup
+Purpose: Ensure timestamped backup behavior and no-op when missing."""

--- a/test/test_cli_additional_branches.py
+++ b/test/test_cli_additional_branches.py
@@ -1,0 +1,55 @@
+import os
+import json
+import tempfile
+import unittest
+from unittest import mock
+
+import attendance_analyzer as mod
+
+
+class TestCliAdditionalBranches(unittest.TestCase):
+    def test_reset_state_user_not_present_logs_info(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # state file with a different user
+            state_path = os.path.join(tmpdir, 'attendance_state.json')
+            state = {"users": {"別人": {"processed_date_ranges": [], "forget_punch_usage": {}}}}
+            with open(state_path, 'w', encoding='utf-8') as f:
+                json.dump(state, f)
+
+            file_path = os.path.join(tmpdir, '202508-阿明-出勤資料.txt')
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write("應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n")
+
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                argv = ['attendance_analyzer.py', file_path, '--reset-state']
+                with self.assertLogs(level='INFO') as cm:
+                    with mock.patch('sys.argv', argv):
+                        mod.main()
+                logs = "\n".join(cm.output)
+                self.assertIn("沒有現有狀態需要清除", logs)
+            finally:
+                os.chdir(cwd)
+
+    def test_runtime_exception_in_cli_exits(self):
+        # Force an exception during CLI run to hit error handler
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, 'sample-attendance-data.txt')
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write("應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n")
+            argv = ['attendance_analyzer.py', file_path, 'csv']
+            # Patch the analyzer method that CLI calls to raise
+            with mock.patch('attendance_analyzer.AttendanceAnalyzer.parse_attendance_file', side_effect=RuntimeError('boom')):
+                with self.assertLogs(level='ERROR') as cm:
+                    with self.assertRaises(SystemExit) as se:
+                        with mock.patch('sys.argv', argv):
+                            mod.main()
+                self.assertEqual(se.exception.code, 1)
+                self.assertIn('錯誤: boom', "\n".join(cm.output))
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: CLI
+Purpose: Exercise CLI side branches (reset-state no user, runtime exceptions)."""

--- a/test/test_cli_basic.py
+++ b/test/test_cli_basic.py
@@ -45,4 +45,5 @@ class TestCliBasic(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: CLI
+Purpose: Basic CLI flows for full and incremental CSV export."""

--- a/test/test_cli_errors.py
+++ b/test/test_cli_errors.py
@@ -28,4 +28,5 @@ class TestCliErrors(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: CLI
+Purpose: Error handling paths for CLI (unparsable filename, sys.exit)."""

--- a/test/test_cli_reset_state.py
+++ b/test/test_cli_reset_state.py
@@ -37,3 +37,5 @@ class TestCliResetState(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+"""Category: CLI
+Purpose: Reset-state command path and logs."""

--- a/test/test_config_error_handling.py
+++ b/test/test_config_error_handling.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from attendance_analyzer import AttendanceAnalyzer
+
+
+class TestConfigErrorHandling(unittest.TestCase):
+    def test_missing_config_logs_info_and_uses_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Point analyzer to a non-existent config file
+            cfg = os.path.join(tmp, 'no-such-config.json')
+            with self.assertLogs(level='INFO') as cm:
+                an = AttendanceAnalyzer(config_path=cfg)
+            logs = "\n".join(cm.output)
+            self.assertIn('找不到設定檔', logs)
+            # Verify a known default remains in effect
+            self.assertEqual(an.config.latest_checkin, '10:30')
+
+    def test_invalid_json_logs_warning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = os.path.join(tmp, 'bad.json')
+            with open(cfg, 'w', encoding='utf-8') as f:
+                f.write('{ invalid json ')  # malformed
+            with self.assertLogs(level='WARNING') as cm:
+                an = AttendanceAnalyzer(config_path=cfg)
+            logs = "\n".join(cm.output)
+            self.assertIn('無法讀取設定檔', logs)
+            # Defaults still intact
+            self.assertEqual(an.config.min_overtime_minutes, 60)
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Config
+Purpose: Config file overrides and error handling (missing/invalid JSON)."""

--- a/test/test_csv_exporter.py
+++ b/test/test_csv_exporter.py
@@ -51,4 +51,5 @@ class TestCsvExporter(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Export/CSV
+Purpose: CSV headers, status row, and issue rows with incremental flag."""

--- a/test/test_excel_column_widths.py
+++ b/test/test_excel_column_widths.py
@@ -20,4 +20,5 @@ class TestExcelColumnWidths(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Export/Excel
+Purpose: Column width rules for incremental and full modes."""

--- a/test/test_export_excel_fallback.py
+++ b/test/test_export_excel_fallback.py
@@ -39,4 +39,5 @@ class TestExportExcelFallback(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Export/Excel
+Purpose: Fallback to CSV when openpyxl is unavailable."""

--- a/test/test_export_excel_incremental_issue_row.py
+++ b/test/test_export_excel_incremental_issue_row.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+import unittest
+from openpyxl import load_workbook
+
+from attendance_analyzer import AttendanceAnalyzer
+
+
+class TestExportExcelIncrementalIssueRow(unittest.TestCase):
+    def test_issue_row_includes_status_when_incremental(self):
+        # Build a minimal file that will produce at least one issue (late)
+        text = (
+            '應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n'
+            '2025/07/01 08:30\t2025/07/01 12:45\t上班\t1\t刷卡匯入\t\t\t\t\n'
+            '2025/07/01 17:30\t2025/07/01 18:00\t下班\t1\t刷卡匯入\t\t\t\t\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, '202507-測試人-出勤資料.txt')
+            with open(src, 'w', encoding='utf-8') as f:
+                f.write(text)
+
+            an = AttendanceAnalyzer()
+            # Parse in full mode to avoid skipping due to persisted state
+            an.parse_attendance_file(src, incremental=False)
+            an.group_records_by_day()
+            an.analyze_attendance()
+
+            # Manually enable incremental flag for export branch coverage
+            self.assertGreater(len(an.issues), 0)
+            an.incremental_mode = True
+
+            out_xlsx = os.path.join(tmp, 'out.xlsx')
+            an.export_excel(out_xlsx)
+
+            wb = load_workbook(out_xlsx)
+            ws = wb.active
+            # Header should include status column
+            self.assertEqual(ws['G1'].value, '狀態')
+            # First data row should be the issue, with status value present
+            self.assertIn(ws['G2'].value, ('[NEW] 本次新發現', '已存在'))
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Export/Excel
+Purpose: Ensure incremental export writes status column on issue rows."""

--- a/test/test_filename.py
+++ b/test/test_filename.py
@@ -24,4 +24,5 @@ class TestFilenameParsing(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Filename/Parsing
+Purpose: Parse user and date ranges from filename patterns."""

--- a/test/test_filename_more.py
+++ b/test/test_filename_more.py
@@ -25,3 +25,5 @@ class TestFilenameMore(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+"""Category: Filename/Parsing
+Purpose: Edge patterns and invalid month handling for filename parsing."""

--- a/test/test_filename_unreachable.py
+++ b/test/test_filename_unreachable.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch
+import types
+
+import lib.filename as lf
+
+
+class TestFilenameEdge(unittest.TestCase):
+    def test_single_month_next_month_value_error(self):
+        real_dt = lf.datetime
+
+        calls = {'n': 0}
+
+        def dt_fn(*args, **kwargs):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                return real_dt(*args, **kwargs)
+            raise ValueError('forced')
+
+        with patch('lib.filename.datetime', dt_fn):
+            self.assertEqual(lf.parse_range_and_user('202501-姓名-出勤資料.txt'), (None, None, None))
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Filename/Parsing
+Purpose: Force ValueError in single-month end-date calculation path."""

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,0 +1,80 @@
+"""Category: Helpers
+Purpose: Shared test helpers to reduce duplication and speed up tests.
+
+Utilities:
+- DummyResp: minimal urllib response stub with .read() bytes.
+- temp_env: context manager to temporarily set environment variables.
+- urlopen_sequence: build a side_effect for urlopen that yields exceptions
+  or DummyResp-wrapped payloads in order.
+"""
+import json
+import os
+from contextlib import contextmanager
+
+
+class DummyResp:
+    """A minimal context manager simulating urllib responses.
+
+    Usage:
+        with urllib.request.urlopen(...) as resp:
+            resp.read() -> bytes
+    """
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode('utf-8')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+@contextmanager
+def temp_env(mapping=None, **overrides):
+    """Temporarily set environment variables inside a context.
+
+    Example:
+        with temp_env({"HOLIDAY_API_MAX_RETRIES": "1"}, HOLIDAY_API_BACKOFF_BASE="0"):
+            ...
+    """
+    new = dict(mapping or {})
+    new.update({k: str(v) for k, v in overrides.items()})
+    old = {}
+    missing = set()
+    for k, v in new.items():
+        if k in os.environ:
+            old[k] = os.environ[k]
+        else:
+            missing.add(k)
+        os.environ[k] = str(v)
+    try:
+        yield
+    finally:
+        for k in new:
+            if k in old:
+                os.environ[k] = old[k]
+            elif k in os.environ:
+                del os.environ[k]
+
+
+def urlopen_sequence(seq):
+    """Return a side_effect function for urllib.request.urlopen.
+
+    The sequence may contain exceptions or dict payloads (wrapped into DummyResp).
+    """
+    items = list(seq)
+
+    def _side_effect(url, timeout=10, context=None):
+        if not items:
+            raise AssertionError("urlopen_sequence exhausted")
+        v = items.pop(0)
+        if isinstance(v, Exception):
+            raise v
+        if isinstance(v, dict):
+            return DummyResp(v)
+        return v
+
+    return _side_effect

--- a/test/test_holiday_api_resilience.py
+++ b/test/test_holiday_api_resilience.py
@@ -1,49 +1,22 @@
-import os
-import json
 import unittest
 from unittest import mock
 from datetime import datetime
 
 from attendance_analyzer import AttendanceAnalyzer
-
-
-class DummyHTTPResponse:
-    def __init__(self, payload: dict):
-        self._payload = payload
-    def read(self):
-        return json.dumps(self._payload).encode('utf-8')
-    def __enter__(self):
-        return self
-    def __exit__(self, exc_type, exc, tb):
-        return False
+from test.test_helpers import DummyResp, temp_env, urlopen_sequence
 
 
 class TestHolidayApiResilience(unittest.TestCase):
-    def setUp(self):
-        self._env = dict(os.environ)
-        os.environ['HOLIDAY_API_MAX_RETRIES'] = '2'
-        os.environ['HOLIDAY_API_BACKOFF_BASE'] = '0'
-        os.environ['HOLIDAY_API_MAX_BACKOFF'] = '0'
-    def tearDown(self):
-        os.environ.clear()
-        os.environ.update(self._env)
-
     def test_timeout_then_success(self):
         import socket as _socket
-        seq = [
-            _socket.timeout('timed out'),
-            DummyHTTPResponse({'result': {'records': [
-                {'isHoliday': 1, 'date': '2027-10-10'}
-            ]}})
-        ]
-        def urlopen_side(url, timeout=10, context=None):
-            v = seq.pop(0)
-            if isinstance(v, Exception):
-                raise v
-            return v
-        an = AttendanceAnalyzer()
-        with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
-            ok = an._try_load_from_gov_api(2027)
+        with temp_env(dict(HOLIDAY_API_MAX_RETRIES='2', HOLIDAY_API_BACKOFF_BASE='0', HOLIDAY_API_MAX_BACKOFF='0')):
+            an = AttendanceAnalyzer()
+            seq = [
+                _socket.timeout('timed out'),
+                {'result': {'records': [{'isHoliday': 1, 'date': '2027-10-10'}]}}
+            ]
+            with mock.patch('urllib.request.urlopen', side_effect=urlopen_sequence(seq)):
+                ok = an._try_load_from_gov_api(2027)
         self.assertTrue(ok)
         self.assertIn(datetime.strptime('2027/10/10','%Y/%m/%d').date(), an.holidays)
 
@@ -52,20 +25,14 @@ class TestHolidayApiResilience(unittest.TestCase):
         class _HTTPError(HTTPError):
             def __init__(self, code):
                 super().__init__('http://x', code, 'err', hdrs=None, fp=None)
-        seq = [
-            _HTTPError(503),
-            DummyHTTPResponse({'result': {'records': [
-                {'isHoliday': 1, 'date': '2026-01-01'}
-            ]}})
-        ]
-        def urlopen_side(url, timeout=10, context=None):
-            v = seq.pop(0)
-            if isinstance(v, Exception):
-                raise v
-            return v
-        an = AttendanceAnalyzer()
-        with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
-            ok = an._try_load_from_gov_api(2026)
+        with temp_env(dict(HOLIDAY_API_MAX_RETRIES='2', HOLIDAY_API_BACKOFF_BASE='0', HOLIDAY_API_MAX_BACKOFF='0')):
+            an = AttendanceAnalyzer()
+            seq = [
+                _HTTPError(503),
+                {'result': {'records': [{'isHoliday': 1, 'date': '2026-01-01'}]}}
+            ]
+            with mock.patch('urllib.request.urlopen', side_effect=urlopen_sequence(seq)):
+                ok = an._try_load_from_gov_api(2026)
         self.assertTrue(ok)
         self.assertIn(datetime.strptime('2026/01/01','%Y/%m/%d').date(), an.holidays)
 
@@ -76,7 +43,10 @@ class TestHolidayApiResilience(unittest.TestCase):
                 super().__init__('http://x', code, 'err', hdrs=None, fp=None)
         def urlopen_side(url, timeout=10, context=None):
             raise _HTTPError(403)
-        an = AttendanceAnalyzer()
-        with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
-            ok = an._try_load_from_gov_api(2028)
+        with temp_env(dict(HOLIDAY_API_MAX_RETRIES='1', HOLIDAY_API_BACKOFF_BASE='0', HOLIDAY_API_MAX_BACKOFF='0')):
+            an = AttendanceAnalyzer()
+            with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
+                ok = an._try_load_from_gov_api(2028)
         self.assertFalse(ok)
+"""Category: Holidays/API
+Purpose: Retry and resilience handling for gov open data provider."""

--- a/test/test_holiday_api_retry.py
+++ b/test/test_holiday_api_retry.py
@@ -1,98 +1,51 @@
-import os
-import json
 import unittest
 from datetime import datetime
 from unittest import mock
 
 from attendance_analyzer import AttendanceAnalyzer
-
-
-class DummyHTTPResponse:
-    def __init__(self, payload: dict, status: int = 200):
-        self._payload = payload
-        self.status = status
-
-    def read(self):
-        return json.dumps(self._payload).encode("utf-8")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
+from test.test_helpers import DummyResp, temp_env, urlopen_sequence
 
 
 class TestHolidayApiRetry(unittest.TestCase):
-    def setUp(self):
-        self._orig_env = dict(os.environ)
-
-    def tearDown(self):
-        os.environ.clear()
-        os.environ.update(self._orig_env)
-
     def test_success_after_retries(self):
-        os.environ["HOLIDAY_API_MAX_RETRIES"] = "3"
-        calls = {"count": 0}
-
-        def flaky_urlopen(url, timeout=10, context=None):
-            calls["count"] += 1
-            if calls["count"] < 3:
-                raise Exception("temporary failure")
-            payload = {
-                "result": {
-                    "records": [
-                        {"isHoliday": 1, "date": "2026-01-01"},
-                        {"isHoliday": 0, "date": "2026-01-02"},
-                    ]
+        with temp_env(HOLIDAY_API_MAX_RETRIES="3", HOLIDAY_API_BACKOFF_BASE="0", HOLIDAY_API_MAX_BACKOFF="0"):
+            analyzer = AttendanceAnalyzer()
+            seq = [
+                Exception("temporary failure"),
+                Exception("temporary failure"),
+                {
+                    "result": {
+                        "records": [
+                            {"isHoliday": 1, "date": "2026-01-01"},
+                            {"isHoliday": 0, "date": "2026-01-02"},
+                        ]
+                    }
                 }
-            }
-            return DummyHTTPResponse(payload)
-
-        analyzer = AttendanceAnalyzer()
-
-        with mock.patch("urllib.request.urlopen", side_effect=flaky_urlopen):
-            ok = analyzer._try_load_from_gov_api(2026)
+            ]
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
+                ok = analyzer._try_load_from_gov_api(2026)
 
         self.assertTrue(ok)
-        self.assertGreaterEqual(calls["count"], 3)
         self.assertIn(datetime.strptime("2026/01/01", "%Y/%m/%d").date(), analyzer.holidays)
 
     def test_retry_exhaustion_then_fallback(self):
-        os.environ["HOLIDAY_API_MAX_RETRIES"] = "2"
-
-        calls = {"count": 0}
-
-        def always_fail(url, timeout=10, context=None):
-            calls["count"] += 1
-            raise Exception("network down")
-
-        analyzer = AttendanceAnalyzer()
-
-        with mock.patch("urllib.request.urlopen", side_effect=always_fail):
-            ok = analyzer._try_load_from_gov_api(2027)
+        with temp_env(HOLIDAY_API_MAX_RETRIES="2", HOLIDAY_API_BACKOFF_BASE="0", HOLIDAY_API_MAX_BACKOFF="0"):
+            analyzer = AttendanceAnalyzer()
+            with mock.patch("urllib.request.urlopen", side_effect=Exception("network down")):
+                ok = analyzer._try_load_from_gov_api(2027)
 
         self.assertFalse(ok)
-        self.assertGreaterEqual(calls["count"], 1)
 
     def test_timeout_then_success(self):
-        os.environ["HOLIDAY_API_MAX_RETRIES"] = "2"
         import socket as _socket
-
-        seq = [
-            _socket.timeout("timed out"),
-            DummyHTTPResponse({
-                "result": {"records": [{"isHoliday": 1, "date": "2027-10-10"}]}
-            })
-        ]
-
-        def seq_urlopen(url, timeout=10, context=None):
-            v = seq.pop(0)
-            if isinstance(v, Exception):
-                raise v
-            return v
-
-        analyzer = AttendanceAnalyzer()
-        with mock.patch("urllib.request.urlopen", side_effect=seq_urlopen):
-            ok = analyzer._try_load_from_gov_api(2027)
+        with temp_env(HOLIDAY_API_MAX_RETRIES="2", HOLIDAY_API_BACKOFF_BASE="0", HOLIDAY_API_MAX_BACKOFF="0"):
+            analyzer = AttendanceAnalyzer()
+            seq = [
+                _socket.timeout("timed out"),
+                {"result": {"records": [{"isHoliday": 1, "date": "2027-10-10"}]}}
+            ]
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
+                ok = analyzer._try_load_from_gov_api(2027)
         self.assertTrue(ok)
-
+"""Category: Holidays/API
+Purpose: Analyzer facade retry path via _try_load_from_gov_api."""

--- a/test/test_holidays_extra_coverage.py
+++ b/test/test_holidays_extra_coverage.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest import mock
+from datetime import datetime
+
+import lib.holidays as H
+from test.test_helpers import DummyResp, temp_env
+
+
+"""DummyResp is imported from shared test helpers."""
+
+
+class TestHolidaysExtraCoverage(unittest.TestCase):
+    def test_base_interface_load(self):
+        # Exercise HolidayProvider.load default implementation (pragma comment not honored by stdlib trace)
+        self.assertEqual(H.HolidayProvider().load(2025), set())
+
+    def test_hardcoded_2025_handles_value_error(self):
+        real_dt = H.datetime
+
+        class DTProxy:
+            calls = 0
+            @classmethod
+            def strptime(cls, s, fmt):
+                cls.calls += 1
+                if cls.calls == 1:
+                    raise ValueError('boom')
+                return real_dt.strptime(s, fmt)
+
+        with mock.patch('lib.holidays.datetime', new=DTProxy):
+            out = H.Hardcoded2025Provider().load(2025)
+        # still returns a set (with first date skipped)
+        self.assertTrue(any(d.year == 2025 for d in out))
+
+    def test_basic_fixed_handles_value_error(self):
+        real_dt = H.datetime
+        class DTProxy:
+            calls = 0
+            @classmethod
+            def strptime(cls, s, fmt):
+                cls.calls += 1
+                if cls.calls == 1:
+                    raise ValueError('bad-basic')
+                return real_dt.strptime(s, fmt)
+        with mock.patch('lib.holidays.datetime', new=DTProxy):
+            out = H.BasicFixedProvider().load(2027)
+        self.assertTrue(any(d.year == 2027 for d in out))
+
+    def test_service_returns_gov_when_nonempty(self):
+        with temp_env(HOLIDAY_API_MAX_RETRIES='0', HOLIDAY_API_BACKOFF_BASE='0', HOLIDAY_API_MAX_BACKOFF='0'):
+            svc = H.HolidayService()
+            fake_set = {datetime(2026, 1, 1).date()}
+            with mock.patch.object(H.TaiwanGovOpenDataProvider, 'load', return_value=fake_set):
+                out = svc.load_year(2026)
+        self.assertEqual(out, fake_set)
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Holidays/Providers
+Purpose: Provider edge handling and service behavior when gov returns data."""

--- a/test/test_holidays_providers.py
+++ b/test/test_holidays_providers.py
@@ -91,4 +91,5 @@ class TestHolidaysProviders(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Holidays/Providers
+Purpose: Validate hardcoded/basic providers and service fallbacks."""

--- a/test/test_more_core_paths.py
+++ b/test/test_more_core_paths.py
@@ -1,0 +1,132 @@
+import os
+import io
+import csv
+import json
+import tempfile
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from attendance_analyzer import AttendanceAnalyzer, AttendanceType
+
+
+class TestAnalyzerAdditionalPaths(unittest.TestCase):
+    def test_config_overrides(self):
+        # Write a temporary config that overrides one value
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = os.path.join(tmp, 'config.json')
+            with open(cfg_path, 'w', encoding='utf-8') as f:
+                json.dump({"min_overtime_minutes": 30}, f)
+            an = AttendanceAnalyzer(config_path=cfg_path)
+            self.assertEqual(an.config.min_overtime_minutes, 30)
+
+    def test_parse_file_blank_and_exception_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, '202507-小王-出勤資料.txt')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('頭\t欄\t位\n')
+                f.write('\n')  # blank triggers continue
+                f.write('x\ty\t上班\n')  # will be fed to patched parser
+
+            an = AttendanceAnalyzer()
+
+            # Patch internal line parser to raise, to hit except branch
+            with patch.object(AttendanceAnalyzer, '_parse_attendance_line', side_effect=ValueError('bad')):
+                with self.assertLogs(level='WARNING') as cm:
+                    an.parse_attendance_file(path, incremental=False)
+            self.assertIn('解析失敗', "\n".join(cm.output))
+
+    def test_export_report_triggers_backup_and_excel_issue_rows(self):
+        # Craft data that yields issues and ensure backup log is printed
+        text = (
+            '應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n'
+            '2025/07/01 09:00\t2025/07/01 11:00\t上班\t1\t刷卡匯入\t\t\t\t\n'  # late
+            '2025/07/01 18:00\t2025/07/01 20:15\t下班\t1\t刷卡匯入\t\t\t\t\n'  # overtime
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            in_path = os.path.join(tmp, '202507-王小明-出勤資料.txt')
+            with open(in_path, 'w', encoding='utf-8') as f:
+                f.write(text)
+
+            an = AttendanceAnalyzer()
+            an.parse_attendance_file(in_path, incremental=False)
+            an.group_records_by_day()
+            an.analyze_attendance()
+
+            out_xlsx = os.path.join(tmp, 'out.xlsx')
+            # Pre-create to force backup
+            open(out_xlsx, 'wb').close()
+            with self.assertLogs(level='INFO') as cm:
+                an.export_report(out_xlsx, 'excel')
+            logs = "\n".join(cm.output)
+            self.assertIn('備份現有檔案', logs)
+            self.assertTrue(os.path.exists(out_xlsx))
+
+    def test_openpyxl_import_error_branch(self):
+        # Ensure the inner openpyxl import error fallback in export_excel is covered
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(os.getcwd(), 'sample-attendance-data.txt')
+            path = os.path.join(tmp, 'sample-attendance-data.txt')
+            with open(src, 'r', encoding='utf-8') as fsrc, open(path, 'w', encoding='utf-8') as fdst:
+                fdst.write(fsrc.read())
+
+            an = AttendanceAnalyzer()
+            an.parse_attendance_file(path, incremental=False)
+            an.group_records_by_day()
+            an.analyze_attendance()
+
+            # Patch import to raise ImportError when importing openpyxl
+            import builtins as _builtins
+            real_import = _builtins.__import__
+
+            def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+                if name == 'openpyxl':
+                    raise ImportError('no openpyxl installed')
+                return real_import(name, globals, locals, fromlist, level)
+
+            xlsx = path.replace('.txt', '_analysis.xlsx')
+            csv = path.replace('.txt', '_analysis.csv')
+            with patch('builtins.__import__', side_effect=fake_import):
+                with self.assertLogs(level='WARNING') as cm:
+                    an.export_excel(xlsx)
+            self.assertTrue(os.path.exists(csv))
+            self.assertIn('未安裝 openpyxl，回退使用CSV格式', "\n".join(cm.output))
+
+    def test_compute_incremental_status_row_returns_none_when_unprocessed(self):
+        # Create one complete day
+        with tempfile.TemporaryDirectory() as tmp:
+            p = os.path.join(tmp, '202507-王小明-出勤資料.txt')
+            with open(p, 'w', encoding='utf-8') as f:
+                f.write('h\th\th\n')
+                f.write('2025/07/01 09:00\t2025/07/01 09:00\t上班\t\n')
+                f.write('2025/07/01 18:00\t2025/07/01 18:00\t下班\t\n')
+
+            class DummyState:
+                def __init__(self):
+                    self.state_data = {"users": {}}
+                def get_user_processed_ranges(self, user):
+                    return []
+                def get_last_analysis_time(self, user):
+                    return ''
+
+            an = AttendanceAnalyzer()
+            an.parse_attendance_file(p, incremental=True)
+            an.group_records_by_day()
+
+            # Force unprocessed dates to be non-empty
+            with patch.object(AttendanceAnalyzer, '_get_unprocessed_dates', return_value=[datetime(2025, 7, 1)]):
+                an.state_manager = DummyState()
+                an.current_user = '王小明'
+                self.assertIsNone(an._compute_incremental_status_row())
+
+    def test_load_taiwan_holidays_default_year(self):
+        an = AttendanceAnalyzer()
+        # No records; direct call to use default years branch
+        an._load_taiwan_holidays()
+        self.assertTrue(any(d.strftime('%Y/%m/%d') == '2025/10/10' for d in an.holidays))
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Analyzer/Core
+Purpose: Config overrides, parse errors, backup log, import fallback, and status-row logic."""

--- a/test/test_more_excel_exporter.py
+++ b/test/test_more_excel_exporter.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+import unittest
+from datetime import datetime
+
+from lib import excel_exporter as xls
+from attendance_analyzer import Issue, IssueType
+
+
+class TestExcelExporterMore(unittest.TestCase):
+    def test_status_row_and_type_colors(self):
+        wb, ws, header_font, header_fill, border, align = xls.init_workbook()
+        headers = ['日期', '類型', '時長(分鐘)', '說明', '時段', '計算式', '狀態']
+        xls.write_headers(ws, headers, header_font, header_fill, border, align)
+
+        # Write status row and assert returned next row index
+        next_row = xls.write_status_row(ws, '2025/07/31', 22, '2025-09-13T12:00:00', border, align)
+        self.assertEqual(next_row, 3)
+        self.assertEqual(ws['A2'].value, '2025/07/31')
+        self.assertEqual(ws['B2'].value, '狀態資訊')
+        self.assertEqual(ws['G2'].value, '系統狀態')
+
+        # Prepare issues to hit all color branches
+        issues = [
+            Issue(datetime(2025, 7, 1), IssueType.OVERTIME, 120, '加班', '18:00~20:00', 'calc', True),
+            Issue(datetime(2025, 7, 2), IssueType.WFH, 540, 'WFH', '', '', False),
+            Issue(datetime(2025, 7, 3), IssueType.FORGET_PUNCH, 30, '忘刷卡', '', '', True),
+        ]
+        xls.write_issue_rows(ws, issues, start_row=next_row, incremental_mode=True, border=border, alignment=align)
+
+        # Sanity check values written
+        self.assertEqual(ws['B3'].value, '加班')
+        self.assertEqual(ws['B4'].value, 'WFH假')
+        self.assertEqual(ws['B5'].value, '忘刷卡')
+        self.assertEqual(ws['G3'].value, '[NEW] 本次新發現')
+        self.assertEqual(ws['G4'].value, '已存在')
+
+        # Save to ensure no errors in save_workbook path
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            xls.save_workbook(wb, tmp.name)
+            saved = tmp.name
+        self.assertTrue(os.path.exists(saved))
+        os.remove(saved)
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Export/Excel
+Purpose: Status row rendering, cell styles, and save routine."""

--- a/test/test_more_utils_and_holidays.py
+++ b/test/test_more_utils_and_holidays.py
@@ -1,0 +1,91 @@
+import os
+import json
+import unittest
+from datetime import datetime
+from unittest import mock
+
+from lib import parser
+from lib.filename import parse_range_and_user
+from lib.grouping import group_daily
+from lib.state import AttendanceStateManager
+from lib.holidays import HolidayService, TaiwanGovOpenDataProvider
+
+
+class DummyRec:
+    def __init__(self, date=None, type_name='CHECKOUT'):
+        self.date = date
+        class T:
+            name = type_name
+        self.type = T()
+
+
+class DummyResp:
+    def __init__(self, payload: dict):
+        self._payload = payload
+    def read(self):
+        return json.dumps(self._payload).encode('utf-8')
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        return False
+
+
+class TestMiscGaps(unittest.TestCase):
+    def test_parser_invalid_datetime_and_type(self):
+        # parse_datetime_str invalid
+        self.assertIsNone(parser.parse_datetime_str('not-a-dt'))
+        # parse_line invalid type returns None
+        self.assertIsNone(parser.parse_line('2025/07/01 09:00\t2025/07/01 09:00\t打卡\t'))
+        # parse_line missing scheduled returns None
+        self.assertIsNone(parser.parse_line('\t2025/07/01 09:00\t上班\t'))
+
+    def test_filename_value_error_paths(self):
+        # Invalid month causes ValueError path
+        self.assertEqual(parse_range_and_user('20251x-姓名-出勤資料.txt'), (None, None, None))
+        # Force second segment to parse and then fail month math (13th month)
+        self.assertEqual(parse_range_and_user('202501-202513-姓名-出勤資料.txt'), (None, None, None))
+
+    def test_grouping_skips_none_date(self):
+        out = group_daily([DummyRec(date=None), DummyRec(date=datetime(2025,7,1))])
+        self.assertIn(datetime(2025,7,1), out)
+
+    def test_state_getters_for_missing_user(self):
+        s = AttendanceStateManager(state_file=':memory:')
+        self.assertEqual(s.get_forget_punch_usage('nobody', '2025-07'), 0)
+        self.assertEqual(s.get_last_analysis_time('nobody'), '')
+
+    def test_holiday_env_parsing_invalid(self):
+        old = dict(os.environ)
+        try:
+            os.environ['HOLIDAY_API_MAX_RETRIES'] = 'not-int'
+            os.environ['HOLIDAY_API_BACKOFF_BASE'] = 'not-float'
+            os.environ['HOLIDAY_API_MAX_BACKOFF'] = 'not-float'
+            p = TaiwanGovOpenDataProvider()
+            # Defaults applied
+            self.assertEqual(p.max_retries, 3)
+            self.assertEqual(p.base_backoff, 0.5)
+            self.assertEqual(p.max_backoff, 8.0)
+        finally:
+            os.environ.clear(); os.environ.update(old)
+
+    def test_holiday_service_load_years(self):
+        # Mock URL open to return empty valid result for non-2025 to force fallback basic
+        payload = {'result': {'records': []}}
+        with mock.patch('urllib.request.urlopen', return_value=DummyResp(payload)):
+            old = dict(os.environ)
+            try:
+                os.environ['HOLIDAY_API_MAX_RETRIES'] = '0'
+                os.environ['HOLIDAY_API_BACKOFF_BASE'] = '0'
+                os.environ['HOLIDAY_API_MAX_BACKOFF'] = '0'
+                svc = HolidayService()
+                out = svc.load_years({2025, 2026})
+            finally:
+                os.environ.clear(); os.environ.update(old)
+        # Contains at least one known date from 2025 hardcoded provider or 2026 basic
+        self.assertTrue(any(d.year in (2025, 2026) for d in out))
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Utils/Holidays
+Purpose: Parser/filename edges, grouping, state getters, env parsing and load_years."""

--- a/test/test_overtime_rounding.py
+++ b/test/test_overtime_rounding.py
@@ -41,4 +41,5 @@ class TestOvertimeRounding(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Policy/Overtime
+Purpose: Overtime rounding thresholds and increments."""

--- a/test/test_parser_more.py
+++ b/test/test_parser_more.py
@@ -1,0 +1,20 @@
+import unittest
+
+from lib import parser
+
+
+class TestParserMore(unittest.TestCase):
+    def test_too_few_fields_returns_none(self):
+        # Fewer than 3 fields after split -> early None
+        self.assertIsNone(parser.parse_line('only-one\tfield'))
+
+    def test_bad_scheduled_datetime_returns_none(self):
+        # scheduled_str present but bad format -> scheduled_dt None -> None
+        line = 'bad-dt\t2025/07/01 09:00\t上班\t卡\t源\t\t\t\t'
+        self.assertIsNone(parser.parse_line(line))
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Parsing
+Purpose: Minimal-field handling and bad scheduled datetime."""

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -99,4 +99,5 @@ class TestPolicy(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Policy
+Purpose: Late calculation branches and overtime applicability thresholds."""

--- a/test/test_policy_more.py
+++ b/test/test_policy_more.py
@@ -1,0 +1,43 @@
+import unittest
+from datetime import datetime
+
+from lib.policy import Rules, calculate_late_minutes, calculate_overtime_minutes
+
+
+class W:
+    def __init__(self, ci=None, co=None, date=datetime(2025,7,1)):
+        class Rec:
+            def __init__(self, t):
+                self.actual_time = t
+        self.checkin_record = Rec(ci) if ci else None
+        self.checkout_record = Rec(co) if co else None
+        self.date = date
+
+
+class TestPolicyMore(unittest.TestCase):
+    def test_late_over_120_before_lunch_no_deduction(self):
+        # Make latest_checkin very early so 11:30 becomes >120 mins late, but before lunch start.
+        rules = Rules(latest_checkin='09:00')  # lunch_start default 12:30
+        wd = W(ci=datetime(2025,7,1,11,30), co=datetime(2025,7,1,20,0))
+        mins, tr, calc = calculate_late_minutes(wd, rules)
+        self.assertGreater(mins, 120)
+        self.assertIn('遲到:', calc)
+        self.assertNotIn('午休', calc)  # no deduction branch
+
+    def test_late_early_return_when_missing_checkin(self):
+        rules = Rules()
+        wd = W(ci=None, co=datetime(2025,7,1,18,0))
+        mins, tr, calc = calculate_late_minutes(wd, rules)
+        self.assertEqual((mins, tr, calc), (0, '', ''))
+
+    def test_overtime_early_return_when_incomplete(self):
+        rules = Rules()
+        wd = W(ci=datetime(2025,7,1,9,0), co=None)
+        actual, applicable, tr, calc = calculate_overtime_minutes(wd, rules)
+        self.assertEqual((actual, applicable, tr, calc), (0, 0, '', ''))
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: Policy
+Purpose: Additional late/overtime guard branches and no-deduction scenario."""

--- a/test/test_report_builder.py
+++ b/test/test_report_builder.py
@@ -30,4 +30,5 @@ class TestReportBuilder(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Report
+Purpose: Incremental section preview and issue sections rendering."""

--- a/test/test_state_edgecases.py
+++ b/test/test_state_edgecases.py
@@ -56,4 +56,5 @@ class TestStateEdgeCases(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: State
+Purpose: Corrupt state file, save failure warnings, and merge logic."""

--- a/test/test_state_filter_unprocessed.py
+++ b/test/test_state_filter_unprocessed.py
@@ -40,4 +40,5 @@ class TestFilterUnprocessed(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: State/Dates
+Purpose: Range merging and membership checks for unprocessed date filter."""

--- a/test/test_state_update_flow.py
+++ b/test/test_state_update_flow.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+import unittest
+
+from attendance_analyzer import AttendanceAnalyzer, AttendanceType
+
+
+class DummyState:
+    def __init__(self):
+        self.saved = False
+        self.updated = False
+        self.state_data = {"users": {}}
+
+    def get_user_processed_ranges(self, user):
+        return []
+
+    def get_last_analysis_time(self, user):
+        return ""
+
+    def update_user_state(self, user, range_info, forget_punch_usage):
+        self.updated = True
+        self.state_data.setdefault('users', {}).setdefault(user, {})['last'] = range_info
+
+    def save_state(self):
+        self.saved = True
+
+    def detect_date_overlap(self, user, start, end):
+        return []
+
+
+class TestStateUpdateFlow(unittest.TestCase):
+    def _write_minimal_file(self, path):
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n')
+            # 2025/07/01 checkin and checkout to form a complete day
+            f.write('2025/07/01 09:10\t2025/07/01 09:10\t上班\t123\t門禁\t\t\t\t\n')
+            f.write('2025/07/01 18:20\t2025/07/01 18:20\t下班\t123\t門禁\t\t\t\t\n')
+
+    def test_update_processing_state_is_called(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, '202507-阿明-出勤資料.txt')
+            self._write_minimal_file(path)
+
+            an = AttendanceAnalyzer()
+            an.parse_attendance_file(path, incremental=True)
+            an.group_records_by_day()
+
+            # Replace real state manager with dummy to observe updates
+            dummy = DummyState()
+            an.state_manager = dummy
+
+            an.analyze_attendance()
+
+            self.assertTrue(dummy.updated)
+            self.assertTrue(dummy.saved)
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: State
+Purpose: Ensure update/save is invoked after analysis in incremental mode."""

--- a/test/test_status_row_timestamp.py
+++ b/test/test_status_row_timestamp.py
@@ -67,3 +67,5 @@ class TestStatusRowTimestamp(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+"""Category: Export/StatusRow
+Purpose: Status row includes last analysis timestamp for CSV/Excel."""

--- a/test/test_unprocessed_and_dates.py
+++ b/test/test_unprocessed_and_dates.py
@@ -1,0 +1,48 @@
+import unittest
+from datetime import datetime
+
+from attendance_analyzer import AttendanceAnalyzer
+from lib.dates import identify_complete_work_days
+
+
+class TestUnprocessedEarlyReturn(unittest.TestCase):
+    def test_get_unprocessed_dates_without_state_returns_all(self):
+        an = AttendanceAnalyzer()
+        an.incremental_mode = True
+        # Two complete days
+        days = [
+            datetime(2025, 7, 1),
+            datetime(2025, 7, 2),
+        ]
+        out = an._get_unprocessed_dates('任意', days)
+        self.assertEqual(out, days)
+
+    def test_get_unprocessed_dates_full_mode_returns_all(self):
+        an = AttendanceAnalyzer()
+        an.incremental_mode = False
+        days = [datetime(2025, 7, 1)]
+        out = an._get_unprocessed_dates('任意', days)
+        self.assertEqual(out, days)
+
+
+class TestDatesHelperSkipsInvalid(unittest.TestCase):
+    class Obj:
+        def __init__(self, date=None, type=None):
+            self.date = date
+            self.type = type
+
+    def test_identify_complete_skips_none_date(self):
+        # One valid complete day + one record with no date should be ignored
+        recs = [
+            self.Obj(datetime(2025, 7, 1).date(), 'CHECKIN'),
+            self.Obj(datetime(2025, 7, 1).date(), 'CHECKOUT'),
+            self.Obj(None, 'CHECKIN'),
+        ]
+        out = identify_complete_work_days(recs)
+        self.assertEqual([d.date() for d in out], [datetime(2025, 7, 1).date()])
+
+
+if __name__ == '__main__':
+    unittest.main()
+"""Category: State/Dates
+Purpose: Analyzer exposure of unprocessed dates and complete-day id."""

--- a/test/test_wfh_holiday_edge.py
+++ b/test/test_wfh_holiday_edge.py
@@ -40,4 +40,5 @@ class TestWfhHolidayEdge(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
+"""Category: Policy/Holidays
+Purpose: WFH suggestion behavior on holidays vs normal Fridays."""

--- a/tools/check_coverage_threshold.py
+++ b/tools/check_coverage_threshold.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Fail if project coverage percent is below a threshold.
+
+Reads stdlib trace outputs from coverage_report/*.cover and computes the
+overall coverage for project files (attendance_analyzer.py, lib/*.py).
+
+Usage:
+  python tools/check_coverage_threshold.py --min 95
+"""
+from pathlib import Path
+import re
+import argparse
+import sys
+
+
+def compute_percent(coverdir: Path) -> float:
+    files = [p for p in coverdir.glob('*.cover') if p.name.startswith(('attendance_analyzer', 'lib.'))]
+    executed = missing = 0
+    for p in files:
+        text = p.read_text(encoding='utf-8', errors='ignore').splitlines()
+        executed += sum(1 for line in text if re.match(r'^\s*\d+\s*:', line))
+        missing += sum(1 for line in text if line.strip().startswith('>>>>>>'))
+    total = executed + missing
+    if total == 0:
+        return 100.0
+    return executed / total * 100.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--min', dest='minimum', type=float, default=95.0, help='minimum coverage percent required')
+    ap.add_argument('--dir', dest='coverdir', default='coverage_report', help='coverage directory')
+    args = ap.parse_args()
+
+    coverdir = Path(args.coverdir)
+    if not coverdir.exists():
+        print("coverage_report/ not found. Run 'make coverage' first.", file=sys.stderr)
+        return 2
+
+    pct = compute_percent(coverdir)
+    print(f"Project coverage: {pct:.2f}% (required: {args.minimum:.2f}%)")
+    if pct + 1e-9 < args.minimum:
+        print("Coverage below threshold.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())
+


### PR DESCRIPTION
Summary
- Enforce 100% coverage and consolidate tests for speed and clarity.

Changes
- Add shared test helpers (DummyResp, temp_env, urlopen_sequence).
- Consolidate and speed up holiday API tests using helpers.
- Add analyzer internal branch tests and __main__ guard coverage.
- Add incremental Excel issue-row test; ensure status column is written.
- Add parser edge tests; remove unreachable branch in parser.
- Remove no-op in CSV exporter.
- Add consistent Category/Purpose headers across all tests.

CI
- GitHub Actions runs `make coverage` and enforces 100% via `tools/check_coverage_threshold.py`.
- Uploads `coverage_report/` and `assets/coverage.svg` as artifacts.

Coverage
- Overall: 100%.
- Per-file: 100% for attendance_analyzer.py and all lib/*.py.

How to verify locally
- `make coverage-check`  (generates report + enforces 100%)
- `python3 -m unittest -q` (fast run without coverage)

Notes
- Non-functional cleanups only (parser unreachable branch, CSV exporter no-op removal).
