### PR TITLE
fix(parser): handle headerless files, keep status row with WFH-only issues

### DIFF
--- a/attendance_analyzer.py
+++ b/attendance_analyzer.py
@@ -242,13 +242,10 @@ class AttendanceAnalyzer:
         # 解析檔案內容
         with open(filepath, encoding="utf-8") as f:
             lines = f.readlines()
-        logger.debug("📥  讀入檔案 %s，共 %d 行資料 (含表頭)", filepath, len(lines))
+        logger.debug("📥  讀入檔案 %s，共 %d 行資料", filepath, len(lines))
 
         parsed_records = 0
         for line_num, line in enumerate(lines, 1):
-            if line_num == 1:  # 跳過表頭
-                continue
-
             line = line.strip()
             if not line:
                 continue
@@ -260,7 +257,7 @@ class AttendanceAnalyzer:
                     parsed_records += 1
             except (ValueError, IndexError) as e:
                 logger.warning("第%d行解析失敗: %s", line_num, e)
-        skipped_lines = max(len(lines) - 1 - parsed_records, 0)
+        skipped_lines = max(len(lines) - parsed_records, 0)
         logger.debug(
             "✅  完成解析，有效紀錄 %d 筆，略過 %d 行",
             parsed_records,
@@ -691,7 +688,11 @@ class AttendanceAnalyzer:
         from lib import csv_exporter
 
         status_tuple = None
-        if self.incremental_mode and not self.issues and self.current_user:
+        # Auto-filled Friday WFH suggestions are calendar-derived, not
+        # attendance-derived. Only suppress the status row when there are
+        # real attendance issues.
+        non_wfh_issues = [i for i in self.issues if i.type != IssueType.WFH]
+        if self.incremental_mode and not non_wfh_issues and self.current_user:
             status_tuple = self._compute_incremental_status_row()
 
         csv_exporter.save_csv(
@@ -733,7 +734,8 @@ class AttendanceAnalyzer:
         ws.append(headers)
 
         # data_start_appended = False  # Variable assigned but never used
-        if self.incremental_mode and not self.issues and self.current_user:
+        non_wfh_issues = [i for i in self.issues if i.type != IssueType.WFH]
+        if self.incremental_mode and not non_wfh_issues and self.current_user:
             status_tuple = self._compute_incremental_status_row()
             if status_tuple:
                 last_date, total, last_time = status_tuple

--- a/lib/csv_exporter.py
+++ b/lib/csv_exporter.py
@@ -60,7 +60,10 @@ def _build_rows(
 ) -> list[list[str]]:
     rows: list[list[str]] = []
     rows.append(_header_row(incremental_mode))
-    if status and incremental_mode and not issues:
+    # Auto-filled Friday WFH suggestions are calendar-derived, so they should
+    # not suppress the "all dates processed" status row.
+    non_wfh_issues = [i for i in issues if getattr(getattr(i, "type", None), "name", "") != "WFH"]
+    if status and incremental_mode and not non_wfh_issues:
         last_date, complete_days, last_analysis_time = status
         rows.append(_status_row(last_date, complete_days, last_analysis_time))
     for issue in issues:

--- a/test/test_parse_first_line.py
+++ b/test/test_parse_first_line.py
@@ -1,0 +1,48 @@
+"""Regression: parse_attendance_file must accept files without a header.
+
+Previously line 1 was unconditionally skipped, silently dropping the first
+record when the input had no header row (e.g. files produced by other tools).
+"""
+import os
+import tempfile
+import unittest
+
+from attendance_analyzer import AttendanceAnalyzer
+
+HEADER = "\t".join([
+    "應刷卡時段", "當日卡鐘資料", "刷卡別", "卡鐘編號", "資料來源",
+    "異常狀態", "處理狀態", "異常處理作業", "備註",
+])
+ROW_IN = "2025/07/01 09:30\t2025/07/01 10:25\t上班\t1\t刷卡匯入\t遲到\t\t\t"
+ROW_OUT = "2025/07/01 18:30\t2025/07/01 19:49\t下班\t1\t刷卡匯入\t\t\t\t"
+
+
+class TestParseFirstLine(unittest.TestCase):
+    def _write(self, lines: list[str]) -> str:
+        fd, path = tempfile.mkstemp(prefix="202507-Tester-出勤資料-", suffix=".txt")
+        os.close(fd)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+        return path
+
+    def test_file_with_header_parses_two_records(self) -> None:
+        path = self._write([HEADER, ROW_IN, ROW_OUT])
+        try:
+            a = AttendanceAnalyzer()
+            a.parse_attendance_file(path, incremental=False)
+            self.assertEqual(len(a.records), 2)
+        finally:
+            os.remove(path)
+
+    def test_file_without_header_parses_all_records(self) -> None:
+        path = self._write([ROW_IN, ROW_OUT])
+        try:
+            a = AttendanceAnalyzer()
+            a.parse_attendance_file(path, incremental=False)
+            self.assertEqual(len(a.records), 2, "first data line must not be dropped as header")
+        finally:
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `parse_attendance_file` 無條件跳過第 1 行,假設一定有表頭。Portal 以外來源(其他工具、手動匯出)若無 header,第一筆出勤記錄會被靜默丟棄 — 例如該日的遲到/加班完全消失。
- `lib.parser.parse_line` 本身就會拒絕非「上班/下班」的列(回傳 `None`),所以直接移除這個特例,header-prefixed 與 header-less 兩種輸入都能正確解析。
- 修這個 bug 時順帶撞到一個既存問題:`904b2d2` 加入週五 WFH auto-fill 後,`self.issues` 在增量模式下永遠非空,讓 `_compute_incremental_status_row` 條件 `not self.issues` 失效 → 「全部已處理」的狀態列再也不會輸出。把判斷改成排除自動補的 WFH 條目(`analyzer` + `csv_exporter` 兩處)。
- 新增 `test/test_parse_first_line.py` 涵蓋有/無 header 兩種輸入。

## Reproduction (before fix)

```bash
# 產生無 header 的出勤檔(其他工具常見格式)
printf '2026/04/01 09:30\t2026/04/01 11:52\t上班\t1\t刷卡匯入\t遲到\t\t\t\n2026/04/01 18:30\t2026/04/01 19:49\t下班\t1\t刷卡匯入\t\t\t\t\n' > 202604-Test-出勤資料.txt
python3 attendance_analyzer.py 202604-Test-出勤資料.txt
# → 4/01 遲到/加班完全沒出現(上班記錄被當 header 丟掉)
```

## Test plan
- [x] 新測試 `test/test_parse_first_line.py` 涵蓋有/無 header
- [x] 全測試套件通過 (`python3 -m unittest discover -s test`,136 tests OK,skipped=2 為 openpyxl 環境相關)
- [x] 既有 `test_csv_status_has_timestamp` 從 fail → pass(原 main 也壞,被一併修)
- [x] 手動驗證 4/01 上班/下班 兩筆記錄都正確進入 analyzer