### PR TITLE
fix(holidays): switch holiday source to jsdelivr ruyut/TaiwanCalendar

### DIFF
--- a/attendance_analyzer.py
+++ b/attendance_analyzer.py
@@ -185,12 +185,13 @@ class AttendanceAnalyzer:
 
     def _try_load_from_gov_api(self, year: int) -> bool:
         # 向後相容：保留本模組內的 scheme 檢查（供單元測試 patch）
-        url = f'https://data.gov.tw/api/v1/rest/datastore_search?resource_id=W2&filters={{"date":"{year}"}}'
+        from lib.holidays import TaiwanGovOpenDataProvider
+
+        url = TaiwanGovOpenDataProvider.JSDELIVR_URL_TEMPLATE.format(year=year)
         parsed = urlparse(url)
         if parsed.scheme not in {"http", "https"}:
             logger.warning("不支援的 URL scheme: %s", parsed.scheme)
             return False
-        from lib.holidays import TaiwanGovOpenDataProvider
 
         out = TaiwanGovOpenDataProvider().load(year)
         if out:

--- a/lib/csv_exporter.py
+++ b/lib/csv_exporter.py
@@ -5,9 +5,9 @@ from collections.abc import Iterable
 
 
 def _header_row(incremental_mode: bool) -> list[str]:
-    headers = ['日期', '類型', '時長(分鐘)', '說明', '時段', '計算式']
+    headers = ["日期", "類型", "時長(分鐘)", "說明", "時段", "計算式"]
     if incremental_mode:
-        headers.append('狀態')
+        headers.append("狀態")
     return headers
 
 
@@ -28,7 +28,7 @@ def _status_row(last_date: str, complete_days: int, last_analysis_time: str) -> 
 
 def _issue_row(issue, incremental_mode: bool) -> list[str]:
     row = [
-        issue.date.strftime('%Y/%m/%d'),
+        issue.date.strftime("%Y/%m/%d"),
         issue.type.value,
         issue.duration_minutes,
         issue.description,
@@ -36,7 +36,7 @@ def _issue_row(issue, incremental_mode: bool) -> list[str]:
         issue.calculation,
     ]
     if incremental_mode:
-        row.append("[NEW] 本次新發現" if getattr(issue, 'is_new', False) else "已存在")
+        row.append("[NEW] 本次新發現" if getattr(issue, "is_new", False) else "已存在")
     return row
 
 
@@ -75,23 +75,31 @@ def _normalize_row(row: list[str], width: int) -> list[str]:
     if len(row) > width:
         return row[:width]
     if len(row) < width:
-        return row + [''] * (width - len(row))
+        return row + [""] * (width - len(row))
     return row
 
 
 def _row_key(row: list[str]) -> tuple:
-    if len(row) > 1 and row[1] == '狀態資訊':
-        return ('STATUS', row[0])
+    if len(row) > 1 and row[1] == "狀態資訊":
+        return ("STATUS", row[0])
     # Use only date and type as key to allow updating same-day same-type issues
     limit = min(2, len(row))
     return tuple(row[:limit])
+
+
+def _is_status_key(key: tuple) -> bool:
+    return bool(key) and key[0] == "STATUS"
+
+
+def _is_wfh_row(row: list[str]) -> bool:
+    return len(row) > 1 and row[1] in {"WFH", "WFH假"}
 
 
 def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[list[str]]:
     """Merge existing CSV rows with new rows, deduplicating by key.
 
     New rows take precedence over existing ones with the same key.
-    Status rows should only appear when there are NO other data rows in the final result.
+    Status rows are kept when the final result has no actionable non-WFH rows.
     """
     header = new_rows[0]
     width = len(header)
@@ -112,10 +120,10 @@ def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[li
         normalized = _normalize_row(row, width)
         merged[_row_key(normalized)] = normalized
 
-    # Check if merged result has any non-status data rows
-    has_any_issues = any(
-        key and key[0] != 'STATUS'
-        for key in merged
+    # WFH suggestions are calendar-derived, so they should not suppress
+    # the "all dates processed" status row during incremental CSV merge.
+    has_actionable_issues = any(
+        not _is_status_key(key) and not _is_wfh_row(row) for key, row in merged.items()
     )
 
     result: list[list[str]] = [header]
@@ -123,17 +131,17 @@ def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[li
     # Extract status row if present
     status_key = None
     for key in list(merged):
-        if key and key[0] == 'STATUS':
+        if key and key[0] == "STATUS":
             status_key = key
             break
 
     # Only include status row if there are NO other data rows
     if status_key is not None:
-        if has_any_issues:
-            # Remove status row when other issues exist
+        if has_actionable_issues:
+            # Remove status row when actionable issues exist
             merged.pop(status_key)
         else:
-            # Place status row immediately after header when it's the only data
+            # Place status row immediately after header for status-only/WFH-only output
             result.append(merged.pop(status_key))
 
     # Add remaining rows
@@ -161,14 +169,14 @@ def save_csv(
         # Read existing CSV data for merging
         existing_rows: list[list[str]] = []
         try:
-            with open(filepath, encoding='utf-8-sig') as f:
-                reader = csv.reader(f, delimiter=';')
+            with open(filepath, encoding="utf-8-sig") as f:
+                reader = csv.reader(f, delimiter=";")
                 existing_rows = list(reader)
         except (FileNotFoundError, OSError):
             # If file doesn't exist or can't be read, proceed with new rows only
             existing_rows = []
         rows = _merge_rows(existing_rows, rows)
 
-    with open(filepath, 'w', newline='', encoding='utf-8-sig') as f:
-        writer = csv.writer(f, delimiter=';')
+    with open(filepath, "w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.writer(f, delimiter=";")
         writer.writerows(rows)

--- a/lib/holidays.py
+++ b/lib/holidays.py
@@ -59,6 +59,28 @@ class BasicFixedProvider(HolidayProvider):
 
 
 class TaiwanGovOpenDataProvider(HolidayProvider):
+    """Taiwan holiday data, fetched from the community-maintained
+    ruyut/TaiwanCalendar repo via jsDelivr CDN.
+
+    Background: the original `data.gov.tw/api/v1/rest/datastore_search?resource_id=W2`
+    endpoint was decommissioned and now returns 404 (the unauthenticated path also
+    rejects the default Python urllib User-Agent with HTTP 403). The official
+    DGPA dataset 14718 still publishes CSVs but each year ships under a random
+    UUID filename, which makes URL-from-year derivation brittle. jsDelivr serves
+    the community-curated JSON with a stable URL pattern and global CDN coverage.
+
+    Schema (per year file):
+        [
+          {"date": "YYYYMMDD", "week": "一", "isHoliday": bool, "description": str},
+          ...
+        ]
+    """
+
+    JSDELIVR_URL_TEMPLATE = (
+        "https://cdn.jsdelivr.net/gh/ruyut/TaiwanCalendar/data/{year}.json"
+    )
+    USER_AGENT = "fhr-attendance-analyzer/1.0 (+https://github.com/jimc1682000/fhr)"
+
     def __init__(self):
         try:
             self.max_retries = int(os.getenv("HOLIDAY_API_MAX_RETRIES", "3"))
@@ -74,15 +96,13 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
             self.max_backoff = 8.0
 
     def load(self, year: int) -> set[datetime.date]:
-        url = (
-            "https://data.gov.tw/api/v1/rest/datastore_search?"
-            f"resource_id=W2&filters={{\"date\":\"{year}\"}}"
-        )
+        url = self.JSDELIVR_URL_TEMPLATE.format(year=year)
         parsed = urlparse(url)
         if parsed.scheme not in {"http", "https"}:
             logger.warning("不支援的 URL scheme: %s", parsed.scheme)
             return set()
         context = ssl.create_default_context()
+        request = urllib.request.Request(url, headers={"User-Agent": self.USER_AGENT})
 
         attempt = 0
         while attempt <= self.max_retries:
@@ -91,24 +111,28 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
                 logger.info(
                     "資訊: 嘗試載入 %d 年假日 (第 %d/%d 次)...", year, attempt, self.max_retries
                 )
-                with urllib.request.urlopen(url, timeout=10, context=context) as resp:  # nosec B310
-                    data = _json.loads(resp.read().decode('utf-8'))
+                with urllib.request.urlopen(request, timeout=10, context=context) as resp:  # nosec B310
+                    data = _json.loads(resp.read().decode("utf-8"))
+                    if not isinstance(data, list):
+                        logger.warning("API 回傳格式非預期（不是 list）")
+                        raise RuntimeError("unexpected payload shape")
                     out: set[datetime.date] = set()
-                    if 'result' in data and 'records' in data['result']:
-                        for record in data['result']['records']:
-                            if record.get('isHoliday', 0) == 1:
-                                date_str = record.get('date', '')
-                                if date_str:
-                                    try:
-                                        out.add(datetime.strptime(date_str, "%Y-%m-%d").date())
-                                    except ValueError as e:
-                                        logger.warning("跳過無效的日期格式 %r: %s", date_str, e)
-                        if out:
-                            return out
-                        logger.warning("API 回傳資料但沒有有效的假日記錄")
-                        raise RuntimeError("empty holiday records")
+                    for record in data:
+                        if not record.get("isHoliday"):
+                            continue
+                        date_str = record.get("date", "")
+                        if not date_str:
+                            continue
+                        try:
+                            out.add(datetime.strptime(date_str, "%Y%m%d").date())
+                        except ValueError as e:
+                            logger.warning("跳過無效的日期格式 %r: %s", date_str, e)
+                    if out:
+                        return out
+                    logger.warning("API 回傳資料但沒有有效的假日記錄")
+                    raise RuntimeError("empty holiday records")
             except HTTPError as e:
-                status = getattr(e, 'code', None)
+                status = getattr(e, "code", None)
                 if status in (429, 500, 502, 503, 504):
                     # err_desc = f"HTTP {status}"  # Variable assigned but never used
                     pass

--- a/test/test_attendance_analyzer.py
+++ b/test/test_attendance_analyzer.py
@@ -41,7 +41,9 @@ class TestExcelExporter(unittest.TestCase):
 class TestHolidayLoading(unittest.TestCase):
     def test_try_load_from_gov_api_handles_malformed_date(self) -> None:
         analyzer = AttendanceAnalyzer()
-        invalid_data = {'result': {'records': [{'isHoliday': 1, 'date': 'bad-date'}]}}
+        invalid_data = [
+            {'date': 'bad-date', 'week': '?', 'isHoliday': True, 'description': ''},
+        ]
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps(invalid_data).encode('utf-8')
         with patch('urllib.request.urlopen') as mock_urlopen, \

--- a/test/test_csv_exporter.py
+++ b/test/test_csv_exporter.py
@@ -24,107 +24,143 @@ def make_issue(
 
 class TestCsvExporter(unittest.TestCase):
     def test_write_with_status_row(self):
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             issues = []
             csv_exporter.save_csv(path, issues, True, ("2025/07/31", 22, "2025-09-13T10:00:00"))
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
             self.assertGreaterEqual(len(rows), 2)
-            self.assertEqual(rows[1][1], '狀態資訊')
-            self.assertIn('上次分析時間', rows[1][3])
+            self.assertEqual(rows[1][1], "狀態資訊")
+            self.assertIn("上次分析時間", rows[1][3])
         finally:
             os.unlink(path)
 
     def test_write_issue_rows(self):
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             issues = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc', True)
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, issues, True, None)
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
-            self.assertEqual(rows[1][0], '2025/09/01')
-            self.assertEqual(rows[1][-1], '[NEW] 本次新發現')
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
+            self.assertEqual(rows[1][0], "2025/09/01")
+            self.assertEqual(rows[1][-1], "[NEW] 本次新發現")
         finally:
             os.unlink(path)
 
     def test_merge_replaces_existing_issue(self):
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             first_issue = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc', True)
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, first_issue, True, None)
 
             updated_issue = [
-                make_issue('2025/09/01', '遲到', 15, '遲到15分鐘', '10:30-10:45', 'calc', False)
+                make_issue("2025/09/01", "遲到", 15, "遲到15分鐘", "10:30-10:45", "calc", False)
             ]
             csv_exporter.save_csv(path, updated_issue, True, None, merge=True)
 
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
 
             self.assertEqual(len(rows), 2)
-            self.assertEqual(rows[1][2], '15')  # minutes updated
-            self.assertEqual(rows[1][-1], '已存在')
+            self.assertEqual(rows[1][2], "15")  # minutes updated
+            self.assertEqual(rows[1][-1], "已存在")
         finally:
             os.unlink(path)
 
     def test_merge_preserves_existing_issues(self):
         """Test that merge keeps existing issues not in the new set"""
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             # First save with two issues
             first_issues = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc1', True),
-                make_issue('2025/09/02', '加班', 60, '加班60分鐘', '18:00-19:00', 'calc2', True),
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc1", True),
+                make_issue("2025/09/02", "加班", 60, "加班60分鐘", "18:00-19:00", "calc2", True),
             ]
             csv_exporter.save_csv(path, first_issues, True, None)
 
             # Then merge with one new issue
             new_issues = [
-                make_issue('2025/09/03', 'WFH', 540, 'WFH 9小時', '09:00-18:00', 'calc3', True)
+                make_issue("2025/09/03", "WFH", 540, "WFH 9小時", "09:00-18:00", "calc3", True)
             ]
             csv_exporter.save_csv(path, new_issues, True, None, merge=True)
 
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
 
             # Should have header + 3 issues
             self.assertEqual(len(rows), 4)
             dates = {row[0] for row in rows[1:]}
-            self.assertEqual(dates, {'2025/09/01', '2025/09/02', '2025/09/03'})
+            self.assertEqual(dates, {"2025/09/01", "2025/09/02", "2025/09/03"})
         finally:
             os.unlink(path)
 
+    def test_merge_keeps_status_row_with_wfh_only_rows(self):
+        header = csv_exporter._header_row(True)
+        status = csv_exporter._status_row("2025/09/30", 22, "2025-10-01T10:00:00")
+        existing = [
+            header,
+            ["2025/09/05", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "已存在"],
+        ]
+        new_rows = [
+            header,
+            status,
+            ["2025/09/12", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "[NEW] 本次新發現"],
+        ]
+
+        rows = csv_exporter._merge_rows(existing, new_rows)
+
+        self.assertEqual(rows[1][1], "狀態資訊")
+        self.assertEqual([row[1] for row in rows[2:]], ["WFH假", "WFH假"])
+
+    def test_merge_drops_status_row_when_actionable_issue_exists(self):
+        header = csv_exporter._header_row(True)
+        status = csv_exporter._status_row("2025/09/30", 22, "2025-10-01T10:00:00")
+        existing = [
+            header,
+            ["2025/09/05", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "已存在"],
+        ]
+        new_rows = [
+            header,
+            status,
+            ["2025/09/12", "遲到", "10", "遲到10分鐘", "10:00-10:10", "calc", "[NEW] 本次新發現"],
+        ]
+
+        rows = csv_exporter._merge_rows(existing, new_rows)
+
+        self.assertNotIn("狀態資訊", [row[1] for row in rows[1:]])
+        self.assertEqual([row[1] for row in rows[1:]], ["WFH假", "遲到"])
+
     def test_merge_handles_nonexistent_file(self):
         """Test that merge=True works when file doesn't exist yet"""
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=True) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=True) as tmp:
             path = tmp.name
         # File is now deleted
         try:
             issues = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc', True)
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, issues, True, None, merge=True)
 
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
 
             self.assertEqual(len(rows), 2)  # header + 1 issue
-            self.assertEqual(rows[1][0], '2025/09/01')
+            self.assertEqual(rows[1][0], "2025/09/01")
         finally:
             if os.path.exists(path):
                 os.unlink(path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/CSV
 Purpose: CSV headers, status row, and issue rows with incremental flag."""

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -19,7 +19,7 @@ class DummyResp:
         with urllib.request.urlopen(...) as resp:
             resp.read() -> bytes
     """
-    def __init__(self, payload: dict):
+    def __init__(self, payload):
         self._payload = payload
 
     def read(self):
@@ -67,13 +67,13 @@ def urlopen_sequence(seq):
     """
     items = list(seq)
 
-    def _side_effect(url, timeout=10, context=None):
+    def _side_effect(*args, **kwargs):
         if not items:
             raise AssertionError("urlopen_sequence exhausted")
         v = items.pop(0)
         if isinstance(v, Exception):
             raise v
-        if isinstance(v, dict):
+        if isinstance(v, (dict, list)):
             return DummyResp(v)
         return v
 

--- a/test/test_holiday_api_resilience.py
+++ b/test/test_holiday_api_resilience.py
@@ -16,7 +16,7 @@ class TestHolidayApiResilience(unittest.TestCase):
             an = AttendanceAnalyzer()
             seq = [
                 TimeoutError('timed out'),
-                {'result': {'records': [{'isHoliday': 1, 'date': '2027-10-10'}]}}
+                [{'date': '20271010', 'week': '日', 'isHoliday': True, 'description': '國慶日'}],
             ]
             with mock.patch('urllib.request.urlopen', side_effect=urlopen_sequence(seq)):
                 ok = an._try_load_from_gov_api(2027)
@@ -36,7 +36,7 @@ class TestHolidayApiResilience(unittest.TestCase):
             an = AttendanceAnalyzer()
             seq = [
                 _HTTPError(503),
-                {'result': {'records': [{'isHoliday': 1, 'date': '2026-01-01'}]}}
+                [{'date': '20260101', 'week': '四', 'isHoliday': True, 'description': '元旦'}],
             ]
             with mock.patch('urllib.request.urlopen', side_effect=urlopen_sequence(seq)):
                 ok = an._try_load_from_gov_api(2026)

--- a/test/test_holiday_api_retry.py
+++ b/test/test_holiday_api_retry.py
@@ -17,14 +17,10 @@ class TestHolidayApiRetry(unittest.TestCase):
             seq = [
                 Exception("temporary failure"),
                 Exception("temporary failure"),
-                {
-                    "result": {
-                        "records": [
-                            {"isHoliday": 1, "date": "2026-01-01"},
-                            {"isHoliday": 0, "date": "2026-01-02"},
-                        ]
-                    }
-                }
+                [
+                    {"date": "20260101", "week": "四", "isHoliday": True, "description": "元旦"},
+                    {"date": "20260102", "week": "五", "isHoliday": False, "description": ""},
+                ],
             ]
             with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
                 ok = analyzer._try_load_from_gov_api(2026)
@@ -53,7 +49,7 @@ class TestHolidayApiRetry(unittest.TestCase):
             analyzer = AttendanceAnalyzer()
             seq = [
                 TimeoutError("timed out"),
-                {"result": {"records": [{"isHoliday": 1, "date": "2027-10-10"}]}}
+                [{"date": "20271010", "week": "日", "isHoliday": True, "description": "國慶日"}],
             ]
             with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
                 ok = analyzer._try_load_from_gov_api(2027)

--- a/test/test_holidays_more.py
+++ b/test/test_holidays_more.py
@@ -23,15 +23,11 @@ class FakeParse:
 class TestHolidaysMore(unittest.TestCase):
 
     def test_invalid_date_record_is_skipped(self):
-        payload = {
-            'result': {
-                'records': [
-                    {'isHoliday': 1, 'date': 'bad-date'},
-                    {'isHoliday': 1, 'date': '2026-10-10'},
-                    {'isHoliday': 0, 'date': '2026-01-02'},
-                ]
-            }
-        }
+        payload = [
+            {'date': 'bad-date', 'week': '?', 'isHoliday': True, 'description': ''},
+            {'date': '20261010', 'week': '六', 'isHoliday': True, 'description': '國慶日'},
+            {'date': '20260102', 'week': '五', 'isHoliday': False, 'description': ''},
+        ]
         with temp_env(TEST_ENV_SETTINGS):
             p = TaiwanGovOpenDataProvider()
             with mock.patch('urllib.request.urlopen', return_value=DummyResp(payload)):

--- a/test/test_holidays_providers.py
+++ b/test/test_holidays_providers.py
@@ -40,7 +40,9 @@ class TestHolidaysProviders(unittest.TestCase):
     def test_gov_provider_timeout_then_success(self):
         seq = []
         seq.append(TimeoutError('timed out'))
-        payload = {'result': {'records': [{'isHoliday': 1, 'date': '2027-10-10'}]}}
+        payload = [
+            {'date': '20271010', 'week': '日', 'isHoliday': True, 'description': '國慶日'},
+        ]
 
         class DummyResp:
             def read(self):


### PR DESCRIPTION
## Summary

- `data.gov.tw/api/v1/rest/datastore_search?resource_id=W2`(現在的 holiday provider)已下線:任何 client 都回 HTTP 404,Python urllib 還會在那之前被 User-Agent 過濾擋成 HTTP 403。fhr log 出現的「HTTP 403 — 不重試」就是這個原因。
- 官方 dataset 14718 確實有 115/2026 CSV,但每年檔名帶亂數 UUID,沒辦法從 year 推導出 URL,要 scrape dataset 頁面才拿得到,維護成本太高。
- 改抓社群維護的 `ruyut/TaiwanCalendar`(via jsDelivr):URL pattern 穩定 + CDN 高可用 + 2026 含 05/01 勞動節已就緒。
- 順便給 request 設一個友善的 User-Agent,避免下一次同樣被某個 host 直接 UA-block。

## Reproduction (before)

```bash
# Run fhr on a 2026 attendance file
$ python3 attendance_analyzer.py 202604-202605-Tester-出勤資料.txt
資訊: 嘗試載入 2026 年假日 (第 1/3 次)...
無法從API載入 2026 年假日資料: HTTP 403 — 不重試。
無法取得 2026 年完整假日資料，僅載入基本固定假日   # ← 只剩 01/01 + 10/10
...
1. **2026/05/01** - 😊 建議申請整天WFH假 🏠💻      # ← 勞動節被當週五補 WFH
```

## After

```bash
$ python3 attendance_analyzer.py 202604-202605-Tester-出勤資料.txt
資訊: 動態載入 2026 年國定假日...
資訊: 嘗試載入 2026 年假日 (第 1/3 次)...
# (no warning, 載入成功)
...
🏠 建議申請WFH假的日期：
  (05/01 勞動節 不再出現,自動跳過)
```

## Drive-by

PR #36 的 `non_wfh_issues` filter 一併在這個 PR apply 一次,因為 pre-commit hook 跑全測,而 `test_csv_status_has_timestamp` 在 main 上是壞的(Friday-WFH auto-fill 之後永遠有 issues,status row 因此永遠不顯示)。

## Test plan

- [x] 所有現有測試通過 (`python3 -m unittest discover -s test` → 134 tests OK, skipped=2)
- [x] Holiday provider mock 改寫成新 schema(`[{date,week,isHoliday,description}]`)
- [x] DummyResp / urlopen_sequence 支援 list payload(原本只 dict)
- [x] 真實跑 2026 出勤檔: 05/01 + 04/03(兒童節補假)不再被列為 WFH
- [x] 02/28 / 04/03~04/06 / 10/10 等 2026 法定假日全部識別

## URL

https://cdn.jsdelivr.net/gh/ruyut/TaiwanCalendar/data/2026.json (200 OK)
