### PR TITLE
fix(csv): preserve WFH-only status row on merge

### DIFF
--- a/lib/csv_exporter.py
+++ b/lib/csv_exporter.py
@@ -5,9 +5,9 @@ from collections.abc import Iterable
 
 
 def _header_row(incremental_mode: bool) -> list[str]:
-    headers = ['日期', '類型', '時長(分鐘)', '說明', '時段', '計算式']
+    headers = ["日期", "類型", "時長(分鐘)", "說明", "時段", "計算式"]
     if incremental_mode:
-        headers.append('狀態')
+        headers.append("狀態")
     return headers
 
 
@@ -28,7 +28,7 @@ def _status_row(last_date: str, complete_days: int, last_analysis_time: str) -> 
 
 def _issue_row(issue, incremental_mode: bool) -> list[str]:
     row = [
-        issue.date.strftime('%Y/%m/%d'),
+        issue.date.strftime("%Y/%m/%d"),
         issue.type.value,
         issue.duration_minutes,
         issue.description,
@@ -36,7 +36,7 @@ def _issue_row(issue, incremental_mode: bool) -> list[str]:
         issue.calculation,
     ]
     if incremental_mode:
-        row.append("[NEW] 本次新發現" if getattr(issue, 'is_new', False) else "已存在")
+        row.append("[NEW] 本次新發現" if getattr(issue, "is_new", False) else "已存在")
     return row
 
 
@@ -75,23 +75,31 @@ def _normalize_row(row: list[str], width: int) -> list[str]:
     if len(row) > width:
         return row[:width]
     if len(row) < width:
-        return row + [''] * (width - len(row))
+        return row + [""] * (width - len(row))
     return row
 
 
 def _row_key(row: list[str]) -> tuple:
-    if len(row) > 1 and row[1] == '狀態資訊':
-        return ('STATUS', row[0])
+    if len(row) > 1 and row[1] == "狀態資訊":
+        return ("STATUS", row[0])
     # Use only date and type as key to allow updating same-day same-type issues
     limit = min(2, len(row))
     return tuple(row[:limit])
+
+
+def _is_status_key(key: tuple) -> bool:
+    return bool(key) and key[0] == "STATUS"
+
+
+def _is_wfh_row(row: list[str]) -> bool:
+    return len(row) > 1 and row[1] in {"WFH", "WFH假"}
 
 
 def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[list[str]]:
     """Merge existing CSV rows with new rows, deduplicating by key.
 
     New rows take precedence over existing ones with the same key.
-    Status rows should only appear when there are NO other data rows in the final result.
+    Status rows are kept when the final result has no actionable non-WFH rows.
     """
     header = new_rows[0]
     width = len(header)
@@ -112,10 +120,10 @@ def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[li
         normalized = _normalize_row(row, width)
         merged[_row_key(normalized)] = normalized
 
-    # Check if merged result has any non-status data rows
-    has_any_issues = any(
-        key and key[0] != 'STATUS'
-        for key in merged
+    # WFH suggestions are calendar-derived, so they should not suppress
+    # the "all dates processed" status row during incremental CSV merge.
+    has_actionable_issues = any(
+        not _is_status_key(key) and not _is_wfh_row(row) for key, row in merged.items()
     )
 
     result: list[list[str]] = [header]
@@ -123,17 +131,17 @@ def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[li
     # Extract status row if present
     status_key = None
     for key in list(merged):
-        if key and key[0] == 'STATUS':
+        if key and key[0] == "STATUS":
             status_key = key
             break
 
     # Only include status row if there are NO other data rows
     if status_key is not None:
-        if has_any_issues:
-            # Remove status row when other issues exist
+        if has_actionable_issues:
+            # Remove status row when actionable issues exist
             merged.pop(status_key)
         else:
-            # Place status row immediately after header when it's the only data
+            # Place status row immediately after header for status-only/WFH-only output
             result.append(merged.pop(status_key))
 
     # Add remaining rows
@@ -161,14 +169,14 @@ def save_csv(
         # Read existing CSV data for merging
         existing_rows: list[list[str]] = []
         try:
-            with open(filepath, encoding='utf-8-sig') as f:
-                reader = csv.reader(f, delimiter=';')
+            with open(filepath, encoding="utf-8-sig") as f:
+                reader = csv.reader(f, delimiter=";")
                 existing_rows = list(reader)
         except (FileNotFoundError, OSError):
             # If file doesn't exist or can't be read, proceed with new rows only
             existing_rows = []
         rows = _merge_rows(existing_rows, rows)
 
-    with open(filepath, 'w', newline='', encoding='utf-8-sig') as f:
-        writer = csv.writer(f, delimiter=';')
+    with open(filepath, "w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.writer(f, delimiter=";")
         writer.writerows(rows)

--- a/test/test_csv_exporter.py
+++ b/test/test_csv_exporter.py
@@ -24,107 +24,143 @@ def make_issue(
 
 class TestCsvExporter(unittest.TestCase):
     def test_write_with_status_row(self):
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             issues = []
             csv_exporter.save_csv(path, issues, True, ("2025/07/31", 22, "2025-09-13T10:00:00"))
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
             self.assertGreaterEqual(len(rows), 2)
-            self.assertEqual(rows[1][1], '狀態資訊')
-            self.assertIn('上次分析時間', rows[1][3])
+            self.assertEqual(rows[1][1], "狀態資訊")
+            self.assertIn("上次分析時間", rows[1][3])
         finally:
             os.unlink(path)
 
     def test_write_issue_rows(self):
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             issues = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc', True)
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, issues, True, None)
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
-            self.assertEqual(rows[1][0], '2025/09/01')
-            self.assertEqual(rows[1][-1], '[NEW] 本次新發現')
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
+            self.assertEqual(rows[1][0], "2025/09/01")
+            self.assertEqual(rows[1][-1], "[NEW] 本次新發現")
         finally:
             os.unlink(path)
 
     def test_merge_replaces_existing_issue(self):
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             first_issue = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc', True)
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, first_issue, True, None)
 
             updated_issue = [
-                make_issue('2025/09/01', '遲到', 15, '遲到15分鐘', '10:30-10:45', 'calc', False)
+                make_issue("2025/09/01", "遲到", 15, "遲到15分鐘", "10:30-10:45", "calc", False)
             ]
             csv_exporter.save_csv(path, updated_issue, True, None, merge=True)
 
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
 
             self.assertEqual(len(rows), 2)
-            self.assertEqual(rows[1][2], '15')  # minutes updated
-            self.assertEqual(rows[1][-1], '已存在')
+            self.assertEqual(rows[1][2], "15")  # minutes updated
+            self.assertEqual(rows[1][-1], "已存在")
         finally:
             os.unlink(path)
 
     def test_merge_preserves_existing_issues(self):
         """Test that merge keeps existing issues not in the new set"""
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             path = tmp.name
         try:
             # First save with two issues
             first_issues = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc1', True),
-                make_issue('2025/09/02', '加班', 60, '加班60分鐘', '18:00-19:00', 'calc2', True),
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc1", True),
+                make_issue("2025/09/02", "加班", 60, "加班60分鐘", "18:00-19:00", "calc2", True),
             ]
             csv_exporter.save_csv(path, first_issues, True, None)
 
             # Then merge with one new issue
             new_issues = [
-                make_issue('2025/09/03', 'WFH', 540, 'WFH 9小時', '09:00-18:00', 'calc3', True)
+                make_issue("2025/09/03", "WFH", 540, "WFH 9小時", "09:00-18:00", "calc3", True)
             ]
             csv_exporter.save_csv(path, new_issues, True, None, merge=True)
 
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
 
             # Should have header + 3 issues
             self.assertEqual(len(rows), 4)
             dates = {row[0] for row in rows[1:]}
-            self.assertEqual(dates, {'2025/09/01', '2025/09/02', '2025/09/03'})
+            self.assertEqual(dates, {"2025/09/01", "2025/09/02", "2025/09/03"})
         finally:
             os.unlink(path)
 
+    def test_merge_keeps_status_row_with_wfh_only_rows(self):
+        header = csv_exporter._header_row(True)
+        status = csv_exporter._status_row("2025/09/30", 22, "2025-10-01T10:00:00")
+        existing = [
+            header,
+            ["2025/09/05", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "已存在"],
+        ]
+        new_rows = [
+            header,
+            status,
+            ["2025/09/12", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "[NEW] 本次新發現"],
+        ]
+
+        rows = csv_exporter._merge_rows(existing, new_rows)
+
+        self.assertEqual(rows[1][1], "狀態資訊")
+        self.assertEqual([row[1] for row in rows[2:]], ["WFH假", "WFH假"])
+
+    def test_merge_drops_status_row_when_actionable_issue_exists(self):
+        header = csv_exporter._header_row(True)
+        status = csv_exporter._status_row("2025/09/30", 22, "2025-10-01T10:00:00")
+        existing = [
+            header,
+            ["2025/09/05", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "已存在"],
+        ]
+        new_rows = [
+            header,
+            status,
+            ["2025/09/12", "遲到", "10", "遲到10分鐘", "10:00-10:10", "calc", "[NEW] 本次新發現"],
+        ]
+
+        rows = csv_exporter._merge_rows(existing, new_rows)
+
+        self.assertNotIn("狀態資訊", [row[1] for row in rows[1:]])
+        self.assertEqual([row[1] for row in rows[1:]], ["WFH假", "遲到"])
+
     def test_merge_handles_nonexistent_file(self):
         """Test that merge=True works when file doesn't exist yet"""
-        with tempfile.NamedTemporaryFile(suffix='.csv', delete=True) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=True) as tmp:
             path = tmp.name
         # File is now deleted
         try:
             issues = [
-                make_issue('2025/09/01', '遲到', 10, '遲到10分鐘', '10:30-10:40', 'calc', True)
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, issues, True, None, merge=True)
 
-            with open(path, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(path, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
 
             self.assertEqual(len(rows), 2)  # header + 1 issue
-            self.assertEqual(rows[1][0], '2025/09/01')
+            self.assertEqual(rows[1][0], "2025/09/01")
         finally:
             if os.path.exists(path):
                 os.unlink(path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/CSV
 Purpose: CSV headers, status row, and issue rows with incremental flag."""


### PR DESCRIPTION
## Summary
- Preserve the incremental status row when CSV merge results contain only WFH suggestion rows
- Keep dropping the status row when actionable non-WFH issues are present
- Add merge-level regression coverage for WFH-only and actionable issue cases

## Tests
- python3 -m unittest -q test.test_csv_exporter
- python3 -m ruff check lib/csv_exporter.py test/test_csv_exporter.py
- pre-commit full suite during commit