### PR TITLE
fix: 修正請假規則與餘額解析,遷移 ruff format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,9 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pip install openpyxl
-      - name: Lint (ruff) and format check (black)
+      - name: Lint and format check (ruff)
         run: |
-          if command -v ruff >/dev/null 2>&1; then ruff --version && ruff check .; else echo 'ruff missing'; fi
-          if command -v black >/dev/null 2>&1; then black --version && black --check .; else echo 'black missing'; fi
+          if command -v ruff >/dev/null 2>&1; then ruff --version && ruff check . && ruff format --check .; else echo 'ruff missing'; fi
       - name: Run tests with coverage (stdlib trace)
         run: |
           make coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,10 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
-        language_version: python3
-        args: [--line-length=100]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.5
+    rev: v0.15.18  # 對齊 requirements-dev 的 ruff 版本，避免 format 結果分歧
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ This guide sets expectations for contributing to fhr, a small Python attendance 
 - `todos/` — 改進項目管理（立即可執行任務 + 需要開發支援的功能）。
 - `Dockerfile`、`docker-compose.yml` — 服務容器化與佈署。
 - `requirements-service.txt` — 後端服務相依。
-- `requirements-dev.txt` — 開發工具（black/ruff/pre-commit）。
-- `pyproject.toml` — black/ruff 設定。
+- `requirements-dev.txt` — 開發工具（ruff/pre-commit）。
+- `pyproject.toml` — ruff（lint + format）設定。
 - `.pre-commit-config.yaml` — pre-commit 框架配置。
 
 ## Build, Test, and Development Commands
@@ -52,7 +52,7 @@ This guide sets expectations for contributing to fhr, a small Python attendance 
 ## CI
 - GitHub Actions `ci.yml` 在 PR 上會執行：
   - 依 `requirements-dev.txt` 安裝開發相依
-  - Ruff 檢查（lint）與 Black `--check`（格式）
+  - Ruff 檢查（`ruff check`）與 Ruff 格式檢查（`ruff format --check`）
   - 單元測試 + 以 stdlib trace 產生覆蓋率報告
   - 強制覆蓋率達 ≥90%
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ pre-commit run --all-files
 ```
 
 #### 配置的 Hooks
-- **black**: Python 代碼自動格式化（行長度 100）
+- **ruff-format**: Python 代碼自動格式化（行長度 100，取代 black）
 - **ruff**: Python linting 和自動修復
 - **trailing-whitespace**: 移除行尾空白
 - **end-of-file-fixer**: 確保文件以換行符結尾
@@ -125,7 +125,7 @@ Endpoints
 - Workflow：`.github/workflows/ci.yml`
 - 內容：
   - 安裝 dev 相依 `requirements-dev.txt`
-  - Ruff lint & Black 格式檢查
+  - Ruff lint（`ruff check`）& Ruff 格式檢查（`ruff format --check`）
   - 單元測試 + 覆蓋率 >=90% 要求
   - 上傳 coverage_report 與 coverage.svg 產物
 
@@ -194,11 +194,18 @@ Utility helpers for managing generated exports:
 
 ### Business Rules (Hard-coded Constants)
 - Working hours: 8 hours + 1 hour lunch break
-- Flexible check-in: 08:30 (earliest) to 10:30 (latest)
-- Lunch period: 12:30-13:30 (deducted from late calculations when applicable)
+- Flexible check-in: 08:30 (earliest) to **10:00 (latest)**; arriving after 10:00 counts as late
+- Lunch period: 12:30-13:30. **Late-leave hours deduct the lunch overlap**: a late
+  arrival whose 09:30→check-in span crosses lunch subtracts the 12:30-13:30 portion
+  before rounding up to whole hours (e.g. arriving 13:19 = 3h leave, not 4h)
 - Overtime threshold: Minimum 60 minutes to qualify for application
-- Forget-punch allowance: 2 times per month for tardiness ≤60 minutes
+- Forget-punch allowance: **4 times per year** (company policy change; scarce manual
+  resource). The analyzer does **not** auto-substitute forget-punch for late arrivals —
+  all late arrivals are suggested as leave; forget-punch is left for the user to apply
+  manually. (`config.forget_punch_allowance_per_month` is vestigial / unused by analysis.)
 - Friday WFH policy: **All Fridays (regardless of attendance) are recommended as WFH days (9-hour WFH leave), except national holidays**
+- Full-day weekday absence: suggested as a full-day leave (8h, 09:30-18:30); now emitted
+  by the `code-agent-hr` export (`type_hint="full_day"`)
 
 ### Taiwan Holiday Integration
 The system supports mixed holiday loading strategy:
@@ -217,8 +224,9 @@ Key methods:
 ## Key Behavioral Notes
 
 ### Issue Classification Logic
-- **Forget-punch**: Tardiness ≤60 minutes with monthly allowance available
-- **Late**: Tardiness >60 minutes or when forget-punch allowance exhausted
+- **Late**: Any arrival after 10:00 → leave suggestion. Leave hours = ceil of the
+  missed work minutes (09:30→check-in, minus any lunch overlap). Forget-punch is **not**
+  auto-applied (4/year manual allowance; see Business Rules).
 - **Overtime**: Work beyond calculated end time, minimum 60 minutes
 - **WFH Leave**: **Recommended for ALL Fridays (with or without attendance records), unless it's a national holiday**
 - **Regular Leave**: Recommended for full-day absences on weekdays (excluding Fridays)

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@
 
 ## 功能特色
 
-- 🕒 自動計算遲到時數
+- 🕒 自動計算遲到時數（遲到門檻 10:00；遲到請假時數自動扣除午休）
 - ⏰ 自動計算加班時數（符合1小時以上規定）
 - 🏠 **自動識別週五WFH假建議（無論是否有打卡，除國定假日外）**
+- 📝 自動識別平日整日缺勤 → 整日請假建議
 - 📊 生成詳細分析報告
 - 📈 匯出Excel/CSV格式統計資料
-- 🔄 智慧忘刷卡建議（每月2次額度）
 - 🗓️ 支援跨年份出勤分析（自動載入國定假日）
+
+> 註：忘刷卡為每年 4 次的手動額度，分析流程不會自動拿來抵遲到（所有遲到一律列為請假建議）。
 - **🚀 NEW: 增量分析功能 - 避免重複處理已分析資料**
 - **📁 NEW: 支援跨月檔案格式 (`202508-202509-姓名-出勤資料.txt`)**
 - **💾 NEW: 智慧狀態管理 - 自動記住處理進度**
@@ -196,7 +198,7 @@ docker compose up --build -d
 
 ## Lint
 
-- 推薦：安裝 Ruff/Black 並執行 `make lint`（若無 Ruff，會使用內建的輕量 fallback 檢查：語法）。
+- 推薦：安裝 Ruff 並執行 `make lint`（lint + `ruff format` 格式化；若無 Ruff，會使用內建的輕量 fallback 檢查：語法）。
 
 ```bash
 # 使用 ruff（如已安裝）
@@ -207,11 +209,11 @@ python3 tools/lint.py
 
 # 開發者可選：安裝開發工具與 Git Hook
 pip install -r requirements-dev.txt
-make install-hooks  # 安裝 pre-commit hook（black + ruff + tests）
+make install-hooks  # 安裝 pre-commit hook（ruff lint + ruff format + tests）
 ```
 
 CI（GitHub Actions）
-- 對 PR 自動執行：Ruff（lint）、Black（格式檢查）、單元測試 + 覆蓋率 100% 門檻。
+- 對 PR 自動執行：Ruff（`ruff check` lint + `ruff format --check` 格式）、單元測試 + 覆蓋率門檻。
 
 備註：
 - UI 預設為「完整」模式與「Excel」輸出，且選項順序預設優先顯示。

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,13 +27,13 @@ tasks:
     desc: Run linting checks
     cmds:
       - ruff check .
-      - black --check .
+      - ruff format --check .
 
   format:
     desc: Auto-format code
     cmds:
       - ruff check --fix .
-      - black .
+      - ruff format .
 
   # Changelog and release tasks
   changelog-preview:

--- a/attendance_analyzer.py
+++ b/attendance_analyzer.py
@@ -295,9 +295,7 @@ class AttendanceAnalyzer:
             operation,
             note,
         ) = parsed
-        attendance_type = (
-            AttendanceType.CHECKIN if type_str == "上班" else AttendanceType.CHECKOUT
-        )
+        attendance_type = AttendanceType.CHECKIN if type_str == "上班" else AttendanceType.CHECKOUT
         return AttendanceRecord(
             date=scheduled_time.date() if scheduled_time else None,
             scheduled_time=scheduled_time,
@@ -392,9 +390,7 @@ class AttendanceAnalyzer:
     def _get_workdays_to_analyze(self) -> list[WorkDay]:
         if self.incremental_mode and self.current_user:
             complete_days = self._identify_complete_work_days()
-            unprocessed_dates = self._get_unprocessed_dates(
-                self.current_user, complete_days
-            )
+            unprocessed_dates = self._get_unprocessed_dates(self.current_user, complete_days)
             if unprocessed_dates:
                 logger.info(
                     "🔄 增量分析: 發現 %d 個新的完整工作日需要處理",
@@ -407,9 +403,7 @@ class AttendanceAnalyzer:
                 formatted_dates = [d.strftime("%Y-%m-%d") for d in unprocessed_dates]
                 logger.debug("📆  新增待處理日期: %s", formatted_dates)
                 unprocessed_date_set = {d.date() for d in unprocessed_dates}
-                candidates = [
-                    wd for wd in self.workdays if wd.date.date() in unprocessed_date_set
-                ]
+                candidates = [wd for wd in self.workdays if wd.date.date() in unprocessed_date_set]
                 return self._filter_processed_workdays(candidates)
             logger.info("✅ 增量分析: 沒有新的工作日需要處理")
             return []
@@ -445,9 +439,7 @@ class AttendanceAnalyzer:
                 friday = date(year, month, date_num)
                 if friday in existing_wfh_dates:
                     continue
-                if friday in {
-                    d.date() if hasattr(d, "date") else d for d in self.holidays
-                }:
+                if friday in {d.date() if hasattr(d, "date") else d for d in self.holidays}:
                     continue
                 self.issues.append(
                     Issue(
@@ -514,9 +506,7 @@ class AttendanceAnalyzer:
             return
 
         # 1. 計算遲到（超過遲到門檻，從班表起始算起）
-        late_minutes, late_time_range, late_calculation = calculate_late_minutes(
-            workday, rules
-        )
+        late_minutes, late_time_range, late_calculation = calculate_late_minutes(workday, rules)
 
         # 2. 確定工作起始時間
         ch = workday.checkin_record
@@ -526,8 +516,8 @@ class AttendanceAnalyzer:
 
         # 3. 處理遲到情況（全部走請假；忘刷卡為年額度，不在此自動套用）
         if late_minutes > 0:
-            leave_start, leave_end, leave_hours, effective_minutes = (
-                calculate_leave_suggestion(workday, rules, late_minutes)
+            leave_start, leave_end, leave_hours, effective_minutes = calculate_leave_suggestion(
+                workday, rules, late_minutes
             )
 
             self.issues.append(
@@ -547,8 +537,8 @@ class AttendanceAnalyzer:
         expected_checkout = calculate_expected_checkout(workday, rules, work_start_time)
 
         # 5. 檢查早退
-        early_leave_minutes, early_leave_range, early_leave_calc = (
-            calculate_early_leave(workday, rules, expected_checkout)
+        early_leave_minutes, early_leave_range, early_leave_calc = calculate_early_leave(
+            workday, rules, expected_checkout
         )
         if early_leave_minutes > 0:
             self.issues.append(
@@ -611,9 +601,7 @@ class AttendanceAnalyzer:
         }
 
         # 更新狀態
-        self.state_manager.update_user_state(
-            self.current_user, range_info, self.forget_punch_usage
-        )
+        self.state_manager.update_user_state(self.current_user, range_info, self.forget_punch_usage)
 
         # 儲存狀態檔案
         self.state_manager.save_state()
@@ -627,9 +615,7 @@ class AttendanceAnalyzer:
         # 顯示增量分析資訊
         if self.incremental_mode and self.current_user:
             complete_days = self._identify_complete_work_days()
-            unprocessed_dates = self._get_unprocessed_dates(
-                self.current_user, complete_days
-            )
+            unprocessed_dates = self._get_unprocessed_dates(self.current_user, complete_days)
             from lib.report import build_incremental_lines
 
             report.extend(
@@ -648,32 +634,20 @@ class AttendanceAnalyzer:
         from lib.report import build_issue_section, build_summary
 
         report.extend(
-            build_issue_section(
-                "## 🔄 建議使用忘刷卡的日期：", "🔄", forget_punch_issues
-            )
+            build_issue_section("## 🔄 建議使用忘刷卡的日期：", "🔄", forget_punch_issues)
         )
 
         # 遲到統計
         late_issues = [issue for issue in self.issues if issue.type == IssueType.LATE]
-        report.extend(
-            build_issue_section("## 😰 需要請遲到的日期：", "😅", late_issues)
-        )
+        report.extend(build_issue_section("## 😰 需要請遲到的日期：", "😅", late_issues))
 
         # 加班統計
-        overtime_issues = [
-            issue for issue in self.issues if issue.type == IssueType.OVERTIME
-        ]
-        report.extend(
-            build_issue_section("## 💪 需要請加班的日期：", "🔥", overtime_issues)
-        )
+        overtime_issues = [issue for issue in self.issues if issue.type == IssueType.OVERTIME]
+        report.extend(build_issue_section("## 💪 需要請加班的日期：", "🔥", overtime_issues))
 
         # 早退統計
-        early_leave_issues = [
-            issue for issue in self.issues if issue.type == IssueType.EARLY_LEAVE
-        ]
-        report.extend(
-            build_issue_section("## ⏰ 早退需要請假的日期：", "⏰", early_leave_issues)
-        )
+        early_leave_issues = [issue for issue in self.issues if issue.type == IssueType.EARLY_LEAVE]
+        report.extend(build_issue_section("## ⏰ 早退需要請假的日期：", "⏰", early_leave_issues))
 
         # 週一到週四請假建議
         weekday_leave_issues = [

--- a/attendance_analyzer.py
+++ b/attendance_analyzer.py
@@ -295,7 +295,9 @@ class AttendanceAnalyzer:
             operation,
             note,
         ) = parsed
-        attendance_type = AttendanceType.CHECKIN if type_str == "上班" else AttendanceType.CHECKOUT
+        attendance_type = (
+            AttendanceType.CHECKIN if type_str == "上班" else AttendanceType.CHECKOUT
+        )
         return AttendanceRecord(
             date=scheduled_time.date() if scheduled_time else None,
             scheduled_time=scheduled_time,
@@ -390,16 +392,24 @@ class AttendanceAnalyzer:
     def _get_workdays_to_analyze(self) -> list[WorkDay]:
         if self.incremental_mode and self.current_user:
             complete_days = self._identify_complete_work_days()
-            unprocessed_dates = self._get_unprocessed_dates(self.current_user, complete_days)
+            unprocessed_dates = self._get_unprocessed_dates(
+                self.current_user, complete_days
+            )
             if unprocessed_dates:
-                logger.info("🔄 增量分析: 發現 %d 個新的完整工作日需要處理", len(unprocessed_dates))
                 logger.info(
-                    "📊 跳過已處理的工作日: %d 個", len(complete_days) - len(unprocessed_dates)
+                    "🔄 增量分析: 發現 %d 個新的完整工作日需要處理",
+                    len(unprocessed_dates),
+                )
+                logger.info(
+                    "📊 跳過已處理的工作日: %d 個",
+                    len(complete_days) - len(unprocessed_dates),
                 )
                 formatted_dates = [d.strftime("%Y-%m-%d") for d in unprocessed_dates]
                 logger.debug("📆  新增待處理日期: %s", formatted_dates)
                 unprocessed_date_set = {d.date() for d in unprocessed_dates}
-                candidates = [wd for wd in self.workdays if wd.date.date() in unprocessed_date_set]
+                candidates = [
+                    wd for wd in self.workdays if wd.date.date() in unprocessed_date_set
+                ]
                 return self._filter_processed_workdays(candidates)
             logger.info("✅ 增量分析: 沒有新的工作日需要處理")
             return []
@@ -435,7 +445,9 @@ class AttendanceAnalyzer:
                 friday = date(year, month, date_num)
                 if friday in existing_wfh_dates:
                     continue
-                if friday in {d.date() if hasattr(d, "date") else d for d in self.holidays}:
+                if friday in {
+                    d.date() if hasattr(d, "date") else d for d in self.holidays
+                }:
                     continue
                 self.issues.append(
                     Issue(
@@ -478,7 +490,6 @@ class AttendanceAnalyzer:
         return False
 
     def _analyze_single_workday(self, workday: WorkDay, rules) -> None:
-
         from lib.policy import (
             calculate_early_leave,
             calculate_expected_checkout,
@@ -503,7 +514,9 @@ class AttendanceAnalyzer:
             return
 
         # 1. 計算遲到（超過遲到門檻，從班表起始算起）
-        late_minutes, late_time_range, late_calculation = calculate_late_minutes(workday, rules)
+        late_minutes, late_time_range, late_calculation = calculate_late_minutes(
+            workday, rules
+        )
 
         # 2. 確定工作起始時間
         ch = workday.checkin_record
@@ -511,17 +524,19 @@ class AttendanceAnalyzer:
 
         work_start_time = actual_checkin
 
-        # 3. 處理遲到情況（全部走請假）
+        # 3. 處理遲到情況（全部走請假；忘刷卡為年額度，不在此自動套用）
         if late_minutes > 0:
-            leave_start, leave_end, leave_hours = calculate_leave_suggestion(
-                workday, rules, late_minutes
+            leave_start, leave_end, leave_hours, effective_minutes = (
+                calculate_leave_suggestion(workday, rules, late_minutes)
             )
 
             self.issues.append(
                 Issue(
                     date=workday.date,
                     type=IssueType.LATE,
-                    duration_minutes=late_minutes,
+                    # duration 用扣午休後的缺工分鐘（下游 ceil 算請假時數）；
+                    # 描述仍顯示實際遲到分鐘
+                    duration_minutes=effective_minutes,
                     description=f"遲到{late_minutes}分鐘 ⏱️",
                     time_range=f"{leave_start}~{leave_end}",
                     calculation=f"建議請假 {leave_hours} 小時: {leave_start}~{leave_end}",
@@ -532,8 +547,8 @@ class AttendanceAnalyzer:
         expected_checkout = calculate_expected_checkout(workday, rules, work_start_time)
 
         # 5. 檢查早退
-        early_leave_minutes, early_leave_range, early_leave_calc = calculate_early_leave(
-            workday, rules, expected_checkout
+        early_leave_minutes, early_leave_range, early_leave_calc = (
+            calculate_early_leave(workday, rules, expected_checkout)
         )
         if early_leave_minutes > 0:
             self.issues.append(
@@ -596,7 +611,9 @@ class AttendanceAnalyzer:
         }
 
         # 更新狀態
-        self.state_manager.update_user_state(self.current_user, range_info, self.forget_punch_usage)
+        self.state_manager.update_user_state(
+            self.current_user, range_info, self.forget_punch_usage
+        )
 
         # 儲存狀態檔案
         self.state_manager.save_state()
@@ -610,7 +627,9 @@ class AttendanceAnalyzer:
         # 顯示增量分析資訊
         if self.incremental_mode and self.current_user:
             complete_days = self._identify_complete_work_days()
-            unprocessed_dates = self._get_unprocessed_dates(self.current_user, complete_days)
+            unprocessed_dates = self._get_unprocessed_dates(
+                self.current_user, complete_days
+            )
             from lib.report import build_incremental_lines
 
             report.extend(
@@ -629,20 +648,32 @@ class AttendanceAnalyzer:
         from lib.report import build_issue_section, build_summary
 
         report.extend(
-            build_issue_section("## 🔄 建議使用忘刷卡的日期：", "🔄", forget_punch_issues)
+            build_issue_section(
+                "## 🔄 建議使用忘刷卡的日期：", "🔄", forget_punch_issues
+            )
         )
 
         # 遲到統計
         late_issues = [issue for issue in self.issues if issue.type == IssueType.LATE]
-        report.extend(build_issue_section("## 😰 需要請遲到的日期：", "😅", late_issues))
+        report.extend(
+            build_issue_section("## 😰 需要請遲到的日期：", "😅", late_issues)
+        )
 
         # 加班統計
-        overtime_issues = [issue for issue in self.issues if issue.type == IssueType.OVERTIME]
-        report.extend(build_issue_section("## 💪 需要請加班的日期：", "🔥", overtime_issues))
+        overtime_issues = [
+            issue for issue in self.issues if issue.type == IssueType.OVERTIME
+        ]
+        report.extend(
+            build_issue_section("## 💪 需要請加班的日期：", "🔥", overtime_issues)
+        )
 
         # 早退統計
-        early_leave_issues = [issue for issue in self.issues if issue.type == IssueType.EARLY_LEAVE]
-        report.extend(build_issue_section("## ⏰ 早退需要請假的日期：", "⏰", early_leave_issues))
+        early_leave_issues = [
+            issue for issue in self.issues if issue.type == IssueType.EARLY_LEAVE
+        ]
+        report.extend(
+            build_issue_section("## ⏰ 早退需要請假的日期：", "⏰", early_leave_issues)
+        )
 
         # 週一到週四請假建議
         weekday_leave_issues = [

--- a/docs/pre-commit-setup.md
+++ b/docs/pre-commit-setup.md
@@ -51,7 +51,7 @@ pre-commit run
 我們的 `.pre-commit-config.yaml` 包含以下 hooks：
 
 ### 代碼格式化
-- **black**: Python 代碼自動格式化，行長度限制 100 字符
+- **ruff-format**: Python 代碼自動格式化，行長度限制 100 字符（取代 black）
 - **ruff**: Python linting 和自動修復
 
 ### 通用檢查
@@ -76,7 +76,7 @@ pre-commit run
 ### Hooks 失敗時的處理
 
 ```bash
-# 如果 hooks 修復了代碼（如 black 格式化）
+# 如果 hooks 修復了代碼（如 ruff-format 格式化）
 # 需要重新暫存修改的文件
 git add .
 git commit
@@ -90,8 +90,8 @@ git commit --no-verify
 ### 只運行特定 hook
 
 ```bash
-# 只運行 black
-pre-commit run black
+# 只運行 ruff-format
+pre-commit run ruff-format
 
 # 只運行 ruff
 pre-commit run ruff
@@ -154,7 +154,7 @@ pre-commit install --install-hooks
 在 `.pre-commit-config.yaml` 中使用 `exclude` 參數：
 
 ```yaml
-- id: black
+- id: ruff-format
   exclude: ^(migrations/|legacy_code/)
 ```
 
@@ -190,8 +190,8 @@ pre-commit install --install-hooks
 
 - [Pre-commit 官方文檔](https://pre-commit.com/)
 - [Pre-commit Hooks 倉庫](https://github.com/pre-commit/pre-commit-hooks)
-- [Black 文檔](https://black.readthedocs.io/)
 - [Ruff 文檔](https://docs.astral.sh/ruff/)
+- [Ruff formatter 文檔](https://docs.astral.sh/ruff/formatter/)
 
 ---
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -39,7 +39,7 @@
 | **執行測試** | `python -m unittest -q` | 完整測試套件 |
 | **測試覆蓋率** | `make coverage` | 產生覆蓋率報告 |
 | **程式碼檢查** | `make lint` | Ruff 或 fallback 檢查 |
-| **安裝開發工具** | `pip install -r requirements-dev.txt` | Black, Ruff, pre-commit |
+| **安裝開發工具** | `pip install -r requirements-dev.txt` | Ruff, pre-commit |
 | **安裝 Git Hook** | `make install-hooks` | 自動格式化與測試 |
 
 ## 📁 檔案格式速查

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -212,7 +212,7 @@ Git-cliff 配置檔，定義：
 
 ### .pre-commit-config.yaml
 Pre-commit hooks 配置，包含：
-- Black (格式化)
+- Ruff format (格式化)
 - Ruff (linting)
 - Commitizen (commit message 驗證)
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -31,7 +31,7 @@ Compose
 
 Dev Lint/Test Hooks
 - Optional developer tools: `pip install -r requirements-dev.txt`
-- Install git hooks to lint (black/ruff) and run tests before commit:
+- Install git hooks to lint (ruff) and run tests before commit:
   ```bash
   make install-hooks
   # Skip tests temporarily: SKIP_TESTS=1 git commit -m "..."

--- a/fix_imports.py
+++ b/fix_imports.py
@@ -1,131 +1,151 @@
 #!/usr/bin/env python3
 """Quick script to fix import sorting issues in Python files."""
+
 from pathlib import Path
 
 
 def fix_imports_in_file(filepath):
     """Fix import sorting in a single Python file."""
-    with open(filepath, encoding='utf-8') as f:
+    with open(filepath, encoding="utf-8") as f:
         content = f.read()
-    
-    lines = content.split('\n')
-    
+
+    lines = content.split("\n")
+
     # Find import blocks
     i = 0
     while i < len(lines):
         # Skip shebang and module docstrings
-        if i == 0 and lines[i].startswith('#!'):
+        if i == 0 and lines[i].startswith("#!"):
             i += 1
             continue
-        if i < len(lines) and (lines[i].startswith('"""') or lines[i].startswith("'''")):
+        if i < len(lines) and (
+            lines[i].startswith('"""') or lines[i].startswith("'''")
+        ):
             # Skip docstring
             if lines[i].count('"""') == 1 or lines[i].count("'''") == 1:
                 i += 1
-                quote = '"""' if '"""' in lines[i-1] else "'''"
+                quote = '"""' if '"""' in lines[i - 1] else "'''"
                 while i < len(lines) and quote not in lines[i]:
                     i += 1
             i += 1
             continue
-            
+
         # Check if we're at the start of imports
-        if lines[i].startswith('import ') or lines[i].startswith('from '):
+        if lines[i].startswith("import ") or lines[i].startswith("from "):
             import_start = i
             import_lines = []
-            
+
             # Collect all consecutive import lines
-            while i < len(lines) and (lines[i].startswith('import ') or 
-                                      lines[i].startswith('from ') or 
-                                      lines[i].strip() == ''):
+            while i < len(lines) and (
+                lines[i].startswith("import ")
+                or lines[i].startswith("from ")
+                or lines[i].strip() == ""
+            ):
                 if lines[i].strip():
                     import_lines.append(lines[i])
                 i += 1
-            
+
             if import_lines:
                 # Sort imports: stdlib first, then third-party, then local
                 stdlib_imports = []
                 third_party_imports = []
                 local_imports = []
-                
+
                 for line in import_lines:
-                    if line.startswith('from '):
-                        module = line.split()[1].split('.')[0]
+                    if line.startswith("from "):
+                        module = line.split()[1].split(".")[0]
                     else:
-                        module = line.split()[1].split('.')[0].rstrip(',')
-                    
+                        module = line.split()[1].split(".")[0].rstrip(",")
+
                     # Common stdlib modules
-                    if module in ['os', 'sys', 'json', 'unittest', 'tempfile', 
-                                  'datetime', 'pathlib', 'argparse', 're', 'trace',
-                                  'io', 'uuid', 'shutil', 'logging', 'typing',
-                                  'contextlib', 'asyncio']:
+                    if module in [
+                        "os",
+                        "sys",
+                        "json",
+                        "unittest",
+                        "tempfile",
+                        "datetime",
+                        "pathlib",
+                        "argparse",
+                        "re",
+                        "trace",
+                        "io",
+                        "uuid",
+                        "shutil",
+                        "logging",
+                        "typing",
+                        "contextlib",
+                        "asyncio",
+                    ]:
                         stdlib_imports.append(line)
-                    elif module in ['attendance_analyzer', 'lib', 'server']:
+                    elif module in ["attendance_analyzer", "lib", "server"]:
                         local_imports.append(line)
                     else:
                         third_party_imports.append(line)
-                
+
                 # Sort each group
                 stdlib_imports.sort()
                 third_party_imports.sort()
                 local_imports.sort()
-                
+
                 # Reconstruct the import block
                 new_imports = []
                 if stdlib_imports:
                     new_imports.extend(stdlib_imports)
                 if third_party_imports:
                     if new_imports:
-                        new_imports.append('')
+                        new_imports.append("")
                     new_imports.extend(third_party_imports)
                 if local_imports:
                     if new_imports:
-                        new_imports.append('')
+                        new_imports.append("")
                     new_imports.extend(local_imports)
-                
+
                 # Replace in original lines
-                lines[import_start:i] = new_imports + ['']
-                
+                lines[import_start:i] = new_imports + [""]
+
                 # Update content
-                content = '\n'.join(lines)
-                
+                content = "\n".join(lines)
+
                 # Write back
-                with open(filepath, 'w', encoding='utf-8') as f:
+                with open(filepath, "w", encoding="utf-8") as f:
                     f.write(content)
                 return True
-        
+
         i += 1
-    
+
     return False
 
 
 def main():
     """Fix imports in all Python files."""
     fixed_count = 0
-    
+
     # Fix test files
-    test_dir = Path('test')
-    for py_file in test_dir.glob('*.py'):
+    test_dir = Path("test")
+    for py_file in test_dir.glob("*.py"):
         if fix_imports_in_file(py_file):
             print(f"Fixed imports in {py_file}")
             fixed_count += 1
-    
+
     # Fix lib files
-    lib_dir = Path('lib')
-    for py_file in lib_dir.glob('*.py'):
+    lib_dir = Path("lib")
+    for py_file in lib_dir.glob("*.py"):
         if fix_imports_in_file(py_file):
             print(f"Fixed imports in {py_file}")
             fixed_count += 1
-    
+
     # Fix server files
-    server_dir = Path('server')
+    server_dir = Path("server")
     if server_dir.exists():
-        for py_file in server_dir.glob('*.py'):
+        for py_file in server_dir.glob("*.py"):
             # Skip server/main.py as we've already fixed it manually
-            if py_file.name != 'main.py' and fix_imports_in_file(py_file):
+            if py_file.name != "main.py" and fix_imports_in_file(py_file):
                 print(f"Fixed imports in {py_file}")
                 fixed_count += 1
-    
+
     print(f"\nFixed {fixed_count} files")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fix_imports.py
+++ b/fix_imports.py
@@ -18,9 +18,7 @@ def fix_imports_in_file(filepath):
         if i == 0 and lines[i].startswith("#!"):
             i += 1
             continue
-        if i < len(lines) and (
-            lines[i].startswith('"""') or lines[i].startswith("'''")
-        ):
+        if i < len(lines) and (lines[i].startswith('"""') or lines[i].startswith("'''")):
             # Skip docstring
             if lines[i].count('"""') == 1 or lines[i].count("'''") == 1:
                 i += 1

--- a/lib/backup.py
+++ b/lib/backup.py
@@ -10,9 +10,8 @@ def backup_with_timestamp(filepath: str) -> str | None:
     if not os.path.exists(filepath):
         return None
 
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     base_name, ext = os.path.splitext(filepath)
     backup_filepath = f"{base_name}_{timestamp}{ext}"
     os.rename(filepath, backup_filepath)
     return backup_filepath
-

--- a/lib/cascade.py
+++ b/lib/cascade.py
@@ -14,6 +14,7 @@ Monthly-capped tiers (e.g. 異地辦公(8hr一週) → 40h/月) get a per-month
 budget. Already-applied forms (from `state.applied_forms`) are also
 deducted up-front so re-runs of `portal-apply` don't double-spend.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -23,6 +24,7 @@ from datetime import datetime
 TYPE_HINT_TO_CASCADE = {
     "late": "leave_cascade_late",
     "early_leave": "leave_cascade_late",
+    "full_day": "leave_cascade_late",
     "sick": "leave_cascade_sick",
     "WFH": "leave_cascade_wfh",
 }
@@ -46,9 +48,10 @@ MONTHLY_CAPS_HOURS: dict[str, int] = {
 @dataclass
 class AllocationDecision:
     """One assignment made by the cascade allocator."""
+
     entry: dict
-    leave_type: str | None       # None when nothing in the cascade could absorb
-    reason: str                  # human-readable explanation
+    leave_type: str | None  # None when nothing in the cascade could absorb
+    reason: str  # human-readable explanation
     insufficient: bool = False
 
 
@@ -156,14 +159,17 @@ def allocate(
                 reason = f"{cand} 剩 {rem}h，扣本筆 {hours}h → 餘 {remaining[cand]}h"
                 break
             reason = f"{cand} 剩 {rem}h 不足 {hours}h"
-        decisions.append(AllocationDecision(
-            entry=entry,
-            leave_type=picked,
-            reason=reason,
-            insufficient=(picked is None),
-        ))
-    return AllocationResult(decisions=decisions, remaining=remaining,
-                            monthly_used=monthly_used)
+        decisions.append(
+            AllocationDecision(
+                entry=entry,
+                leave_type=picked,
+                reason=reason,
+                insufficient=(picked is None),
+            )
+        )
+    return AllocationResult(
+        decisions=decisions, remaining=remaining, monthly_used=monthly_used
+    )
 
 
 def summarize(result: AllocationResult) -> str:

--- a/lib/cascade.py
+++ b/lib/cascade.py
@@ -167,9 +167,7 @@ def allocate(
                 insufficient=(picked is None),
             )
         )
-    return AllocationResult(
-        decisions=decisions, remaining=remaining, monthly_used=monthly_used
-    )
+    return AllocationResult(decisions=decisions, remaining=remaining, monthly_used=monthly_used)
 
 
 def summarize(result: AllocationResult) -> str:

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -9,17 +9,24 @@ works without changes.
 Subcommand handlers live in `lib/commands/`. Each module exposes
 `add_parser(subparsers)` and `run(args)`.
 """
+
 from __future__ import annotations
 
 import argparse
 import sys
 
 KNOWN_SUBCOMMANDS = {
-    "analyze", "export", "import",
-    "portal-fetch", "portal_fetch",
-    "portal-sync", "portal_sync",
-    "portal-balances", "portal_balances",
-    "portal-apply", "portal_apply",
+    "analyze",
+    "export",
+    "import",
+    "portal-fetch",
+    "portal_fetch",
+    "portal-sync",
+    "portal_sync",
+    "portal-balances",
+    "portal_balances",
+    "portal-apply",
+    "portal_apply",
     "reasons",
 }
 
@@ -89,27 +96,35 @@ def run(argv: list | None = None) -> None:
 
     if args.cmd == "analyze":
         from lib.commands import analyze as analyze_cmd
+
         analyze_cmd.run(args)
     elif args.cmd == "export":
         from lib.commands import export as export_cmd
+
         export_cmd.run(args)
     elif args.cmd == "import":
         from lib.commands import import_ as import_cmd
+
         import_cmd.run(args)
     elif args.cmd in ("portal-fetch", "portal_fetch"):
         from lib.commands import portal_fetch as portal_fetch_cmd
+
         portal_fetch_cmd.run(args)
     elif args.cmd in ("portal-sync", "portal_sync"):
         from lib.commands import portal_sync as portal_sync_cmd
+
         portal_sync_cmd.run(args)
     elif args.cmd in ("portal-balances", "portal_balances"):
         from lib.commands import portal_balances as portal_balances_cmd
+
         portal_balances_cmd.run(args)
     elif args.cmd in ("portal-apply", "portal_apply"):
         from lib.commands import portal_apply as portal_apply_cmd
+
         portal_apply_cmd.run(args)
     elif args.cmd == "reasons":
         from lib.commands import reasons as reasons_cmd
+
         reasons_cmd.run(args)
     else:
         parser.error(f"unknown subcommand: {args.cmd}")

--- a/lib/commands/analyze.py
+++ b/lib/commands/analyze.py
@@ -52,9 +52,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
         help="啟用增量分析模式 (預設開啟)",
     )
     parser.add_argument("--full", "-f", action="store_true", help="強制完整重新分析")
-    parser.add_argument(
-        "--reset-state", "-r", action="store_true", help="清除指定使用者的狀態記錄"
-    )
+    parser.add_argument("--reset-state", "-r", action="store_true", help="清除指定使用者的狀態記錄")
     parser.add_argument(
         "--debug", action="store_true", help="啟用 debug 模式（詳細日誌、不寫入狀態檔）"
     )
@@ -114,9 +112,7 @@ def run(args: argparse.Namespace) -> None:
             sys.exit(1)
 
     try:
-        analyzer = AttendanceAnalyzer(
-            debug=args.debug, unprocessed_only=args.unprocessed_only
-        )
+        analyzer = AttendanceAnalyzer(debug=args.debug, unprocessed_only=args.unprocessed_only)
 
         if incremental_mode:
             logger.info("📂 正在解析考勤檔案... (增量分析模式)")
@@ -162,9 +158,7 @@ def run(args: argparse.Namespace) -> None:
 
         if format_type.lower() == "excel":
             csv_filepath = filepath.replace(".txt", "_analysis.csv")
-            backup_path = analyzer.export_report(
-                csv_filepath, "csv", export_policy=export_policy
-            )
+            backup_path = analyzer.export_report(csv_filepath, "csv", export_policy=export_policy)
             exported_files.append(csv_filepath)
             if backup_path:
                 backup_files.append(backup_path)
@@ -205,9 +199,7 @@ def run(args: argparse.Namespace) -> None:
                 else:
                     removed_paths: set[str] = set()
                     for path in exported_files:
-                        removed = cleanup_exports_helper(
-                            path, include_canonical=args.debug
-                        )
+                        removed = cleanup_exports_helper(path, include_canonical=args.debug)
                         removed_paths.update(os.path.abspath(p) for p in removed)
                     for backup in backup_files:
                         if os.path.exists(backup):

--- a/lib/commands/analyze.py
+++ b/lib/commands/analyze.py
@@ -3,6 +3,7 @@
 Extracted from the pre-subcommand `lib/cli.py:run()` with the argparse
 configuration split into `add_parser()` so the top-level CLI can register
 it as a subparser. Run-time behavior is byte-for-byte identical."""
+
 from __future__ import annotations
 
 import argparse
@@ -44,23 +45,34 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
         help="輸出格式 (預設: excel)",
     )
     parser.add_argument(
-        "--incremental", "-i", action="store_true", default=True,
+        "--incremental",
+        "-i",
+        action="store_true",
+        default=True,
         help="啟用增量分析模式 (預設開啟)",
     )
     parser.add_argument("--full", "-f", action="store_true", help="強制完整重新分析")
-    parser.add_argument("--reset-state", "-r", action="store_true", help="清除指定使用者的狀態記錄")
-    parser.add_argument("--debug", action="store_true",
-                        help="啟用 debug 模式（詳細日誌、不寫入狀態檔）")
     parser.add_argument(
-        "--export-policy", choices=["merge", "archive"], default="merge",
+        "--reset-state", "-r", action="store_true", help="清除指定使用者的狀態記錄"
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="啟用 debug 模式（詳細日誌、不寫入狀態檔）"
+    )
+    parser.add_argument(
+        "--export-policy",
+        choices=["merge", "archive"],
+        default="merge",
         help="匯出策略：merge 直接覆寫主檔案，archive 保留 timestamp 備份。",
     )
     parser.add_argument(
-        "--cleanup-exports", action="store_true",
+        "--cleanup-exports",
+        action="store_true",
         help="清除 timestamp 備份；搭配 --debug 時同時刪除本次產出的匯出檔案。",
     )
     parser.add_argument(
-        "--unprocessed-only", "-u", action="store_true",
+        "--unprocessed-only",
+        "-u",
+        action="store_true",
         help="只分析處理狀態為空（未處理）的記錄，跳過已處理的記錄。",
     )
     return parser
@@ -102,7 +114,9 @@ def run(args: argparse.Namespace) -> None:
             sys.exit(1)
 
     try:
-        analyzer = AttendanceAnalyzer(debug=args.debug, unprocessed_only=args.unprocessed_only)
+        analyzer = AttendanceAnalyzer(
+            debug=args.debug, unprocessed_only=args.unprocessed_only
+        )
 
         if incremental_mode:
             logger.info("📂 正在解析考勤檔案... (增量分析模式)")
@@ -148,7 +162,9 @@ def run(args: argparse.Namespace) -> None:
 
         if format_type.lower() == "excel":
             csv_filepath = filepath.replace(".txt", "_analysis.csv")
-            backup_path = analyzer.export_report(csv_filepath, "csv", export_policy=export_policy)
+            backup_path = analyzer.export_report(
+                csv_filepath, "csv", export_policy=export_policy
+            )
             exported_files.append(csv_filepath)
             if backup_path:
                 backup_files.append(backup_path)
@@ -189,7 +205,9 @@ def run(args: argparse.Namespace) -> None:
                 else:
                     removed_paths: set[str] = set()
                     for path in exported_files:
-                        removed = cleanup_exports_helper(path, include_canonical=args.debug)
+                        removed = cleanup_exports_helper(
+                            path, include_canonical=args.debug
+                        )
                         removed_paths.update(os.path.abspath(p) for p in removed)
                     for backup in backup_files:
                         if os.path.exists(backup):

--- a/lib/commands/export.py
+++ b/lib/commands/export.py
@@ -19,9 +19,7 @@ def _parse_date(value: str) -> date:
             return datetime.strptime(value, fmt).date()
         except ValueError:
             continue
-    raise argparse.ArgumentTypeError(
-        f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）"
-    )
+    raise argparse.ArgumentTypeError(f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）")
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:

--- a/lib/commands/export.py
+++ b/lib/commands/export.py
@@ -4,6 +4,7 @@ Currently supports a single target (`code-agent-hr`), which produces
 `attendance-analysis/v1` JSON consumable by code_agent_hr's
 `apply_forms.py`. Future targets register here as additional `--to`
 values."""
+
 from __future__ import annotations
 
 import argparse
@@ -18,7 +19,9 @@ def _parse_date(value: str) -> date:
             return datetime.strptime(value, fmt).date()
         except ValueError:
             continue
-    raise argparse.ArgumentTypeError(f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）")
+    raise argparse.ArgumentTypeError(
+        f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）"
+    )
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -35,20 +38,27 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     )
     parser.add_argument("filepath", help="考勤檔案路徑（同 `fhr analyze`）")
     parser.add_argument(
-        "--to", required=True, choices=["code-agent-hr"],
+        "--to",
+        required=True,
+        choices=["code-agent-hr"],
         help="目標格式 (= schema 名稱)",
     )
     parser.add_argument("--out", required=True, help="輸出 JSON 路徑")
     parser.add_argument(
-        "--cutoff", type=_parse_date, default=None,
+        "--cutoff",
+        type=_parse_date,
+        default=None,
         help="排除此日期(含)以前的條目；通常設為上一次申請的最後日期",
     )
     parser.add_argument(
-        "--today", type=_parse_date, default=None,
+        "--today",
+        type=_parse_date,
+        default=None,
         help="排除此日期之後的條目（用來剔除未來的 WFH 自動建議）",
     )
     parser.add_argument(
-        "--incremental", action="store_true",
+        "--incremental",
+        action="store_true",
         help=(
             "啟用增量分析 (預設關閉)。export 預設走完整分析,因為下游 portal-apply"
             " 走 applied_forms dedup,不該被 analyzer state cache 影響。"
@@ -92,8 +102,10 @@ def run(args: argparse.Namespace) -> None:
             logger.info(
                 "✅ %s (%d 加班 / %d 小時, %d 請假 / %d 小時, %d skipped)",
                 args.out,
-                s["overtime_count"], s["overtime_hours"],
-                s["leave_count"], s["leave_hours"],
+                s["overtime_count"],
+                s["overtime_hours"],
+                s["leave_count"],
+                s["leave_hours"],
                 len(payload["skipped"]),
             )
         else:

--- a/lib/commands/import_.py
+++ b/lib/commands/import_.py
@@ -7,6 +7,7 @@ tab-delimited .txt the analyzer ingests.
 
 Legacy un-stamped JSON dumps (the kind this session captured ad-hoc)
 are auto-promoted to v1 when `--legacy` is set."""
+
 from __future__ import annotations
 
 import argparse
@@ -31,12 +32,16 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     )
     parser.add_argument("snapshot", help="輸入 JSON 路徑")
     parser.add_argument(
-        "--from", dest="source", required=True, choices=["portal-json"],
+        "--from",
+        dest="source",
+        required=True,
+        choices=["portal-json"],
         help="來源格式 (= schema 名稱)",
     )
     parser.add_argument("--out", required=True, help="輸出 .txt 路徑")
     parser.add_argument(
-        "--legacy", action="store_true",
+        "--legacy",
+        action="store_true",
         help="輸入是舊版未標 schema_version 的 dump，先 promote 再讀",
     )
     parser.add_argument("--debug", action="store_true", help="啟用 debug 模式")

--- a/lib/commands/portal_apply.py
+++ b/lib/commands/portal_apply.py
@@ -54,9 +54,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     )
     parser.add_argument("--user", required=True, help="state cache 使用者")
     parser.add_argument("--input", required=True, help="analysis-v1 JSON 路徑")
-    parser.add_argument(
-        "--attendance", help="出勤 .txt (用於顯示打卡時間;預設 auto-detect)"
-    )
+    parser.add_argument("--attendance", help="出勤 .txt (用於顯示打卡時間;預設 auto-detect)")
     parser.add_argument("--proxy", help="非 WFH 請假的職務代理人")
     parser.add_argument(
         "--auto", action="store_true", help="自動模式,完全用 cascade 結果送單 (不互動)"
@@ -118,9 +116,7 @@ def _resolve_base_url(args: argparse.Namespace) -> str:
         return args.base_url.rstrip("/")
     raw = os.environ.get("EHR_URL", "").rstrip("/")
     if not raw:
-        raise RuntimeError(
-            "找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url"
-        )
+        raise RuntimeError("找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url")
     for suffix in ("/LoginFOrginal.asp", "/LoginFOpen.asp"):
         if raw.endswith(suffix):
             raw = raw[: -len(suffix)]
@@ -338,9 +334,7 @@ def _interactive_overtime(
 ) -> None:
     if not overtime:
         return
-    logger.info(
-        "\n%s\n加班單 (%d 筆) — 蒐集決策中\n%s", "=" * 50, len(overtime), "=" * 50
-    )
+    logger.info("\n%s\n加班單 (%d 筆) — 蒐集決策中\n%s", "=" * 50, len(overtime), "=" * 50)
     for i, entry in enumerate(overtime, 1):
         key = _entry_key(entry, "overtime")
         if key in completed:
@@ -355,9 +349,7 @@ def _interactive_overtime(
                     latest_checkin=latest_checkin,
                 ),
             )
-            plan["overtime"].append(
-                {"entry": entry, "action": "skip", "already_done": True}
-            )
+            plan["overtime"].append({"entry": entry, "action": "skip", "already_done": True})
             continue
         if key in saved_plan:
             d = saved_plan[key]
@@ -376,9 +368,7 @@ def _interactive_overtime(
             )
             continue
 
-        early, delta = _is_early_arrival(
-            entry["date"], schedule_start, latest_checkin, attendance
-        )
+        early, delta = _is_early_arrival(entry["date"], schedule_start, latest_checkin, attendance)
         early_hint = None
         if early:
             sh, sm = (int(x) for x in schedule_start.split(":"))
@@ -401,9 +391,7 @@ def _interactive_overtime(
             action = input("  申請? (y=送出 / s=跳過) [y]: ").strip().lower() or "y"
             if action == "y":
                 default_reason = entry.get("reason", "工作需要")
-                reason = (
-                    input(f"  加班原因 [{default_reason}]: ").strip() or default_reason
-                )
+                reason = input(f"  加班原因 [{default_reason}]: ").strip() or default_reason
                 plan["overtime"].append(
                     {"entry": entry, "action": "submit", "key": key, "reason": reason}
                 )
@@ -452,9 +440,7 @@ def _interactive_leave(
                     latest_checkin=latest_checkin,
                 ),
             )
-            plan["leave"].append(
-                {"entry": entry, "action": "skip", "already_done": True}
-            )
+            plan["leave"].append({"entry": entry, "action": "skip", "already_done": True})
             continue
         if key in saved_plan:
             d = saved_plan[key]
@@ -491,9 +477,7 @@ def _interactive_leave(
         if suggested:
             logger.info("  💡 建議 cascade → %s (%s)", suggested, suggested_code)
         while True:
-            default_code = suggested_code or (
-                "27" if entry.get("type_hint") == "WFH" else "30"
-            )
+            default_code = suggested_code or ("27" if entry.get("type_hint") == "WFH" else "30")
             choice = (
                 input(f"  假別 [{common_display}  ?=展開] ({default_code}): ").strip()
                 or default_code
@@ -508,9 +492,7 @@ def _interactive_leave(
             action = input("  申請? (y=送出 / s=跳過) [y]: ").strip().lower() or "y"
             if action == "y":
                 default_reason = entry.get("reason", "personal matter")
-                reason = (
-                    input(f"  請假原因 [{default_reason}]: ").strip() or default_reason
-                )
+                reason = input(f"  請假原因 [{default_reason}]: ").strip() or default_reason
                 entry_proxy = proxy
                 if "異地辦公" not in leave_type and proxy:
                     new_proxy = input(f"  代理人 [{proxy},Enter 保留]: ").strip()
@@ -671,9 +653,7 @@ def run(args: argparse.Namespace) -> None:
         for e in overtime:
             key = _entry_key(e, "overtime")
             if key in completed:
-                plan["overtime"].append(
-                    {"entry": e, "action": "skip", "already_done": True}
-                )
+                plan["overtime"].append({"entry": e, "action": "skip", "already_done": True})
                 continue
             plan["overtime"].append(
                 {
@@ -686,9 +666,7 @@ def run(args: argparse.Namespace) -> None:
         for e in leave:
             key = _entry_key(e, "leave")
             if key in completed:
-                plan["leave"].append(
-                    {"entry": e, "action": "skip", "already_done": True}
-                )
+                plan["leave"].append({"entry": e, "action": "skip", "already_done": True})
                 continue
             assigned = allocations.get(key) or (
                 "異地辦公" if e.get("type_hint") == "WFH" else "補休假"
@@ -763,9 +741,7 @@ def run(args: argparse.Namespace) -> None:
     if not args.auto:
         prompt_suffix = " (DRY RUN — 不會實際送出)" if args.dry_run else ""
         confirm = (
-            input(
-                f"\n確認送出 {len(submit_ot) + len(submit_lv)} 筆{prompt_suffix}? (y/n) [y]: "
-            )
+            input(f"\n確認送出 {len(submit_ot) + len(submit_lv)} 筆{prompt_suffix}? (y/n) [y]: ")
             .strip()
             .lower()
             or "y"
@@ -840,9 +816,7 @@ def run(args: argparse.Namespace) -> None:
                 screenshot_dir=_resolve_screenshot_dir(args),
             )
         prefix = "🧪 DRY RUN 結果" if args.dry_run else "📊 本次申請結果"
-        logger.info(
-            "\n%s: 加班 %d/%d, 請假 %d/%d", prefix, ot_ok, ot_total, lv_ok, lv_total
-        )
+        logger.info("\n%s: 加班 %d/%d, 請假 %d/%d", prefix, ot_ok, ot_total, lv_ok, lv_total)
         if args.dry_run:
             logger.info(
                 "ℹ️ DRY RUN 已跳過『確定送出』+ 未寫入 applied_forms cache "
@@ -877,9 +851,7 @@ def _resolve_screenshot_dir(args) -> Path | None:
     return Path("tmp") / "dry-run-screenshots" / stamp
 
 
-def _wrap_submit_iter(
-    plans: list[dict], completed: set[str], form_type: str
-) -> Iterable[dict]:
+def _wrap_submit_iter(plans: list[dict], completed: set[str], form_type: str) -> Iterable[dict]:
     """Yield only plans that still need submission, gracefully skipping
     completed ones (state cache may have been updated mid-run)."""
     for p in plans:

--- a/lib/commands/portal_apply.py
+++ b/lib/commands/portal_apply.py
@@ -54,7 +54,9 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     )
     parser.add_argument("--user", required=True, help="state cache 使用者")
     parser.add_argument("--input", required=True, help="analysis-v1 JSON 路徑")
-    parser.add_argument("--attendance", help="出勤 .txt (用於顯示打卡時間;預設 auto-detect)")
+    parser.add_argument(
+        "--attendance", help="出勤 .txt (用於顯示打卡時間;預設 auto-detect)"
+    )
     parser.add_argument("--proxy", help="非 WFH 請假的職務代理人")
     parser.add_argument(
         "--auto", action="store_true", help="自動模式,完全用 cascade 結果送單 (不互動)"
@@ -116,7 +118,9 @@ def _resolve_base_url(args: argparse.Namespace) -> str:
         return args.base_url.rstrip("/")
     raw = os.environ.get("EHR_URL", "").rstrip("/")
     if not raw:
-        raise RuntimeError("找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url")
+        raise RuntimeError(
+            "找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url"
+        )
     for suffix in ("/LoginFOrginal.asp", "/LoginFOpen.asp"):
         if raw.endswith(suffix):
             raw = raw[: -len(suffix)]
@@ -195,7 +199,7 @@ def _format_entry(
 ) -> str:
     st = entry["start_time"]
     et = entry["end_time"]
-    base = f"{entry['date']} {_fmt_time(st)}-{_fmt_time(et)} " f"({entry['hours']}h)"
+    base = f"{entry['date']} {_fmt_time(st)}-{_fmt_time(et)} ({entry['hours']}h)"
     rec = attendance.get(entry["date"])
     if rec:
         base += f"  | 實際 上班 {rec.get('上班', '—')}  下班 {rec.get('下班', '—')}"
@@ -334,7 +338,9 @@ def _interactive_overtime(
 ) -> None:
     if not overtime:
         return
-    logger.info("\n%s\n加班單 (%d 筆) — 蒐集決策中\n%s", "=" * 50, len(overtime), "=" * 50)
+    logger.info(
+        "\n%s\n加班單 (%d 筆) — 蒐集決策中\n%s", "=" * 50, len(overtime), "=" * 50
+    )
     for i, entry in enumerate(overtime, 1):
         key = _entry_key(entry, "overtime")
         if key in completed:
@@ -343,10 +349,15 @@ def _interactive_overtime(
                 i,
                 len(overtime),
                 _format_entry(
-                    entry, attendance, schedule_start=schedule_start, latest_checkin=latest_checkin
+                    entry,
+                    attendance,
+                    schedule_start=schedule_start,
+                    latest_checkin=latest_checkin,
                 ),
             )
-            plan["overtime"].append({"entry": entry, "action": "skip", "already_done": True})
+            plan["overtime"].append(
+                {"entry": entry, "action": "skip", "already_done": True}
+            )
             continue
         if key in saved_plan:
             d = saved_plan[key]
@@ -356,13 +367,18 @@ def _interactive_overtime(
                 i,
                 len(overtime),
                 _format_entry(
-                    entry, attendance, schedule_start=schedule_start, latest_checkin=latest_checkin
+                    entry,
+                    attendance,
+                    schedule_start=schedule_start,
+                    latest_checkin=latest_checkin,
                 ),
                 d.get("action"),
             )
             continue
 
-        early, delta = _is_early_arrival(entry["date"], schedule_start, latest_checkin, attendance)
+        early, delta = _is_early_arrival(
+            entry["date"], schedule_start, latest_checkin, attendance
+        )
         early_hint = None
         if early:
             sh, sm = (int(x) for x in schedule_start.split(":"))
@@ -385,7 +401,9 @@ def _interactive_overtime(
             action = input("  申請? (y=送出 / s=跳過) [y]: ").strip().lower() or "y"
             if action == "y":
                 default_reason = entry.get("reason", "工作需要")
-                reason = input(f"  加班原因 [{default_reason}]: ").strip() or default_reason
+                reason = (
+                    input(f"  加班原因 [{default_reason}]: ").strip() or default_reason
+                )
                 plan["overtime"].append(
                     {"entry": entry, "action": "submit", "key": key, "reason": reason}
                 )
@@ -428,10 +446,15 @@ def _interactive_leave(
                 i,
                 len(leave),
                 _format_entry(
-                    entry, attendance, schedule_start=schedule_start, latest_checkin=latest_checkin
+                    entry,
+                    attendance,
+                    schedule_start=schedule_start,
+                    latest_checkin=latest_checkin,
                 ),
             )
-            plan["leave"].append({"entry": entry, "action": "skip", "already_done": True})
+            plan["leave"].append(
+                {"entry": entry, "action": "skip", "already_done": True}
+            )
             continue
         if key in saved_plan:
             d = saved_plan[key]
@@ -441,7 +464,10 @@ def _interactive_leave(
                 i,
                 len(leave),
                 _format_entry(
-                    entry, attendance, schedule_start=schedule_start, latest_checkin=latest_checkin
+                    entry,
+                    attendance,
+                    schedule_start=schedule_start,
+                    latest_checkin=latest_checkin,
                 ),
                 d.get("action"),
                 d.get("leave_type", ""),
@@ -455,14 +481,19 @@ def _interactive_leave(
             i,
             len(leave),
             _format_entry(
-                entry, attendance, schedule_start=schedule_start, latest_checkin=latest_checkin
+                entry,
+                attendance,
+                schedule_start=schedule_start,
+                latest_checkin=latest_checkin,
             ),
             entry.get("type_hint", ""),
         )
         if suggested:
             logger.info("  💡 建議 cascade → %s (%s)", suggested, suggested_code)
         while True:
-            default_code = suggested_code or ("27" if entry.get("type_hint") == "WFH" else "30")
+            default_code = suggested_code or (
+                "27" if entry.get("type_hint") == "WFH" else "30"
+            )
             choice = (
                 input(f"  假別 [{common_display}  ?=展開] ({default_code}): ").strip()
                 or default_code
@@ -477,7 +508,9 @@ def _interactive_leave(
             action = input("  申請? (y=送出 / s=跳過) [y]: ").strip().lower() or "y"
             if action == "y":
                 default_reason = entry.get("reason", "personal matter")
-                reason = input(f"  請假原因 [{default_reason}]: ").strip() or default_reason
+                reason = (
+                    input(f"  請假原因 [{default_reason}]: ").strip() or default_reason
+                )
                 entry_proxy = proxy
                 if "異地辦公" not in leave_type and proxy:
                     new_proxy = input(f"  代理人 [{proxy},Enter 保留]: ").strip()
@@ -638,15 +671,24 @@ def run(args: argparse.Namespace) -> None:
         for e in overtime:
             key = _entry_key(e, "overtime")
             if key in completed:
-                plan["overtime"].append({"entry": e, "action": "skip", "already_done": True})
+                plan["overtime"].append(
+                    {"entry": e, "action": "skip", "already_done": True}
+                )
                 continue
             plan["overtime"].append(
-                {"entry": e, "action": "submit", "key": key, "reason": e.get("reason", "工作需要")}
+                {
+                    "entry": e,
+                    "action": "submit",
+                    "key": key,
+                    "reason": e.get("reason", "工作需要"),
+                }
             )
         for e in leave:
             key = _entry_key(e, "leave")
             if key in completed:
-                plan["leave"].append({"entry": e, "action": "skip", "already_done": True})
+                plan["leave"].append(
+                    {"entry": e, "action": "skip", "already_done": True}
+                )
                 continue
             assigned = allocations.get(key) or (
                 "異地辦公" if e.get("type_hint") == "WFH" else "補休假"
@@ -721,7 +763,9 @@ def run(args: argparse.Namespace) -> None:
     if not args.auto:
         prompt_suffix = " (DRY RUN — 不會實際送出)" if args.dry_run else ""
         confirm = (
-            input(f"\n確認送出 {len(submit_ot)+len(submit_lv)} 筆{prompt_suffix}? " "(y/n) [y]: ")
+            input(
+                f"\n確認送出 {len(submit_ot) + len(submit_lv)} 筆{prompt_suffix}? (y/n) [y]: "
+            )
             .strip()
             .lower()
             or "y"
@@ -796,7 +840,9 @@ def run(args: argparse.Namespace) -> None:
                 screenshot_dir=_resolve_screenshot_dir(args),
             )
         prefix = "🧪 DRY RUN 結果" if args.dry_run else "📊 本次申請結果"
-        logger.info("\n%s: 加班 %d/%d, 請假 %d/%d", prefix, ot_ok, ot_total, lv_ok, lv_total)
+        logger.info(
+            "\n%s: 加班 %d/%d, 請假 %d/%d", prefix, ot_ok, ot_total, lv_ok, lv_total
+        )
         if args.dry_run:
             logger.info(
                 "ℹ️ DRY RUN 已跳過『確定送出』+ 未寫入 applied_forms cache "
@@ -831,7 +877,9 @@ def _resolve_screenshot_dir(args) -> Path | None:
     return Path("tmp") / "dry-run-screenshots" / stamp
 
 
-def _wrap_submit_iter(plans: list[dict], completed: set[str], form_type: str) -> Iterable[dict]:
+def _wrap_submit_iter(
+    plans: list[dict], completed: set[str], form_type: str
+) -> Iterable[dict]:
     """Yield only plans that still need submission, gracefully skipping
     completed ones (state cache may have been updated mid-run)."""
     for p in plans:

--- a/lib/commands/portal_balances.py
+++ b/lib/commands/portal_balances.py
@@ -4,6 +4,7 @@ Opens the 請假單 form and reads both the items panel (補休 / 事假 /
 有薪病假 / 半薪病假 / 異地辦公 ...) plus the 特休統計 panel. Useful
 for cascade allocation planning (see `fhr portal-apply --interactive`).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -22,8 +23,9 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     )
     parser.add_argument("--base-url", help="EHR base URL (預設讀 env EHR_URL)")
     parser.add_argument("--session", help="agent-browser session 名稱")
-    parser.add_argument("--json", action="store_true", dest="as_json",
-                        help="輸出 JSON 而不是表格")
+    parser.add_argument(
+        "--json", action="store_true", dest="as_json", help="輸出 JSON 而不是表格"
+    )
     parser.add_argument("--debug", action="store_true", help="啟用 debug 日誌")
     return parser
 

--- a/lib/commands/portal_balances.py
+++ b/lib/commands/portal_balances.py
@@ -23,9 +23,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     )
     parser.add_argument("--base-url", help="EHR base URL (預設讀 env EHR_URL)")
     parser.add_argument("--session", help="agent-browser session 名稱")
-    parser.add_argument(
-        "--json", action="store_true", dest="as_json", help="輸出 JSON 而不是表格"
-    )
+    parser.add_argument("--json", action="store_true", dest="as_json", help="輸出 JSON 而不是表格")
     parser.add_argument("--debug", action="store_true", help="啟用 debug 日誌")
     return parser
 
@@ -35,9 +33,7 @@ def _resolve_base_url(args: argparse.Namespace) -> str:
         return args.base_url.rstrip("/")
     raw = os.environ.get("EHR_URL", "").rstrip("/")
     if not raw:
-        raise RuntimeError(
-            "找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url"
-        )
+        raise RuntimeError("找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url")
     for suffix in ("/LoginFOrginal.asp", "/LoginFOpen.asp"):
         if raw.endswith(suffix):
             raw = raw[: -len(suffix)]

--- a/lib/commands/portal_fetch.py
+++ b/lib/commands/portal_fetch.py
@@ -23,9 +23,7 @@ def _parse_date(value: str) -> date:
             return datetime.strptime(value, fmt).date()
         except ValueError:
             continue
-    raise argparse.ArgumentTypeError(
-        f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）"
-    )
+    raise argparse.ArgumentTypeError(f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）")
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -46,12 +44,8 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
 需在 .env 設定 EHR_URL（之後若擴增其他欄位再補）。
         """,
     )
-    parser.add_argument(
-        "--user", required=True, help="檔名 user 段（會出現在輸出檔名）"
-    )
-    parser.add_argument(
-        "--date-s", dest="date_s", type=_parse_date, help="起始日 (預設本月 1 日)"
-    )
+    parser.add_argument("--user", required=True, help="檔名 user 段（會出現在輸出檔名）")
+    parser.add_argument("--date-s", dest="date_s", type=_parse_date, help="起始日 (預設本月 1 日)")
     parser.add_argument(
         "--date-e", dest="date_e", type=_parse_date, help="結束日 (預設本月最後一日)"
     )
@@ -91,9 +85,7 @@ def _resolve_base_url(args: argparse.Namespace) -> str:
         return args.base_url.rstrip("/")
     raw = os.environ.get("EHR_URL", "").rstrip("/")
     if not raw:
-        raise RuntimeError(
-            "找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url"
-        )
+        raise RuntimeError("找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url")
     # `.env` may carry a full login URL like .../LoginFOrginal.asp; strip the
     # trailing page so the rest of the code can append paths.
     for suffix in ("/LoginFOrginal.asp", "/LoginFOpen.asp"):

--- a/lib/commands/portal_fetch.py
+++ b/lib/commands/portal_fetch.py
@@ -6,6 +6,7 @@ and date-range CLI flags. The output file is named in the
 parse the user/date metadata from the filename (see
 `lib/filename.py`).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -22,7 +23,9 @@ def _parse_date(value: str) -> date:
             return datetime.strptime(value, fmt).date()
         except ValueError:
             continue
-    raise argparse.ArgumentTypeError(f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）")
+    raise argparse.ArgumentTypeError(
+        f"無法解析日期 {value!r}（預期 YYYY/MM/DD 或 YYYY-MM-DD）"
+    )
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -43,11 +46,15 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
 需在 .env 設定 EHR_URL（之後若擴增其他欄位再補）。
         """,
     )
-    parser.add_argument("--user", required=True, help="檔名 user 段（會出現在輸出檔名）")
-    parser.add_argument("--date-s", dest="date_s", type=_parse_date,
-                        help="起始日 (預設本月 1 日)")
-    parser.add_argument("--date-e", dest="date_e", type=_parse_date,
-                        help="結束日 (預設本月最後一日)")
+    parser.add_argument(
+        "--user", required=True, help="檔名 user 段（會出現在輸出檔名）"
+    )
+    parser.add_argument(
+        "--date-s", dest="date_s", type=_parse_date, help="起始日 (預設本月 1 日)"
+    )
+    parser.add_argument(
+        "--date-e", dest="date_e", type=_parse_date, help="結束日 (預設本月最後一日)"
+    )
     parser.add_argument("--out", help="輸出 .txt 路徑 (預設 ./tmp/<auto>.txt)")
     parser.add_argument("--session", help="agent-browser session 名稱 (預設 'fhr')")
     parser.add_argument("--base-url", help="EHR base URL (預設讀 env EHR_URL)")
@@ -67,6 +74,7 @@ def _default_range(today: date | None = None) -> tuple[date, date]:
 
 def _prev_day(d: date) -> date:
     from datetime import timedelta
+
     return d - timedelta(days=1)
 
 
@@ -74,8 +82,7 @@ def _default_out(user: str, start: date, end: date) -> Path:
     if start.year == end.year and start.month == end.month:
         stem = f"{start.year}{start.month:02d}-{user}-出勤資料.txt"
     else:
-        stem = (f"{start.year}{start.month:02d}-{end.year}{end.month:02d}"
-                f"-{user}-出勤資料.txt")
+        stem = f"{start.year}{start.month:02d}-{end.year}{end.month:02d}-{user}-出勤資料.txt"
     return Path("tmp") / stem
 
 
@@ -134,9 +141,13 @@ def run(args: argparse.Namespace) -> None:
         with PortalSession(args.session) as portal:
             ensure_login(portal, base_url)
             count = att.fetch_to_txt(
-                portal, base_url, str(out_path),
-                start_year=start.year, start_month=start.month,
-                end_year=end.year, end_month=end.month,
+                portal,
+                base_url,
+                str(out_path),
+                start_year=start.year,
+                start_month=start.month,
+                end_year=end.year,
+                end_month=end.month,
             )
         logger.info("✅ %s (%d 筆)", out_path, count)
     except AgentBrowserMissing as e:

--- a/lib/commands/portal_sync.py
+++ b/lib/commands/portal_sync.py
@@ -49,9 +49,7 @@ def _resolve_base_url(args: argparse.Namespace) -> str:
         return args.base_url.rstrip("/")
     raw = os.environ.get("EHR_URL", "").rstrip("/")
     if not raw:
-        raise RuntimeError(
-            "找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url"
-        )
+        raise RuntimeError("找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url")
     for suffix in ("/LoginFOrginal.asp", "/LoginFOpen.asp"):
         if raw.endswith(suffix):
             raw = raw[: -len(suffix)]

--- a/lib/commands/portal_sync.py
+++ b/lib/commands/portal_sync.py
@@ -7,6 +7,7 @@ can dedup against the local mirror.
 
 This subcommand is idempotent — running it twice in a row produces no diff
 beyond `last_full_sync`."""
+
 from __future__ import annotations
 
 import argparse
@@ -31,8 +32,11 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     )
     parser.add_argument("--user", required=True, help="state cache 上的使用者名稱")
     parser.add_argument(
-        "--kinds", nargs="+", default=["overtime", "leave"],
-        choices=["overtime", "leave"], help="要同步哪些表單種類 (預設全部)",
+        "--kinds",
+        nargs="+",
+        default=["overtime", "leave"],
+        choices=["overtime", "leave"],
+        help="要同步哪些表單種類 (預設全部)",
     )
     parser.add_argument("--base-url", help="EHR base URL (預設讀 env EHR_URL)")
     parser.add_argument("--session", help="agent-browser session 名稱 (預設 'fhr')")

--- a/lib/commands/reasons.py
+++ b/lib/commands/reasons.py
@@ -98,11 +98,8 @@ def run(args: argparse.Namespace) -> None:
         encoding="utf-8",
     )
     total = sum(
-        len(d.get("overtime", {}).get("git", []))
-        + len(d.get("leave", {}).get("git", []))
+        len(d.get("overtime", {}).get("git", [])) + len(d.get("leave", {}).get("git", []))
         for d in evidence.values()
     )
     logger.info("✅ %s (%d 日 / %d commits)", args.out, len(evidence), total)
-    logger.info(
-        "ℹ️ Slack 部分由 .claude/skills/fhr-reason-abstract 自行抓 + 合併到 reason 欄位"
-    )
+    logger.info("ℹ️ Slack 部分由 .claude/skills/fhr-reason-abstract 自行抓 + 合併到 reason 欄位")

--- a/lib/commands/reasons.py
+++ b/lib/commands/reasons.py
@@ -10,6 +10,7 @@ wants an LLM, and the project's policy is to keep `fhr` LLM-free so
 the skill can use whatever the user prefers (Sonnet, Haiku, Codex,
 local ollama, etc.).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -27,6 +28,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
         epilog="""
 範例:
   fhr reasons --input tmp/analysis.json --author 'Jimmy Chen' \\
+      --exclude-repo hackthon --exclude-repo film-brain \\
       --out tmp/reasons-evidence.json
 
 之後在 Claude Code 喚 /fhr-reason-abstract,skill 會讀 evidence.json
@@ -36,16 +38,28 @@ def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParse
     parser.add_argument("--input", required=True, help="analysis-v1 JSON 路徑")
     parser.add_argument("--out", required=True, help="輸出證據 JSON")
     parser.add_argument(
-        "--author", action="append", required=True,
+        "--author",
+        action="append",
+        required=True,
         help="git --author 比對字串 (可重複指定多個 alias)",
     )
     parser.add_argument(
-        "--root", action="append", dest="roots",
+        "--root",
+        action="append",
+        dest="roots",
         help="git repo 根目錄 (可重複,預設 ~/git ~/workdir ~/github)",
     )
     parser.add_argument(
-        "--schedule-end", default="18:30",
+        "--schedule-end",
+        default="18:30",
         help="判斷 commit 屬於『加班』(>= 此時間) 還是『日間』(<) 的門檻",
+    )
+    parser.add_argument(
+        "--exclude-repo",
+        action="append",
+        dest="exclude_repos",
+        metavar="REPO_NAME",
+        help="排除的 repo 目錄名 (可重複,大小寫不敏感);把個人側專案排除在工作理由證據外",
     )
     parser.add_argument("--debug", action="store_true", help="啟用 debug 日誌")
     return parser
@@ -66,15 +80,22 @@ def run(args: argparse.Namespace) -> None:
         sys.exit(2)
 
     roots = tuple(args.roots) if args.roots else DEFAULT_GIT_REPO_ROOTS
+    exclude_repos = tuple(args.exclude_repos) if args.exclude_repos else ()
     logger.info("🔍 掃描 git repos: %s", ", ".join(roots))
     logger.info("🔍 作者比對: %s", ", ".join(args.author))
+    if exclude_repos:
+        logger.info("🚫 排除個人 repo: %s", ", ".join(exclude_repos))
 
     evidence = evidence_for_analysis(
-        analysis, args.author, roots=roots,
+        analysis,
+        args.author,
+        roots=roots,
         schedule_end=args.schedule_end,
+        exclude_repos=exclude_repos,
     )
     Path(args.out).write_text(
-        json.dumps(evidence, ensure_ascii=False, indent=2), encoding="utf-8",
+        json.dumps(evidence, ensure_ascii=False, indent=2),
+        encoding="utf-8",
     )
     total = sum(
         len(d.get("overtime", {}).get("git", []))

--- a/lib/config.py
+++ b/lib/config.py
@@ -7,12 +7,13 @@ class AttendanceConfig:
     schedule_end: str = "18:30"  # 個人班表結束時間
     earliest_checkin: str = "08:30"
     latest_checkin: str = "10:00"  # 遲到門檻（超過此時間需請假）
-    lunch_start: str = "12:30"
-    lunch_end: str = "13:30"
+    lunch_start: str = "12:30"  # 午休起（遲到請假時數會扣此區間）
+    lunch_end: str = "13:30"  # 午休迄
     work_hours: int = 8
     lunch_hours: int = 1
     min_overtime_minutes: int = 60
     overtime_increment_minutes: int = 60
+    # 忘刷卡政策已改為每年 4 次（稀缺手動額度）。analyzer 不自動拿忘刷卡抵遲到，
+    # 一律走請假；下列欄位目前未被分析流程使用，保留供未來手動工具參考。
     forget_punch_allowance_per_month: int = 2
     forget_punch_max_minutes: int = 60
-

--- a/lib/csv_exporter.py
+++ b/lib/csv_exporter.py
@@ -11,7 +11,9 @@ def _header_row(incremental_mode: bool) -> list[str]:
     return headers
 
 
-def _status_row(last_date: str, complete_days: int, last_analysis_time: str) -> list[str]:
+def _status_row(
+    last_date: str, complete_days: int, last_analysis_time: str
+) -> list[str]:
     return [
         last_date,
         "狀態資訊",
@@ -50,7 +52,9 @@ def write_status_row(
     writer.writerow(_status_row(last_date, complete_days, last_analysis_time))
 
 
-def write_issue_rows(writer: csv.writer, issues: Iterable, incremental_mode: bool) -> None:
+def write_issue_rows(
+    writer: csv.writer, issues: Iterable, incremental_mode: bool
+) -> None:
     for issue in issues:
         writer.writerow(_issue_row(issue, incremental_mode))
 
@@ -97,7 +101,9 @@ def _is_wfh_row(row: list[str]) -> bool:
     return len(row) > 1 and row[1] in {"WFH", "WFH假"}
 
 
-def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[list[str]]:
+def _merge_rows(
+    existing: list[list[str]], new_rows: list[list[str]]
+) -> list[list[str]]:
     """Merge existing CSV rows with new rows, deduplicating by key.
 
     New rows take precedence over existing ones with the same key.

--- a/lib/csv_exporter.py
+++ b/lib/csv_exporter.py
@@ -11,9 +11,7 @@ def _header_row(incremental_mode: bool) -> list[str]:
     return headers
 
 
-def _status_row(
-    last_date: str, complete_days: int, last_analysis_time: str
-) -> list[str]:
+def _status_row(last_date: str, complete_days: int, last_analysis_time: str) -> list[str]:
     return [
         last_date,
         "狀態資訊",
@@ -52,9 +50,7 @@ def write_status_row(
     writer.writerow(_status_row(last_date, complete_days, last_analysis_time))
 
 
-def write_issue_rows(
-    writer: csv.writer, issues: Iterable, incremental_mode: bool
-) -> None:
+def write_issue_rows(writer: csv.writer, issues: Iterable, incremental_mode: bool) -> None:
     for issue in issues:
         writer.writerow(_issue_row(issue, incremental_mode))
 
@@ -66,9 +62,7 @@ def _build_rows(
     rows.append(_header_row(incremental_mode))
     # Auto-filled Friday WFH suggestions are calendar-derived, so they should
     # not suppress the "all dates processed" status row.
-    non_wfh_issues = [
-        i for i in issues if getattr(getattr(i, "type", None), "name", "") != "WFH"
-    ]
+    non_wfh_issues = [i for i in issues if getattr(getattr(i, "type", None), "name", "") != "WFH"]
     if status and incremental_mode and not non_wfh_issues:
         last_date, complete_days, last_analysis_time = status
         rows.append(_status_row(last_date, complete_days, last_analysis_time))
@@ -101,9 +95,7 @@ def _is_wfh_row(row: list[str]) -> bool:
     return len(row) > 1 and row[1] in {"WFH", "WFH假"}
 
 
-def _merge_rows(
-    existing: list[list[str]], new_rows: list[list[str]]
-) -> list[list[str]]:
+def _merge_rows(existing: list[list[str]], new_rows: list[list[str]]) -> list[list[str]]:
     """Merge existing CSV rows with new rows, deduplicating by key.
 
     New rows take precedence over existing ones with the same key.

--- a/lib/dates.py
+++ b/lib/dates.py
@@ -2,6 +2,7 @@
 
 No dependency on analyzer types; operate on duck-typed records.
 """
+
 from collections import defaultdict
 from collections.abc import Iterable
 from datetime import datetime
@@ -36,4 +37,3 @@ def identify_complete_work_days(records: Iterable) -> list[datetime]:
         if flags["checkin"] and flags["checkout"]:
             out.append(datetime.combine(d, datetime.min.time()))
     return sorted(out)
-

--- a/lib/env.py
+++ b/lib/env.py
@@ -11,6 +11,7 @@ Security policy: this loader MUST NOT log values. The 104 EHR Portal
 flow never stores user passwords (see CLAUDE.md) — the .env only
 holds URLs, company info, and Slack user IDs.
 """
+
 from __future__ import annotations
 
 import os

--- a/lib/excel_exporter.py
+++ b/lib/excel_exporter.py
@@ -20,9 +20,7 @@ def init_workbook() -> tuple[Workbook, Worksheet, Font, PatternFill, Border, Ali
     ws.title = "考勤分析"
 
     header_font = Font(bold=True, color="FFFFFF")
-    header_fill = PatternFill(
-        start_color="366092", end_color="366092", fill_type="solid"
-    )
+    header_fill = PatternFill(start_color="366092", end_color="366092", fill_type="solid")
     border = Border(
         left=Side(style="thin"),
         right=Side(style="thin"),

--- a/lib/excel_exporter.py
+++ b/lib/excel_exporter.py
@@ -20,7 +20,9 @@ def init_workbook() -> tuple[Workbook, Worksheet, Font, PatternFill, Border, Ali
     ws.title = "考勤分析"
 
     header_font = Font(bold=True, color="FFFFFF")
-    header_fill = PatternFill(start_color="366092", end_color="366092", fill_type="solid")
+    header_fill = PatternFill(
+        start_color="366092", end_color="366092", fill_type="solid"
+    )
     border = Border(
         left=Side(style="thin"),
         right=Side(style="thin"),
@@ -32,9 +34,14 @@ def init_workbook() -> tuple[Workbook, Worksheet, Font, PatternFill, Border, Ali
     return wb, ws, header_font, header_fill, border, center_alignment
 
 
-def write_headers(ws, headers: list[str], header_font: Font,
-                  header_fill: PatternFill, border: Border,
-                  alignment: Alignment) -> None:
+def write_headers(
+    ws,
+    headers: list[str],
+    header_font: Font,
+    header_fill: PatternFill,
+    border: Border,
+    alignment: Alignment,
+) -> None:
     """Write header row with styles."""
     for col, header in enumerate(headers, 1):
         cell = ws.cell(row=1, column=col)
@@ -45,9 +52,14 @@ def write_headers(ws, headers: list[str], header_font: Font,
         cell.border = border
 
 
-def write_status_row(ws, last_date: str, complete_days: int,
-                     last_analysis_time: str, border: Border,
-                     alignment: Alignment) -> int:
+def write_status_row(
+    ws,
+    last_date: str,
+    complete_days: int,
+    last_analysis_time: str,
+    border: Border,
+    alignment: Alignment,
+) -> int:
     """Write incremental status row and return next data row."""
     ws.cell(row=2, column=1).value = last_date
     ws.cell(row=2, column=2).value = "狀態資訊"
@@ -70,9 +82,14 @@ def write_status_row(ws, last_date: str, complete_days: int,
     return 3
 
 
-def write_issue_rows(ws, issues: list[Issue], start_row: int,
-                     incremental_mode: bool, border: Border,
-                     alignment: Alignment) -> None:
+def write_issue_rows(
+    ws,
+    issues: list[Issue],
+    start_row: int,
+    incremental_mode: bool,
+    border: Border,
+    alignment: Alignment,
+) -> None:
     """Write issue rows into the worksheet."""
     for row_idx, issue in enumerate(issues, start_row):
         date_cell = ws.cell(row=row_idx, column=1)
@@ -140,10 +157,10 @@ def set_column_widths(ws, incremental_mode: bool) -> None:
     col_count = 7 if incremental_mode else 6
     for col in range(1, col_count + 1):
         ws.column_dimensions[chr(64 + col)].width = 15
-    ws.column_dimensions['D'].width = 30
-    ws.column_dimensions['F'].width = 40 if incremental_mode else 35
+    ws.column_dimensions["D"].width = 30
+    ws.column_dimensions["F"].width = 40 if incremental_mode else 35
     if incremental_mode:
-        ws.column_dimensions['G'].width = 24
+        ws.column_dimensions["G"].width = 24
 
 
 def save_workbook(wb: Workbook, filepath: str) -> None:

--- a/lib/export_cleanup.py
+++ b/lib/export_cleanup.py
@@ -58,9 +58,7 @@ def list_backups(filepath: str) -> list[str]:
             if _match_timestamped_filename(stem, ext, candidate):
                 backup_path = os.path.join(directory, candidate)
                 # Double-check the resolved path is within the expected directory
-                if os.path.dirname(os.path.abspath(backup_path)) == os.path.abspath(
-                    directory
-                ):
+                if os.path.dirname(os.path.abspath(backup_path)) == os.path.abspath(directory):
                     backups.append(backup_path)
     except FileNotFoundError:
         return []

--- a/lib/export_cleanup.py
+++ b/lib/export_cleanup.py
@@ -10,7 +10,7 @@ _TIMESTAMP_RE = re.compile(r"\d{8}_\d{6}$")
 
 
 def _match_timestamped_filename(stem: str, ext: str, candidate: str) -> bool:
-    if not candidate.startswith(stem + '_'):
+    if not candidate.startswith(stem + "_"):
         return False
     if ext and not candidate.endswith(ext):
         return False
@@ -36,11 +36,11 @@ def list_backups(filepath: str) -> list[str]:
     """
     # Normalize and validate path to prevent directory traversal
     filepath = os.path.normpath(filepath)
-    if '..' in filepath.split(os.sep):
+    if ".." in filepath.split(os.sep):
         raise ValueError(f"Invalid filepath with directory traversal: {filepath}")
 
     directory, filename = os.path.split(filepath)
-    directory = directory or '.'
+    directory = directory or "."
 
     # Validate directory exists and is accessible
     if not os.path.isdir(directory):
@@ -52,13 +52,15 @@ def list_backups(filepath: str) -> list[str]:
     try:
         for candidate in os.listdir(directory):
             # Only consider files in the same directory (no subdirectories)
-            if os.sep in candidate or candidate in ('.', '..'):
+            if os.sep in candidate or candidate in (".", ".."):
                 continue
 
             if _match_timestamped_filename(stem, ext, candidate):
                 backup_path = os.path.join(directory, candidate)
                 # Double-check the resolved path is within the expected directory
-                if os.path.dirname(os.path.abspath(backup_path)) == os.path.abspath(directory):
+                if os.path.dirname(os.path.abspath(backup_path)) == os.path.abspath(
+                    directory
+                ):
                     backups.append(backup_path)
     except FileNotFoundError:
         return []

--- a/lib/exporters/code_agent_hr.py
+++ b/lib/exporters/code_agent_hr.py
@@ -56,9 +56,7 @@ def _parse_time_range(time_range: str) -> tuple[str, str] | None:
     m = _TIME_RANGE_RE.match(time_range or "")
     if not m:
         return None
-    return _to_hhmm(int(m.group(1)), int(m.group(2))), _to_hhmm(
-        int(m.group(3)), int(m.group(4))
-    )
+    return _to_hhmm(int(m.group(1)), int(m.group(2))), _to_hhmm(int(m.group(3)), int(m.group(4)))
 
 
 def _end_from_start_and_hours(start_hhmm: str, hours: int) -> str:
@@ -101,14 +99,10 @@ def issues_to_analysis(
         d_str = _date_str(d)
 
         if opts.cutoff_date and d <= opts.cutoff_date:
-            skipped.append(
-                {"date": d_str, "type": _zh_type(issue.type), "reason": "<= cutoff"}
-            )
+            skipped.append({"date": d_str, "type": _zh_type(issue.type), "reason": "<= cutoff"})
             continue
         if opts.today and d > opts.today:
-            skipped.append(
-                {"date": d_str, "type": _zh_type(issue.type), "reason": "future"}
-            )
+            skipped.append({"date": d_str, "type": _zh_type(issue.type), "reason": "future"})
             continue
 
         if issue.type == IssueType.OVERTIME:
@@ -120,9 +114,7 @@ def issues_to_analysis(
             if entry:
                 leave.append(entry)
         elif issue.type == IssueType.EARLY_LEAVE:
-            entry = _make_leave_from_late(
-                issue, opts, d_str, skipped, type_hint="early_leave"
-            )
+            entry = _make_leave_from_late(issue, opts, d_str, skipped, type_hint="early_leave")
             if entry:
                 leave.append(entry)
         elif issue.type == IssueType.WFH:
@@ -153,9 +145,7 @@ def _zh_type(issue_type) -> str:
     return getattr(issue_type, "value", str(issue_type))
 
 
-def _make_overtime(
-    issue, opts: ExportOptions, d_str: str, skipped: list
-) -> dict | None:
+def _make_overtime(issue, opts: ExportOptions, d_str: str, skipped: list) -> dict | None:
     rng = _parse_time_range(issue.time_range)
     if not rng:
         skipped.append({"date": d_str, "type": "加班", "reason": "no time"})
@@ -229,9 +219,7 @@ def _make_wfh(opts: ExportOptions, d_str: str) -> dict:
     }
 
 
-def write(
-    path: str | Path, issues: Iterable, options: ExportOptions | None = None
-) -> dict:
+def write(path: str | Path, issues: Iterable, options: ExportOptions | None = None) -> dict:
     """Convenience: render + persist as pretty JSON. Returns the dict."""
     payload = issues_to_analysis(issues, options)
     Path(path).write_text(

--- a/lib/exporters/code_agent_hr.py
+++ b/lib/exporters/code_agent_hr.py
@@ -8,12 +8,15 @@ Time math:
   - overtime: hours = floor(duration_minutes / 60), >= 1
   - late / early_leave: hours = ceil(duration_minutes / 60), >= 1
   - WFH: full-day 0930-1830 / 9h (synthesised)
-  - end_time = start_time + hours * 1h  (NOT actual punch time)
+  - full_day (平日整日請假): 0930-1830 / 8h (午休不計)
+  - end_time = start_time + hours * 1h  (NOT actual punch time;
+    WFH / full_day use schedule_start~schedule_end directly)
 
 Filters:
   - drop entries on or before `cutoff_date` (last applied form)
   - drop entries strictly after `today`
 """
+
 from __future__ import annotations
 
 import json
@@ -35,10 +38,10 @@ _TIME_RANGE_RE = re.compile(r"^\s*(\d{2}):(\d{2})\s*~\s*(\d{2}):(\d{2})\s*$")
 class ExportOptions:
     """Filter / shape knobs for the exporter."""
 
-    cutoff_date: date | None = None       # drop entries with date <= cutoff
-    today: date | None = None             # drop entries with date > today
-    schedule_start_hhmm: str = "0930"     # WFH default start
-    schedule_end_hhmm: str = "1830"       # WFH default end
+    cutoff_date: date | None = None  # drop entries with date <= cutoff
+    today: date | None = None  # drop entries with date > today
+    schedule_start_hhmm: str = "0930"  # WFH default start
+    schedule_end_hhmm: str = "1830"  # WFH default end
     overtime_reason: str = "工作需要"
     leave_reason: str = "personal matter"
     wfh_reason: str = "WFH"
@@ -53,7 +56,9 @@ def _parse_time_range(time_range: str) -> tuple[str, str] | None:
     m = _TIME_RANGE_RE.match(time_range or "")
     if not m:
         return None
-    return _to_hhmm(int(m.group(1)), int(m.group(2))), _to_hhmm(int(m.group(3)), int(m.group(4)))
+    return _to_hhmm(int(m.group(1)), int(m.group(2))), _to_hhmm(
+        int(m.group(3)), int(m.group(4))
+    )
 
 
 def _end_from_start_and_hours(start_hhmm: str, hours: int) -> str:
@@ -96,10 +101,14 @@ def issues_to_analysis(
         d_str = _date_str(d)
 
         if opts.cutoff_date and d <= opts.cutoff_date:
-            skipped.append({"date": d_str, "type": _zh_type(issue.type), "reason": "<= cutoff"})
+            skipped.append(
+                {"date": d_str, "type": _zh_type(issue.type), "reason": "<= cutoff"}
+            )
             continue
         if opts.today and d > opts.today:
-            skipped.append({"date": d_str, "type": _zh_type(issue.type), "reason": "future"})
+            skipped.append(
+                {"date": d_str, "type": _zh_type(issue.type), "reason": "future"}
+            )
             continue
 
         if issue.type == IssueType.OVERTIME:
@@ -111,13 +120,17 @@ def issues_to_analysis(
             if entry:
                 leave.append(entry)
         elif issue.type == IssueType.EARLY_LEAVE:
-            entry = _make_leave_from_late(issue, opts, d_str, skipped, type_hint="early_leave")
+            entry = _make_leave_from_late(
+                issue, opts, d_str, skipped, type_hint="early_leave"
+            )
             if entry:
                 leave.append(entry)
         elif issue.type == IssueType.WFH:
             leave.append(_make_wfh(opts, d_str))
-        # FORGET_PUNCH / WEEKDAY_LEAVE etc. are not actionable through this
-        # schema today — silently ignored. Future schema bumps can add them.
+        elif issue.type == IssueType.WEEKDAY_LEAVE:
+            leave.append(_make_full_day_leave(issue, opts, d_str))
+        # FORGET_PUNCH etc. are not actionable through this schema today —
+        # silently ignored. Future schema bumps can add them.
 
     payload = {
         "cutoff_date": _date_str(opts.cutoff_date) if opts.cutoff_date else None,
@@ -140,7 +153,9 @@ def _zh_type(issue_type) -> str:
     return getattr(issue_type, "value", str(issue_type))
 
 
-def _make_overtime(issue, opts: ExportOptions, d_str: str, skipped: list) -> dict | None:
+def _make_overtime(
+    issue, opts: ExportOptions, d_str: str, skipped: list
+) -> dict | None:
     rng = _parse_time_range(issue.time_range)
     if not rng:
         skipped.append({"date": d_str, "type": "加班", "reason": "no time"})
@@ -160,8 +175,9 @@ def _make_overtime(issue, opts: ExportOptions, d_str: str, skipped: list) -> dic
     }
 
 
-def _make_leave_from_late(issue, opts: ExportOptions, d_str: str, skipped: list,
-                          *, type_hint: str) -> dict | None:
+def _make_leave_from_late(
+    issue, opts: ExportOptions, d_str: str, skipped: list, *, type_hint: str
+) -> dict | None:
     rng = _parse_time_range(issue.time_range)
     if not rng:
         zh = "遲到" if type_hint == "late" else "早退"
@@ -175,6 +191,24 @@ def _make_leave_from_late(issue, opts: ExportOptions, d_str: str, skipped: list,
         "end_time": _end_from_start_and_hours(start, hours),
         "hours": hours,
         "type_hint": type_hint,
+        "reason": opts.leave_reason,
+    }
+
+
+def _make_full_day_leave(issue, opts: ExportOptions, d_str: str) -> dict:
+    """整天請假（平日整日缺勤）：09:30~18:30，時數取 duration（午休不計）。
+
+    type_hint=full_day → cascade 走事假池（補休→特休→事假）；
+    實際假別由 portal-apply 逐筆覆寫。"""
+    start = opts.schedule_start_hhmm
+    end = opts.schedule_end_hhmm
+    hours = max(1, int(issue.duration_minutes) // 60)
+    return {
+        "date": d_str,
+        "start_time": start,
+        "end_time": end,
+        "hours": hours,
+        "type_hint": "full_day",
         "reason": opts.leave_reason,
     }
 
@@ -195,7 +229,9 @@ def _make_wfh(opts: ExportOptions, d_str: str) -> dict:
     }
 
 
-def write(path: str | Path, issues: Iterable, options: ExportOptions | None = None) -> dict:
+def write(
+    path: str | Path, issues: Iterable, options: ExportOptions | None = None
+) -> dict:
     """Convenience: render + persist as pretty JSON. Returns the dict."""
     payload = issues_to_analysis(issues, options)
     Path(path).write_text(

--- a/lib/filename.py
+++ b/lib/filename.py
@@ -12,7 +12,7 @@ def parse_range_and_user(filepath: str) -> tuple[str | None, str | None, str | N
         (user_name, start_date 'YYYY-MM-DD', end_date 'YYYY-MM-DD')
     """
     filename = os.path.basename(filepath)
-    pattern = r'(\d{6})(?:-(\d{6}))?-(.+?)-出勤資料\.txt$'
+    pattern = r"(\d{6})(?:-(\d{6}))?-(.+?)-出勤資料\.txt$"
     match = re.match(pattern, filename)
     if not match:
         return None, None, None
@@ -49,4 +49,3 @@ def parse_range_and_user(filepath: str) -> tuple[str | None, str | None, str | N
             return None, None, None
 
     return user_name, start_date, end_date
-

--- a/lib/grouping.py
+++ b/lib/grouping.py
@@ -2,6 +2,7 @@
 
 These helpers avoid importing analyzer types; they return simple dicts.
 """
+
 from collections import defaultdict
 
 
@@ -20,4 +21,3 @@ def group_daily(records: list) -> dict:
         else:
             daily[key]["checkout"] = rec
     return daily
-

--- a/lib/holidays.py
+++ b/lib/holidays.py
@@ -25,18 +25,36 @@ class Hardcoded2025Provider(HolidayProvider):
             # 元旦連假
             "2025/01/01",
             # 農曆春節
-            "2025/01/25", "2025/01/26", "2025/01/27", "2025/01/28", "2025/01/29",
-            "2025/01/30", "2025/01/31", "2025/02/01", "2025/02/02",
+            "2025/01/25",
+            "2025/01/26",
+            "2025/01/27",
+            "2025/01/28",
+            "2025/01/29",
+            "2025/01/30",
+            "2025/01/31",
+            "2025/02/01",
+            "2025/02/02",
             # 和平紀念日
-            "2025/02/28", "2025/03/01", "2025/03/02",
+            "2025/02/28",
+            "2025/03/01",
+            "2025/03/02",
             # 兒童節/清明節
-            "2025/04/03", "2025/04/04", "2025/04/05", "2025/04/06",
+            "2025/04/03",
+            "2025/04/04",
+            "2025/04/05",
+            "2025/04/06",
             # 端午節
-            "2025/05/30", "2025/05/31", "2025/06/01",
+            "2025/05/30",
+            "2025/05/31",
+            "2025/06/01",
             # 中秋節
-            "2025/10/04", "2025/10/05", "2025/10/06",
+            "2025/10/04",
+            "2025/10/05",
+            "2025/10/06",
             # 國慶日
-            "2025/10/10", "2025/10/11", "2025/10/12",
+            "2025/10/10",
+            "2025/10/11",
+            "2025/10/12",
         ]
         out: set[datetime.date] = set()
         for s in dates:
@@ -109,9 +127,14 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
             attempt += 1
             try:
                 logger.info(
-                    "資訊: 嘗試載入 %d 年假日 (第 %d/%d 次)...", year, attempt, self.max_retries
+                    "資訊: 嘗試載入 %d 年假日 (第 %d/%d 次)...",
+                    year,
+                    attempt,
+                    self.max_retries,
                 )
-                with urllib.request.urlopen(request, timeout=10, context=context) as resp:  # nosec B310
+                with urllib.request.urlopen(
+                    request, timeout=10, context=context
+                ) as resp:  # nosec B310
                     data = _json.loads(resp.read().decode("utf-8"))
                     if not isinstance(data, list):
                         logger.warning("API 回傳格式非預期（不是 list）")
@@ -137,7 +160,9 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
                     # err_desc = f"HTTP {status}"  # Variable assigned but never used
                     pass
                 else:
-                    logger.warning("無法從API載入 %d 年假日資料: HTTP %s — 不重試。", year, status)
+                    logger.warning(
+                        "無法從API載入 %d 年假日資料: HTTP %s — 不重試。", year, status
+                    )
                     return set()
             except (URLError, TimeoutError, _json.JSONDecodeError, ValueError):
                 # err_desc = f"連線/解析錯誤: {e}"  # Variable assigned but never used
@@ -149,7 +174,8 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
             if attempt > self.max_retries:
                 logger.error(
                     "錯誤: 嘗試 %d 次後仍無法載入 %d 年假日資料。回退到基本假日。",
-                    self.max_retries, year
+                    self.max_retries,
+                    year,
                 )
                 break
 
@@ -181,4 +207,3 @@ class HolidayService:
         for y in years:
             out |= self.load_year(y)
         return out
-

--- a/lib/holidays.py
+++ b/lib/holidays.py
@@ -94,9 +94,7 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
         ]
     """
 
-    JSDELIVR_URL_TEMPLATE = (
-        "https://cdn.jsdelivr.net/gh/ruyut/TaiwanCalendar/data/{year}.json"
-    )
+    JSDELIVR_URL_TEMPLATE = "https://cdn.jsdelivr.net/gh/ruyut/TaiwanCalendar/data/{year}.json"
     USER_AGENT = "fhr-attendance-analyzer/1.0 (+https://github.com/jimc1682000/fhr)"
 
     def __init__(self):
@@ -132,9 +130,7 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
                     attempt,
                     self.max_retries,
                 )
-                with urllib.request.urlopen(
-                    request, timeout=10, context=context
-                ) as resp:  # nosec B310
+                with urllib.request.urlopen(request, timeout=10, context=context) as resp:  # nosec B310
                     data = _json.loads(resp.read().decode("utf-8"))
                     if not isinstance(data, list):
                         logger.warning("API 回傳格式非預期（不是 list）")
@@ -160,9 +156,7 @@ class TaiwanGovOpenDataProvider(HolidayProvider):
                     # err_desc = f"HTTP {status}"  # Variable assigned but never used
                     pass
                 else:
-                    logger.warning(
-                        "無法從API載入 %d 年假日資料: HTTP %s — 不重試。", year, status
-                    )
+                    logger.warning("無法從API載入 %d 年假日資料: HTTP %s — 不重試。", year, status)
                     return set()
             except (URLError, TimeoutError, _json.JSONDecodeError, ValueError):
                 # err_desc = f"連線/解析錯誤: {e}"  # Variable assigned but never used

--- a/lib/importers/portal_json.py
+++ b/lib/importers/portal_json.py
@@ -17,6 +17,7 @@ Column mapping (must include header row):
   7 異常處理作業    ← ""
   8 備註            ← ""
 """
+
 from __future__ import annotations
 
 import json

--- a/lib/parser.py
+++ b/lib/parser.py
@@ -2,6 +2,7 @@
 
 Designed to be dependency-light and avoid importing analyzer types.
 """
+
 import re
 from datetime import datetime
 

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -43,18 +43,14 @@ def calculate_late_minutes(workday: Any, rules: Rules) -> tuple[int, str, str]:
         return 0, "", ""
 
     date_str = workday.date.strftime("%Y/%m/%d")
-    latest_checkin = datetime.strptime(
-        f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M"
-    )
+    latest_checkin = datetime.strptime(f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M")
     actual_checkin = ch.actual_time
 
     if actual_checkin <= latest_checkin:
         return 0, "", ""
 
     # 遲到分鐘數 = 實際到班 - 班表起始時間
-    schedule_start = datetime.strptime(
-        f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M"
-    )
+    schedule_start = datetime.strptime(f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M")
     delta = actual_checkin - schedule_start
     late_minutes = int(delta.total_seconds() // 60)
 
@@ -87,9 +83,7 @@ def calculate_leave_suggestion(
     ch = workday.checkin_record
     actual_checkin = ch.actual_time
     date_str = workday.date.strftime("%Y/%m/%d")
-    schedule_start = datetime.strptime(
-        f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M"
-    )
+    schedule_start = datetime.strptime(f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M")
     lunch_start = datetime.strptime(f"{date_str} {rules.lunch_start}", "%Y/%m/%d %H:%M")
     lunch_end = datetime.strptime(f"{date_str} {rules.lunch_end}", "%Y/%m/%d %H:%M")
 
@@ -110,9 +104,7 @@ def calculate_leave_suggestion(
     )
 
 
-def calculate_expected_checkout(
-    workday: Any, rules: Rules, work_start_time: datetime
-) -> datetime:
+def calculate_expected_checkout(workday: Any, rules: Rules, work_start_time: datetime) -> datetime:
     """計算預期下班時間
 
     遲到（>10:00）：預期下班 = 班表結束時間
@@ -127,9 +119,7 @@ def calculate_expected_checkout(
         預期下班時間
     """
     date_str = workday.date.strftime("%Y/%m/%d")
-    latest_checkin = datetime.strptime(
-        f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M"
-    )
+    latest_checkin = datetime.strptime(f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M")
 
     ch = workday.checkin_record
     actual_checkin = ch.actual_time if ch and ch.actual_time else work_start_time
@@ -172,18 +162,14 @@ def optimize_forget_punch(
     forget_end = actual_checkin
 
     # 計算使用預設時段的預期下班時間
-    expected_checkout_default = calculate_expected_checkout(
-        workday, rules, default_start
-    )
+    expected_checkout_default = calculate_expected_checkout(workday, rules, default_start)
 
     # 如果沒有早退，使用預設時段
     if actual_checkout >= expected_checkout_default:
         return default_start.strftime("%H:%M"), forget_end.strftime("%H:%M")
 
     # 有早退，嘗試優化
-    early_leave_minutes = int(
-        (expected_checkout_default - actual_checkout).total_seconds() // 60
-    )
+    early_leave_minutes = int((expected_checkout_default - actual_checkout).total_seconds() // 60)
     early_leave_hours = math.ceil(early_leave_minutes / 60)
 
     # 計算優化調整量：讓早退時間剛好湊整
@@ -219,9 +205,7 @@ def calculate_early_leave(
     early_leave_minutes = int(delta.total_seconds() // 60)
     early_leave_hours = math.ceil(early_leave_minutes / 60)
 
-    time_range = (
-        f"{actual_checkout.strftime('%H:%M')}~{expected_checkout.strftime('%H:%M')}"
-    )
+    time_range = f"{actual_checkout.strftime('%H:%M')}~{expected_checkout.strftime('%H:%M')}"
     calculation = (
         f"實際下班: {actual_checkout.strftime('%H:%M')}, "
         f"預期下班: {expected_checkout.strftime('%H:%M')}, "
@@ -259,9 +243,7 @@ def calculate_overtime_minutes(
     applicable_minutes = applicable_hours * rules.overtime_increment_minutes
 
     # 時段顯示完整實際加班時間
-    time_range = (
-        f"{expected_checkout.strftime('%H:%M')}~{actual_checkout.strftime('%H:%M')}"
-    )
+    time_range = f"{expected_checkout.strftime('%H:%M')}~{actual_checkout.strftime('%H:%M')}"
     calculation = (
         f"預期下班: {expected_checkout.strftime('%H:%M')}, "
         f"實際下班: {actual_checkout.strftime('%H:%M')}, "

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -74,7 +74,8 @@ def calculate_leave_suggestion(
 
     Returns:
         (leave_start_time, leave_end_time, leave_hours, effective_minutes)
-        leave_end_time 為「班表起始 + leave_hours」的整點請假塊；
+        leave_end_time 為涵蓋 leave_hours 個工時的請假塊終點；若塊跨午休，
+        終點會把午休時長加回（Portal 算時數時會扣午休）。
         effective_minutes 為扣午休後實際缺工分鐘（供下游算時數）。
     """
     if late_minutes <= 0:
@@ -94,7 +95,15 @@ def calculate_leave_suggestion(
     effective_minutes = max(0, late_minutes - lunch_overlap)
 
     leave_hours = math.ceil(effective_minutes / 60)
-    leave_end = schedule_start + timedelta(minutes=leave_hours * 60)
+    # 請假塊代表 leave_hours 個「工時」。換算 clock 終點時，若塊延伸進午休
+    # (naive 終點 > 午休起)，Portal 會扣掉午休，需把午休時長加回終點；
+    # 否則 09:30~13:30 會被算成 3 工時而非 4 工時（使用者會少請）。
+    naive_end = schedule_start + timedelta(minutes=leave_hours * 60)
+    if naive_end > lunch_start:
+        lunch_minutes = int((lunch_end - lunch_start).total_seconds() // 60)
+        leave_end = naive_end + timedelta(minutes=lunch_minutes)
+    else:
+        leave_end = naive_end
 
     return (
         schedule_start.strftime("%H:%M"),

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -43,14 +43,18 @@ def calculate_late_minutes(workday: Any, rules: Rules) -> tuple[int, str, str]:
         return 0, "", ""
 
     date_str = workday.date.strftime("%Y/%m/%d")
-    latest_checkin = datetime.strptime(f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M")
+    latest_checkin = datetime.strptime(
+        f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M"
+    )
     actual_checkin = ch.actual_time
 
     if actual_checkin <= latest_checkin:
         return 0, "", ""
 
     # 遲到分鐘數 = 實際到班 - 班表起始時間
-    schedule_start = datetime.strptime(f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M")
+    schedule_start = datetime.strptime(
+        f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M"
+    )
     delta = actual_checkin - schedule_start
     late_minutes = int(delta.total_seconds() // 60)
 
@@ -66,26 +70,49 @@ def calculate_late_minutes(workday: Any, rules: Rules) -> tuple[int, str, str]:
 
 def calculate_leave_suggestion(
     workday: Any, rules: Rules, late_minutes: int
-) -> tuple[str, str, int]:
+) -> tuple[str, str, int, int]:
     """計算遲到請假建議（湊整到小時）
 
+    遲到請假區間 = 班表起始 ~ 實際到班；若橫跨午休（12:30~13:30），
+    午休非工時須扣除，再無條件進位到整點。
+
     Returns:
-        (leave_start_time, leave_end_time, leave_hours)
+        (leave_start_time, leave_end_time, leave_hours, effective_minutes)
+        leave_end_time 為「班表起始 + leave_hours」的整點請假塊；
+        effective_minutes 為扣午休後實際缺工分鐘（供下游算時數）。
     """
     if late_minutes <= 0:
-        return "", "", 0
+        return "", "", 0, 0
 
     ch = workday.checkin_record
     actual_checkin = ch.actual_time
     date_str = workday.date.strftime("%Y/%m/%d")
-    schedule_start = datetime.strptime(f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M")
+    schedule_start = datetime.strptime(
+        f"{date_str} {rules.schedule_start}", "%Y/%m/%d %H:%M"
+    )
+    lunch_start = datetime.strptime(f"{date_str} {rules.lunch_start}", "%Y/%m/%d %H:%M")
+    lunch_end = datetime.strptime(f"{date_str} {rules.lunch_end}", "%Y/%m/%d %H:%M")
 
-    leave_hours = math.ceil(late_minutes / 60)
+    # 扣除遲到區間 [班表起始, 實際到班] 與午休 [lunch_start, lunch_end] 的重疊
+    overlap_start = max(schedule_start, lunch_start)
+    overlap_end = min(actual_checkin, lunch_end)
+    lunch_overlap = max(0, int((overlap_end - overlap_start).total_seconds() // 60))
+    effective_minutes = max(0, late_minutes - lunch_overlap)
 
-    return (schedule_start.strftime("%H:%M"), actual_checkin.strftime("%H:%M"), leave_hours)
+    leave_hours = math.ceil(effective_minutes / 60)
+    leave_end = schedule_start + timedelta(minutes=leave_hours * 60)
+
+    return (
+        schedule_start.strftime("%H:%M"),
+        leave_end.strftime("%H:%M"),
+        leave_hours,
+        effective_minutes,
+    )
 
 
-def calculate_expected_checkout(workday: Any, rules: Rules, work_start_time: datetime) -> datetime:
+def calculate_expected_checkout(
+    workday: Any, rules: Rules, work_start_time: datetime
+) -> datetime:
     """計算預期下班時間
 
     遲到（>10:00）：預期下班 = 班表結束時間
@@ -100,7 +127,9 @@ def calculate_expected_checkout(workday: Any, rules: Rules, work_start_time: dat
         預期下班時間
     """
     date_str = workday.date.strftime("%Y/%m/%d")
-    latest_checkin = datetime.strptime(f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M")
+    latest_checkin = datetime.strptime(
+        f"{date_str} {rules.latest_checkin}", "%Y/%m/%d %H:%M"
+    )
 
     ch = workday.checkin_record
     actual_checkin = ch.actual_time if ch and ch.actual_time else work_start_time
@@ -143,14 +172,18 @@ def optimize_forget_punch(
     forget_end = actual_checkin
 
     # 計算使用預設時段的預期下班時間
-    expected_checkout_default = calculate_expected_checkout(workday, rules, default_start)
+    expected_checkout_default = calculate_expected_checkout(
+        workday, rules, default_start
+    )
 
     # 如果沒有早退，使用預設時段
     if actual_checkout >= expected_checkout_default:
         return default_start.strftime("%H:%M"), forget_end.strftime("%H:%M")
 
     # 有早退，嘗試優化
-    early_leave_minutes = int((expected_checkout_default - actual_checkout).total_seconds() // 60)
+    early_leave_minutes = int(
+        (expected_checkout_default - actual_checkout).total_seconds() // 60
+    )
     early_leave_hours = math.ceil(early_leave_minutes / 60)
 
     # 計算優化調整量：讓早退時間剛好湊整
@@ -186,7 +219,9 @@ def calculate_early_leave(
     early_leave_minutes = int(delta.total_seconds() // 60)
     early_leave_hours = math.ceil(early_leave_minutes / 60)
 
-    time_range = f"{actual_checkout.strftime('%H:%M')}~{expected_checkout.strftime('%H:%M')}"
+    time_range = (
+        f"{actual_checkout.strftime('%H:%M')}~{expected_checkout.strftime('%H:%M')}"
+    )
     calculation = (
         f"實際下班: {actual_checkout.strftime('%H:%M')}, "
         f"預期下班: {expected_checkout.strftime('%H:%M')}, "
@@ -224,7 +259,9 @@ def calculate_overtime_minutes(
     applicable_minutes = applicable_hours * rules.overtime_increment_minutes
 
     # 時段顯示完整實際加班時間
-    time_range = f"{expected_checkout.strftime('%H:%M')}~{actual_checkout.strftime('%H:%M')}"
+    time_range = (
+        f"{expected_checkout.strftime('%H:%M')}~{actual_checkout.strftime('%H:%M')}"
+    )
     calculation = (
         f"預期下班: {expected_checkout.strftime('%H:%M')}, "
         f"實際下班: {actual_checkout.strftime('%H:%M')}, "

--- a/lib/portal/apply_forms.py
+++ b/lib/portal/apply_forms.py
@@ -10,6 +10,7 @@ Each `submit_*` returns True / False — the Portal doesn't expose a clean
 post-submit confirmation other than the form becoming `disabled` + a
 form ID showing up in the snapshot, so we use the same heuristic from
 the original implementation."""
+
 from __future__ import annotations
 
 import logging
@@ -31,8 +32,11 @@ def _snap_filename(form_type: str, entry: dict, seq: int) -> str:
 
 
 def _take_dry_run_screenshot(
-    portal: PortalSession, screenshot_dir: Path | None,
-    form_type: str, entry: dict, seq: int,
+    portal: PortalSession,
+    screenshot_dir: Path | None,
+    form_type: str,
+    entry: dict,
+    seq: int,
 ) -> Path | None:
     if screenshot_dir is None:
         return None
@@ -54,7 +58,8 @@ def _open_form(portal: PortalSession, base_url: str, form_name_zh: str) -> None:
     portal.open(f"{base_url}{FORM_QUEUES_URL_PATH}")
     portal.wait(3000)
     escaped = js_escape(form_name_zh)
-    result = portal.eval_json(f"""
+    result = portal.eval_json(
+        f"""
     (function() {{
         const cells = document.querySelectorAll('td');
         for (const c of cells) {{
@@ -65,16 +70,20 @@ def _open_form(portal: PortalSession, base_url: str, form_name_zh: str) -> None:
         }}
         return {{error: '{escaped} not found'}};
     }})()
-    """)
+    """
+    )
     if not isinstance(result, dict) or not result.get("success"):
         raise RuntimeError(f"無法開啟表單 {form_name_zh}: {result!r}")
     portal.wait(3000)
 
 
-def _fill_datetime(portal: PortalSession, date: str, start_time: str, end_time: str) -> None:
+def _fill_datetime(
+    portal: PortalSession, date: str, start_time: str, end_time: str
+) -> None:
     """Populate StartDate / StartTime / EndDate / EndTime fields via eval."""
     escaped_date = js_escape(date)
-    portal.eval_json(f"""
+    portal.eval_json(
+        f"""
     (function() {{
         const sd = document.querySelector('input[name*="StartDate"]');
         const st = document.querySelector('input[name*="StartTime"]');
@@ -89,26 +98,30 @@ def _fill_datetime(portal: PortalSession, date: str, start_time: str, end_time: 
         }}
         return {{ok: true}};
     }})()
-    """)
+    """
+    )
     portal.wait(1000)
 
 
 def _trigger_hour_calc(portal: PortalSession) -> None:
     """Fire change+blur on every *Time input so the Portal recomputes 合計時數."""
-    portal.eval_json("""
+    portal.eval_json(
+        """
     document.querySelectorAll('input').forEach(i => {
         if (i.name && i.name.includes('Time')) {
             i.dispatchEvent(new Event('change', {bubbles: true}));
             i.dispatchEvent(new Event('blur', {bubbles: true}));
         }
     });
-    """)
+    """
+    )
     portal.wait(2000)
 
 
 def _click_submit(portal: PortalSession) -> None:
     """Recursively walk every iframe to find and click the 確定送出 button."""
-    portal.eval_json("""
+    portal.eval_json(
+        """
     (function() {
         function findAndClick(doc) {
             const btns = Array.from(doc.querySelectorAll(
@@ -124,7 +137,8 @@ def _click_submit(portal: PortalSession) -> None:
         }
         return findAndClick(document);
     })()
-    """)
+    """
+    )
     portal.wait(2000)
     portal.dialog_accept()
     portal.wait(1000)
@@ -162,15 +176,23 @@ def submit_overtime(
     date = entry["date"]
     start = entry["start_time"]
     end = entry["end_time"]
-    logger.info("📝 加班單%s: %s %s:%s-%s:%s (%dh)",
-                " [DRY RUN]" if dry_run else "",
-                date, start[:2], start[2:], end[:2], end[2:], entry.get("hours", 0))
+    logger.info(
+        "📝 加班單%s: %s %s:%s-%s:%s (%dh)",
+        " [DRY RUN]" if dry_run else "",
+        date,
+        start[:2],
+        start[2:],
+        end[:2],
+        end[2:],
+        entry.get("hours", 0),
+    )
 
     _open_form(portal, base_url, "加班單")
     _fill_datetime(portal, date, start, end)
 
     location = js_escape(entry.get("location", "在辦公室"))
-    portal.eval_json(f"""
+    portal.eval_json(
+        f"""
     (function() {{
         const selects = document.querySelectorAll('select');
         for (const sel of selects) {{
@@ -188,11 +210,13 @@ def submit_overtime(
         }}
         return true;
     }})()
-    """)
+    """
+    )
     portal.wait(1000)
 
     escaped_reason = js_escape(reason)
-    portal.eval_json(f"""
+    portal.eval_json(
+        f"""
     (function() {{
         const tb = document.getElementById('OVERTIME_REASON_TextBox1');
         if (tb) {{
@@ -202,14 +226,18 @@ def submit_overtime(
         }}
         return true;
     }})()
-    """)
+    """
+    )
     portal.wait(1000)
     _trigger_hour_calc(portal)
     if dry_run:
-        _take_dry_run_screenshot(portal, screenshot_dir, "overtime",
-                                 entry, screenshot_seq)
-        logger.info("    ✋ DRY RUN: 表單已填寫完成,請瀏覽器手動檢查 (%ds)...",
-                    dry_run_pause_secs)
+        _take_dry_run_screenshot(
+            portal, screenshot_dir, "overtime", entry, screenshot_seq
+        )
+        logger.info(
+            "    ✋ DRY RUN: 表單已填寫完成,請瀏覽器手動檢查 (%ds)...",
+            dry_run_pause_secs,
+        )
         portal.wait(dry_run_pause_secs * 1000)
         return True
     _click_submit(portal)
@@ -242,17 +270,25 @@ def submit_leave(
     date = entry["date"]
     start = entry["start_time"]
     end = entry["end_time"]
-    logger.info("📝 請假單%s: %s %s:%s-%s:%s (%dh) [%s]",
-                " [DRY RUN]" if dry_run else "",
-                date, start[:2], start[2:], end[:2], end[2:],
-                entry.get("hours", 0), leave_type_name)
+    logger.info(
+        "📝 請假單%s: %s %s:%s-%s:%s (%dh) [%s]",
+        " [DRY RUN]" if dry_run else "",
+        date,
+        start[:2],
+        start[2:],
+        end[:2],
+        end[2:],
+        entry.get("hours", 0),
+        leave_type_name,
+    )
 
     _open_form(portal, base_url, "請假單")
 
     is_wfh = "異地辦公" in leave_type_name
     if not is_wfh and proxy_employee:
         escaped_proxy = js_escape(proxy_employee)
-        portal.eval_json(f"""
+        portal.eval_json(
+            f"""
         (function() {{
             const sel = document.getElementById('AGENT_ID_ddlDelegate');
             if (sel) {{
@@ -266,11 +302,13 @@ def submit_leave(
             }}
             return true;
         }})()
-        """)
+        """
+        )
         portal.wait(1000)
 
     escaped_leave = js_escape(leave_type_name)
-    match = portal.eval_json(f"""
+    match = portal.eval_json(
+        f"""
     (function() {{
         const sel = document.getElementById('LEAVE_CLASS_DropDownList1');
         if (!sel) return {{error: 'select not found', matched: 0}};
@@ -288,7 +326,8 @@ def submit_leave(
         }}
         return {{matched: matches.length, matches: matches}};
     }})()
-    """)
+    """
+    )
     if isinstance(match, dict):
         matched = match.get("matched", 0)
         if matched == 0:
@@ -296,7 +335,9 @@ def submit_leave(
             return False
         if matched > 1:
             options = [m.get("text") for m in match.get("matches", [])]
-            logger.error("    ❌ 假別 %s 匹配多個 %s，跳過此單", leave_type_name, options)
+            logger.error(
+                "    ❌ 假別 %s 匹配多個 %s，跳過此單", leave_type_name, options
+            )
             return False
     portal.wait(3000)
 
@@ -304,7 +345,8 @@ def submit_leave(
     _trigger_hour_calc(portal)
 
     escaped_reason = js_escape(reason)
-    portal.eval_json(f"""
+    portal.eval_json(
+        f"""
     (function() {{
         let field = document.querySelector('textarea[id*="REASON"], input[id*="REASON"]');
         if (!field) {{
@@ -322,13 +364,15 @@ def submit_leave(
         }}
         return true;
     }})()
-    """)
+    """
+    )
     portal.wait(1000)
     if dry_run:
-        _take_dry_run_screenshot(portal, screenshot_dir, "leave",
-                                 entry, screenshot_seq)
-        logger.info("    ✋ DRY RUN: 表單已填寫完成,請瀏覽器手動檢查 (%ds)...",
-                    dry_run_pause_secs)
+        _take_dry_run_screenshot(portal, screenshot_dir, "leave", entry, screenshot_seq)
+        logger.info(
+            "    ✋ DRY RUN: 表單已填寫完成,請瀏覽器手動檢查 (%ds)...",
+            dry_run_pause_secs,
+        )
         portal.wait(dry_run_pause_secs * 1000)
         return True
     _click_submit(portal)
@@ -364,9 +408,14 @@ def batch_submit(
             continue
         ot_total += 1
         ok = submit_overtime(
-            portal, base_url, plan["entry"], plan["reason"],
-            dry_run=dry_run, dry_run_pause_secs=dry_run_pause_secs,
-            screenshot_dir=screenshot_dir, screenshot_seq=ot_total,
+            portal,
+            base_url,
+            plan["entry"],
+            plan["reason"],
+            dry_run=dry_run,
+            dry_run_pause_secs=dry_run_pause_secs,
+            screenshot_dir=screenshot_dir,
+            screenshot_seq=ot_total,
         )
         if ok:
             ot_ok += 1
@@ -379,10 +428,14 @@ def batch_submit(
             continue
         lv_total += 1
         ok = submit_leave(
-            portal, base_url, plan["entry"],
-            plan["leave_type"], plan["reason"],
+            portal,
+            base_url,
+            plan["entry"],
+            plan["leave_type"],
+            plan["reason"],
             plan.get("proxy"),
-            dry_run=dry_run, dry_run_pause_secs=dry_run_pause_secs,
+            dry_run=dry_run,
+            dry_run_pause_secs=dry_run_pause_secs,
             screenshot_dir=screenshot_dir,
             screenshot_seq=ot_total + lv_total,
         )

--- a/lib/portal/apply_forms.py
+++ b/lib/portal/apply_forms.py
@@ -77,9 +77,7 @@ def _open_form(portal: PortalSession, base_url: str, form_name_zh: str) -> None:
     portal.wait(3000)
 
 
-def _fill_datetime(
-    portal: PortalSession, date: str, start_time: str, end_time: str
-) -> None:
+def _fill_datetime(portal: PortalSession, date: str, start_time: str, end_time: str) -> None:
     """Populate StartDate / StartTime / EndDate / EndTime fields via eval."""
     escaped_date = js_escape(date)
     portal.eval_json(
@@ -231,9 +229,7 @@ def submit_overtime(
     portal.wait(1000)
     _trigger_hour_calc(portal)
     if dry_run:
-        _take_dry_run_screenshot(
-            portal, screenshot_dir, "overtime", entry, screenshot_seq
-        )
+        _take_dry_run_screenshot(portal, screenshot_dir, "overtime", entry, screenshot_seq)
         logger.info(
             "    ✋ DRY RUN: 表單已填寫完成,請瀏覽器手動檢查 (%ds)...",
             dry_run_pause_secs,
@@ -335,9 +331,7 @@ def submit_leave(
             return False
         if matched > 1:
             options = [m.get("text") for m in match.get("matches", [])]
-            logger.error(
-                "    ❌ 假別 %s 匹配多個 %s，跳過此單", leave_type_name, options
-            )
+            logger.error("    ❌ 假別 %s 匹配多個 %s，跳過此單", leave_type_name, options)
             return False
     portal.wait(3000)
 

--- a/lib/portal/approvals.py
+++ b/lib/portal/approvals.py
@@ -22,9 +22,7 @@ from lib.portal.client import PortalSession
 
 logger = logging.getLogger(__name__)
 
-FORM_LIST_URL_PATH = (
-    "/eWorkFlow/eWorkFlow_NewRed.asp?URL=~/Workflow_Frontend/Search/Default.aspx"
-)
+FORM_LIST_URL_PATH = "/eWorkFlow/eWorkFlow_NewRed.asp?URL=~/Workflow_Frontend/Search/Default.aspx"
 
 # Maps each (form-name, JS-side filter-value) pair we care about.
 FORM_NAMES = {

--- a/lib/portal/approvals.py
+++ b/lib/portal/approvals.py
@@ -11,6 +11,7 @@ For multi-month dedup we still iterate every page (the Portal has its
 own 全部 / 已核准 / 未處理 filter). Pagination follows the same
 select-dropdown trick as attendance scraping.
 """
+
 from __future__ import annotations
 
 import logging
@@ -49,47 +50,34 @@ _RE_OT_LOCATION = re.compile(r"加班地點[：:]\s*(.+)")
 _RE_REASON = re.compile(r"(加班原因|請假原因)[：:]\s*(.+)")
 _RE_STATUS = re.compile(r"(目前狀態|簽核狀態|表單狀態)[：:]\s*(.+)")
 
-# JS that pulls every row's wsdinfotext and current page's controls.
-# Returns the raw `<tr>` payloads — Python parses them.
-_LIST_ALL_PAGES_JS = """
+# JS that reads ONE page of the form list (and reports totalPages).
+# Navigating + parsing 25 pages inside a single eval kept the daemon busy
+# long enough to time out / go unresponsive, so the Python side drives the
+# pagination instead — one short eval per page. `__PAGE__` is substituted
+# with the target page index before each call.
+_READ_PAGE_JS = """
 (async () => {
   const iframes = document.querySelectorAll('iframe');
   if (iframes.length === 0) return {error: 'No iframe found'};
   const dataFrame = iframes[iframes.length - 1];
-
-  function rowsIn(doc) {
-    const rows = doc.querySelectorAll('tr[id^="tbWorkSheetDataList_"]');
-    return Array.from(rows).map(r => ({
-      id: r.id || '',
-      wsdinfotext: r.getAttribute('wsdinfotext') || ''
-    }));
-  }
-
   let doc = dataFrame.contentDocument;
   if (!doc) return {error: 'Cannot access iframe contentDocument'};
 
+  const target = __PAGE__;
   const sel = doc.querySelector('select');
   const totalPages = sel ? sel.options.length : 1;
-  const out = [];
-  const seen = new Set();
 
-  for (let i = 0; i < totalPages; i++) {
+  if (sel && sel.selectedIndex !== target) {
+    sel.selectedIndex = target;
+    sel.dispatchEvent(new Event('change', {bubbles: true}));
+    await new Promise(r => setTimeout(r, 1500));
     doc = dataFrame.contentDocument;
-    const pageSel = doc.querySelector('select');
-    if (pageSel && i > 0) {
-      pageSel.selectedIndex = i;
-      pageSel.dispatchEvent(new Event('change', {bubbles: true}));
-      await new Promise(r => setTimeout(r, 1500));
-      doc = dataFrame.contentDocument;
-    }
-    for (const r of rowsIn(doc)) {
-      if (r.id && !seen.has(r.id)) {
-        seen.add(r.id);
-        out.push(r);
-      }
-    }
   }
-  return {totalPages, rows: out};
+
+  const rows = Array.from(
+    doc.querySelectorAll('tr[id^="tbWorkSheetDataList_"]')
+  ).map(r => ({id: r.id || '', wsdinfotext: r.getAttribute('wsdinfotext') || ''}));
+  return {totalPages, page: target, rows};
 })()
 """
 
@@ -109,8 +97,8 @@ def parse_wsdinfotext(text: str) -> dict | None:
     status = _RE_STATUS.search(text or "")
 
     return {
-        "date": start.group(1),                              # YYYY/MM/DD
-        "start_time": start.group(2).replace(":", ""),       # HHMM
+        "date": start.group(1),  # YYYY/MM/DD
+        "start_time": start.group(2).replace(":", ""),  # HHMM
         "end_date": end.group(1) if end else start.group(1),
         "end_time": end.group(2).replace(":", "") if end else "",
         "hours": int(hours.group(1)) if hours else None,
@@ -146,8 +134,10 @@ def _extract_filter_refs(snapshot: str) -> dict[str, str]:
             ref = "@" + line.split("ref=")[1].split("]")[0]
             comboboxes.append(ref)
         if (
-            'button "提交"' in line and "[disabled" not in line
-            and "ref=" in line and "submit" not in refs
+            'button "提交"' in line
+            and "[disabled" not in line
+            and "ref=" in line
+            and "submit" not in refs
         ):
             refs["submit"] = "@" + line.split("ref=")[1].split("]")[0]
     if len(comboboxes) < 2 or "submit" not in refs:
@@ -162,25 +152,46 @@ def fetch_form_entries(
     base_url: str,
     form_name_zh: str,
 ) -> list[dict]:
-    """Return parsed entries for a single form type (e.g. "加班單")."""
+    """Return parsed entries for a single form type (e.g. "加班單").
+
+    Pages are read one short eval at a time (Python drives pagination) so a
+    long form list doesn't tie up the agent-browser daemon."""
     portal.open(f"{base_url}{FORM_LIST_URL_PATH}")
     portal.wait(2500)
     _set_form_filter(portal, form_name_zh)
 
-    result = portal.eval_json(_LIST_ALL_PAGES_JS)
-    if not isinstance(result, dict) or "rows" not in result:
-        raise RuntimeError(f"eval 失敗或回傳格式異常: {result!r}")
-    if "error" in result:
-        raise RuntimeError(f"eval 回報錯誤: {result['error']}")
+    def _read_page(idx: int) -> dict:
+        result = portal.eval_json(_READ_PAGE_JS.replace("__PAGE__", str(idx)))
+        if isinstance(result, dict) and "error" in result:
+            raise RuntimeError(f"eval 回報錯誤: {result['error']}")
+        if not isinstance(result, dict) or "rows" not in result:
+            raise RuntimeError(f"eval 失敗或回傳格式異常: {result!r}")
+        return result
 
     entries: list[dict] = []
-    for row in result["rows"]:
-        parsed = parse_wsdinfotext(row.get("wsdinfotext", ""))
-        if parsed is None:
-            continue
-        parsed["row_id"] = row.get("id", "")
-        entries.append(parsed)
-    logger.info("✅ %s: %d 筆", form_name_zh, len(entries))
+    seen: set[str] = set()
+
+    first = _read_page(0)
+    total_pages = int(first.get("totalPages", 1) or 1)
+
+    def _collect(rows: list[dict]) -> None:
+        for row in rows:
+            rid = row.get("id", "")
+            if rid and rid in seen:
+                continue
+            if rid:
+                seen.add(rid)
+            parsed = parse_wsdinfotext(row.get("wsdinfotext", ""))
+            if parsed is None:
+                continue
+            parsed["row_id"] = rid
+            entries.append(parsed)
+
+    _collect(first["rows"])
+    for idx in range(1, total_pages):
+        _collect(_read_page(idx)["rows"])
+
+    logger.info("✅ %s: %d 筆 (%d 頁)", form_name_zh, len(entries), total_pages)
     return entries
 
 

--- a/lib/portal/attendance.py
+++ b/lib/portal/attendance.py
@@ -13,6 +13,7 @@ on the Portal — see `docs/personal-query.md`).
 Reused from `code_agent_hr/scripts/personal/fetch_data.py` with light
 cleanup (no behavior change in the JS).
 """
+
 from __future__ import annotations
 
 import logging
@@ -82,8 +83,13 @@ _PAGINATE_AND_EXTRACT_JS = """
 """
 
 
-def _set_query_form(portal: PortalSession, start_year: int, start_month: int,
-                    end_year: int, end_month: int) -> None:
+def _set_query_form(
+    portal: PortalSession,
+    start_year: int,
+    start_month: int,
+    end_year: int,
+    end_month: int,
+) -> None:
     """Populate the date range + data-type dropdowns + click the search button.
 
     We fetch fresh refs each call because snapshot refs go stale on navigation.
@@ -97,7 +103,7 @@ def _set_query_form(portal: PortalSession, start_year: int, start_month: int,
 
     # 起始 / 結束年份
     portal._run(["fill", refs["start_year"], str(start_year)])  # noqa: SLF001
-    portal._run(["fill", refs["end_year"], str(end_year)])      # noqa: SLF001
+    portal._run(["fill", refs["end_year"], str(end_year)])  # noqa: SLF001
     portal.select_ref(refs["start_month"], str(start_month))
     portal.select_ref(refs["end_month"], str(end_month))
     portal.select_ref(refs["data_type"], "全部刷卡資料")
@@ -169,8 +175,13 @@ def fetch_snapshot(
 ) -> dict[str, Any]:
     """Drive the Portal and return a `portal-attendance-snapshot/v1` payload."""
     url = f"{base_url}{ATTENDANCE_URL_PATH}"
-    logger.info("📡 正在查詢出勤紀錄 (%d/%02d ~ %d/%02d)...",
-                start_year, start_month, end_year, end_month)
+    logger.info(
+        "📡 正在查詢出勤紀錄 (%d/%02d ~ %d/%02d)...",
+        start_year,
+        start_month,
+        end_year,
+        end_month,
+    )
     portal.open(url)
     portal.wait(1500)
     _set_query_form(portal, start_year, start_month, end_year, end_month)
@@ -207,9 +218,12 @@ def fetch_to_txt(
     Returns the record count so callers can log it.
     """
     snapshot = fetch_snapshot(
-        portal, base_url,
-        start_year=start_year, start_month=start_month,
-        end_year=end_year, end_month=end_month,
+        portal,
+        base_url,
+        start_year=start_year,
+        start_month=start_month,
+        end_year=end_year,
+        end_month=end_month,
     )
     write_txt(out_txt, snapshot["records"])
     return len(snapshot["records"])

--- a/lib/portal/balances.py
+++ b/lib/portal/balances.py
@@ -23,9 +23,7 @@ from lib.portal.client import PortalSession, js_escape
 
 logger = logging.getLogger(__name__)
 
-FORM_QUEUES_URL_PATH = (
-    "/eWorkFlow/eWorkFlow_NewRed.asp?URL=~/Workflow_Frontend/Queues/Default.aspx"
-)
+FORM_QUEUES_URL_PATH = "/eWorkFlow/eWorkFlow_NewRed.asp?URL=~/Workflow_Frontend/Queues/Default.aspx"
 
 # Lower-cased numbers like "1 小時" / "0 工作天" parsed into typed pieces.
 _RE_HOURS = re.compile(r"^\s*(\d+)\s*小時\s*$")
@@ -135,9 +133,7 @@ def parse_items_panel(rows: list[list[str]]) -> dict[str, dict]:
     # Metric rows follow the header in fixed order; keep only same-width rows.
     metric_rows = [r for r in rows[h + 1 :] if len(r) == width][:4]
     by_key: dict[str, list[str]] = {}
-    for key, r in zip(
-        ("total", "current", "used", "remaining"), metric_rows, strict=False
-    ):
+    for key, r in zip(("total", "current", "used", "remaining"), metric_rows, strict=False):
         by_key[key] = r
 
     out: dict[str, dict] = {}

--- a/lib/portal/balances.py
+++ b/lib/portal/balances.py
@@ -13,6 +13,7 @@ we click the 請假單 cell to open the form. agent-browser snapshot refs
 can't be used here because clicking the cell requires a real DOM event
 that the snapshot ref doesn't expose — we shell out via eval.
 """
+
 from __future__ import annotations
 
 import logging
@@ -103,42 +104,55 @@ def _parse_hours(text: str) -> int | None:
 def parse_items_panel(rows: list[list[str]]) -> dict[str, dict]:
     """Convert the items-panel cell matrix into {leave_name: {可休總, 已休, 剩餘}}.
 
-    The Portal renders the panel as a fixed layout:
-      row 0: ["", 加班, 補休假, 事假..., 異地辦公(8hr一週), 生日假]  # header
-      row 1: [可休總時數, "", "8 小時", "", ..., "40 小時 / 1 月", ...]
-      row 2: [已休(加班)時數, "15 小時", "1 小時", "50 小時", ..., "0 工作天"]
-      row 3: [剩餘時數, "", "7 小時", "", ..., "1 工作天"]
+    The Portal wraps the real grid in nested tables, so the rows we get back
+    are noisy: a flattened blob row, the four metric labels each on their own
+    single-cell row, then the clean grid. The clean grid is:
+      header:   [加班, 補休假, 事假..., 異地辦公(8hr一週), 生日假]   # leave names
+      +1 可休總時數:  ["", "28 小時", "", ..., "40 小時 / 1 月", ...]
+      +2 目前可休時數: [...]                                     # often blank
+      +3 已休(加班)時數: ["43 小時", "0 小時", "50 小時", ...]
+      +4 剩餘時數:    ["", "28 小時", "", "0 小時", ...]
 
-    We index by the header row's column names so the parser keeps working
-    if the Portal ever reorders columns.
+    We locate the header row dynamically (the row that carries 補休假 as its
+    own cell) and read the following metric rows positionally — the Portal
+    never attaches the metric label to the data row, so order is the only
+    anchor. Columns without a 小時 value (事假/半薪病假 = legal, no cap) stay
+    None, which the cascade treats as unlimited.
     """
-    if len(rows) < 4:
+    # Header = the leave-name row. Its first cell is always 加班 and it
+    # carries 補休假 as a standalone cell. The flattened blob row also
+    # contains "補休假" (as a substring inside a tab-joined cell) and can be
+    # 60+ cells wide, so match on r[0] == "加班" to avoid picking it up.
+    h = None
+    for i, r in enumerate(rows):
+        if r and r[0] == "加班" and "補休假" in r:
+            h = i
+            break
+    if h is None:
         return {}
-    headers = rows[0]
+    headers = rows[h]
+    width = len(headers)
+    # Metric rows follow the header in fixed order; keep only same-width rows.
+    metric_rows = [r for r in rows[h + 1 :] if len(r) == width][:4]
+    by_key: dict[str, list[str]] = {}
+    for key, r in zip(
+        ("total", "current", "used", "remaining"), metric_rows, strict=False
+    ):
+        by_key[key] = r
+
     out: dict[str, dict] = {}
     for col, name in enumerate(headers):
-        if not name or col == 0:
+        if not name:
             continue
         entry: dict[str, str | int | None] = {}
-        for row, key in (
-            (1, "total"),
-            (2, "used"),
-            (3, "remaining"),
-        ):
-            if row >= len(rows) or col >= len(rows[row]):
-                entry[key] = None
-                continue
-            raw = rows[row][col]
+        for key in ("total", "used", "remaining"):
+            r = by_key.get(key)
+            raw = r[col] if r and col < len(r) else ""
             if not raw:
                 entry[key] = None
                 continue
-            hours = _parse_hours(raw)
-            if hours is not None:
-                entry[key] = hours
-                entry[f"{key}_raw"] = raw
-            else:
-                entry[key] = None
-                entry[f"{key}_raw"] = raw
+            entry[key] = _parse_hours(raw)
+            entry[f"{key}_raw"] = raw
         out[name] = entry
     return out
 

--- a/lib/portal/client.py
+++ b/lib/portal/client.py
@@ -26,6 +26,7 @@ login page in headed mode and POLLS the current URL until it changes
 away from the login screen. The user types their password directly
 into the browser window.
 """
+
 from __future__ import annotations
 
 import json
@@ -90,8 +91,9 @@ class PortalSession:
     that want a hard reset can call `close()` explicitly.
     """
 
-    def __init__(self, session: str | None = None, *, check: bool = True,
-                 timeout_secs: int = 30):
+    def __init__(
+        self, session: str | None = None, *, check: bool = True, timeout_secs: int = 30
+    ):
         self.session = session or _default_session()
         self.timeout_secs = timeout_secs
         if check:
@@ -99,8 +101,9 @@ class PortalSession:
 
     # ---------- subprocess primitives ----------
 
-    def _run(self, args: list[str], *, timeout: int | None = None,
-             capture: bool = True) -> str:
+    def _run(
+        self, args: list[str], *, timeout: int | None = None, capture: bool = True
+    ) -> str:
         cmd = [_binary(), *args, "--session", self.session]
         try:
             result = subprocess.run(
@@ -247,8 +250,13 @@ def is_logged_in(portal: PortalSession, base_url: str) -> bool:
     return "/ehrPortal/" in url or "/WorkflowWeb/" in url
 
 
-def ensure_login(portal: PortalSession, base_url: str, *,
-                 max_wait_secs: int = 600, poll_interval_secs: int = 3) -> None:
+def ensure_login(
+    portal: PortalSession,
+    base_url: str,
+    *,
+    max_wait_secs: int = 600,
+    poll_interval_secs: int = 3,
+) -> None:
     """If not logged in, open the login page in headed mode and poll
     until the URL transitions away. Raises `LoginTimeout` if the user
     never logs in within `max_wait_secs`."""
@@ -263,8 +271,11 @@ def ensure_login(portal: PortalSession, base_url: str, *,
     while time.time() < deadline:
         time.sleep(poll_interval_secs)
         url = portal.get_url() or ""
-        if url and "login" not in url.lower() and "loginf" not in url.lower() and (
-            "/ehrPortal/" in url or "/WorkflowWeb/" in url
+        if (
+            url
+            and "login" not in url.lower()
+            and "loginf" not in url.lower()
+            and ("/ehrPortal/" in url or "/WorkflowWeb/" in url)
         ):
             logger.info("\n🎉 登入成功 (session=%s)", portal.session)
             time.sleep(1)

--- a/lib/portal/client.py
+++ b/lib/portal/client.py
@@ -91,9 +91,7 @@ class PortalSession:
     that want a hard reset can call `close()` explicitly.
     """
 
-    def __init__(
-        self, session: str | None = None, *, check: bool = True, timeout_secs: int = 30
-    ):
+    def __init__(self, session: str | None = None, *, check: bool = True, timeout_secs: int = 30):
         self.session = session or _default_session()
         self.timeout_secs = timeout_secs
         if check:
@@ -101,9 +99,7 @@ class PortalSession:
 
     # ---------- subprocess primitives ----------
 
-    def _run(
-        self, args: list[str], *, timeout: int | None = None, capture: bool = True
-    ) -> str:
+    def _run(self, args: list[str], *, timeout: int | None = None, capture: bool = True) -> str:
         cmd = [_binary(), *args, "--session", self.session]
         try:
             result = subprocess.run(

--- a/lib/reasons.py
+++ b/lib/reasons.py
@@ -14,6 +14,7 @@ mechanism we explicitly DON'T want. Instead, the agent skill
 queries Slack via its own MCP tools and merges the two
 sources at write time.
 """
+
 from __future__ import annotations
 
 import logging
@@ -29,12 +30,16 @@ DEFAULT_GIT_REPO_ROOTS: tuple[str, ...] = ("~/git", "~/workdir", "~/github")
 DEFAULT_AUTHORS: tuple[str, ...] = ()  # caller must supply
 
 
-def discover_repos(roots: Iterable[str]) -> list[Path]:
+def discover_repos(roots: Iterable[str], *, exclude: Iterable[str] = ()) -> list[Path]:
     """Return every immediate subdir of `roots` that looks like a git repo.
 
     We look two levels deep (`<root>/*/.git` and `<root>/*/*/.git`) — that
     matches how the user organizes work (`~/git/<repo>`, `~/github/<owner>/<repo>`).
+
+    `exclude` is a set of repo *directory names* (basename, case-insensitive)
+    to skip — used to keep personal side-projects out of work reason evidence.
     """
+    excluded = {e.lower() for e in exclude}
     out: list[Path] = []
     seen: set[str] = set()
     for r in roots:
@@ -43,6 +48,8 @@ def discover_repos(roots: Iterable[str]) -> list[Path]:
             continue
         for candidate in (*root.glob("*/.git"), *root.glob("*/*/.git")):
             repo = candidate.parent.resolve()
+            if repo.name.lower() in excluded:
+                continue
             key = str(repo)
             if key in seen:
                 continue
@@ -55,7 +62,10 @@ def _git(repo: Path, *args: str) -> str:
     try:
         result = subprocess.run(
             ["git", "-C", str(repo), *args],
-            capture_output=True, text=True, timeout=10, check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return ""
@@ -88,8 +98,10 @@ def commits_on(
         return []
     raw = _git(
         repo,
-        "log", *author_flags,
-        f"--since={since}", f"--until={until}",
+        "log",
+        *author_flags,
+        f"--since={since}",
+        f"--until={until}",
         "--pretty=format:%H%x00%aI%x00%s",
     )
     out: list[dict] = []
@@ -98,7 +110,9 @@ def commits_on(
         if len(parts) != 3:
             continue
         sha, iso, subject = parts
-        out.append({"repo": repo.name, "sha": sha[:10], "time": iso, "subject": subject})
+        out.append(
+            {"repo": repo.name, "sha": sha[:10], "time": iso, "subject": subject}
+        )
     return out
 
 
@@ -108,14 +122,17 @@ def harvest_dates(
     *,
     roots: Iterable[str] = DEFAULT_GIT_REPO_ROOTS,
     after_time: str = "00:00",
+    exclude_repos: Iterable[str] = (),
 ) -> dict[str, list[dict]]:
     """For each date, scan every repo and collect commits.
 
     `after_time` is "HH:MM" — used to filter commits earlier than the user's
     schedule_end when only evening overtime evidence is wanted. Default 00:00
     (no time filter) so callers explicitly opt in.
+
+    `exclude_repos` skips repos by directory name (e.g. personal side-projects).
     """
-    repos = discover_repos(list(roots))
+    repos = discover_repos(list(roots), exclude=exclude_repos)
     out: dict[str, list[dict]] = {}
     for d in dates:
         rows: list[dict] = []
@@ -132,6 +149,7 @@ def evidence_for_analysis(
     *,
     roots: Iterable[str] = DEFAULT_GIT_REPO_ROOTS,
     schedule_end: str = "18:30",
+    exclude_repos: Iterable[str] = (),
 ) -> dict[str, dict]:
     """Build a per-date evidence dict from an attendance-analysis/v1 payload.
 
@@ -146,7 +164,7 @@ def evidence_for_analysis(
 
     # Two harvests: one window for overtime (≥ schedule_end), one for leave
     # (whole day). We avoid double-scanning by gathering everything once.
-    raw = harvest_dates(parsed_dates, authors, roots=roots)
+    raw = harvest_dates(parsed_dates, authors, roots=roots, exclude_repos=exclude_repos)
 
     sh, sm = (int(x) for x in schedule_end.split(":"))
     threshold_minutes = sh * 60 + sm
@@ -159,12 +177,10 @@ def evidence_for_analysis(
     ):
         commits = raw.get(d_str, [])
         overtime_commits = [
-            c for c in commits
-            if _commit_minutes_local(c) >= threshold_minutes
+            c for c in commits if _commit_minutes_local(c) >= threshold_minutes
         ]
         leave_commits = [
-            c for c in commits
-            if _commit_minutes_local(c) < threshold_minutes
+            c for c in commits if _commit_minutes_local(c) < threshold_minutes
         ]
         entry = {"date": slash_str}
         if slash_str in overtime_dates:

--- a/lib/reasons.py
+++ b/lib/reasons.py
@@ -110,9 +110,7 @@ def commits_on(
         if len(parts) != 3:
             continue
         sha, iso, subject = parts
-        out.append(
-            {"repo": repo.name, "sha": sha[:10], "time": iso, "subject": subject}
-        )
+        out.append({"repo": repo.name, "sha": sha[:10], "time": iso, "subject": subject})
     return out
 
 
@@ -176,12 +174,8 @@ def evidence_for_analysis(
         strict=True,
     ):
         commits = raw.get(d_str, [])
-        overtime_commits = [
-            c for c in commits if _commit_minutes_local(c) >= threshold_minutes
-        ]
-        leave_commits = [
-            c for c in commits if _commit_minutes_local(c) < threshold_minutes
-        ]
+        overtime_commits = [c for c in commits if _commit_minutes_local(c) >= threshold_minutes]
+        leave_commits = [c for c in commits if _commit_minutes_local(c) < threshold_minutes]
         entry = {"date": slash_str}
         if slash_str in overtime_dates:
             entry["overtime"] = {"git": overtime_commits}

--- a/lib/report.py
+++ b/lib/report.py
@@ -44,7 +44,12 @@ def build_issue_section(
 
 
 def build_summary(
-    forget: int, late: int, overtime: int, early_leave: int, weekday_leave: int, wfh: int
+    forget: int,
+    late: int,
+    overtime: int,
+    early_leave: int,
+    weekday_leave: int,
+    wfh: int,
 ) -> list[str]:
     return [
         "## 📊 統計摘要：\n",

--- a/lib/schema.py
+++ b/lib/schema.py
@@ -8,6 +8,7 @@ Schemas live under `docs/schema/` and follow `<name>/v<major>` naming
 (e.g. `attendance-analysis/v1`). Adding fields is a minor change and
 does not require a bump; renaming or removing fields is a major bump.
 """
+
 from __future__ import annotations
 
 import json
@@ -15,7 +16,9 @@ import re
 from pathlib import Path
 from typing import Any
 
-_VERSION_RE = re.compile(r"^(?P<name>[a-z][a-z0-9-]*)/v(?P<major>\d+)(?:\.(?P<minor>\d+))?$")
+_VERSION_RE = re.compile(
+    r"^(?P<name>[a-z][a-z0-9-]*)/v(?P<major>\d+)(?:\.(?P<minor>\d+))?$"
+)
 
 
 class SchemaVersionError(ValueError):
@@ -55,9 +58,7 @@ def require_schema_version(payload: Any, expected: str) -> None:
         )
     actual = payload.get("schema_version")
     if not actual:
-        raise SchemaVersionError(
-            f"payload 缺少 schema_version 欄位；預期 {expected!r}"
-        )
+        raise SchemaVersionError(f"payload 缺少 schema_version 欄位；預期 {expected!r}")
     exp_name, exp_major, _ = parse_version(expected)
     act_name, act_major, _ = parse_version(str(actual))
     if act_name != exp_name:

--- a/lib/schema.py
+++ b/lib/schema.py
@@ -16,9 +16,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-_VERSION_RE = re.compile(
-    r"^(?P<name>[a-z][a-z0-9-]*)/v(?P<major>\d+)(?:\.(?P<minor>\d+))?$"
-)
+_VERSION_RE = re.compile(r"^(?P<name>[a-z][a-z0-9-]*)/v(?P<major>\d+)(?:\.(?P<minor>\d+))?$")
 
 
 class SchemaVersionError(ValueError):
@@ -62,9 +60,7 @@ def require_schema_version(payload: Any, expected: str) -> None:
     exp_name, exp_major, _ = parse_version(expected)
     act_name, act_major, _ = parse_version(str(actual))
     if act_name != exp_name:
-        raise SchemaVersionError(
-            f"schema_version 名稱不符：預期 {exp_name!r}，得到 {act_name!r}"
-        )
+        raise SchemaVersionError(f"schema_version 名稱不符：預期 {exp_name!r}，得到 {act_name!r}")
     if act_major != exp_major:
         raise SchemaVersionError(
             f"schema_version {actual!r} 與預期 {expected!r} 的主版本不相容；"

--- a/lib/state.py
+++ b/lib/state.py
@@ -49,7 +49,11 @@ class AttendanceStateManager:
     def get_forget_punch_usage(self, user_name: str, year_month: str) -> int:
         if user_name not in self.state_data["users"]:
             return 0
-        return self.state_data["users"][user_name].get("forget_punch_usage", {}).get(year_month, 0)
+        return (
+            self.state_data["users"][user_name]
+            .get("forget_punch_usage", {})
+            .get(year_month, 0)
+        )
 
     def get_last_analysis_time(self, user_name: str) -> str:
         if user_name not in self.state_data.get("users", {}):
@@ -58,7 +62,10 @@ class AttendanceStateManager:
         return max((r.get("last_analysis_time", "") for r in ranges), default="")
 
     def update_user_state(
-        self, user_name: str, new_range: dict[str, str], forget_punch_usage: dict[str, int] = None
+        self,
+        user_name: str,
+        new_range: dict[str, str],
+        forget_punch_usage: dict[str, int] = None,
     ) -> None:
         if user_name not in self.state_data["users"]:
             self.state_data["users"][user_name] = {
@@ -100,7 +107,11 @@ class AttendanceStateManager:
 
     @staticmethod
     def _applied_form_key(entry: dict) -> tuple:
-        return (entry.get("date", ""), entry.get("start_time", ""), entry.get("end_time", ""))
+        return (
+            entry.get("date", ""),
+            entry.get("start_time", ""),
+            entry.get("end_time", ""),
+        )
 
     def get_applied_forms(self, user_name: str, kind: str | None = None) -> dict | list:
         user = self.state_data["users"].get(user_name, {})
@@ -131,7 +142,9 @@ class AttendanceStateManager:
             applied[kind] = cleaned
         applied["last_full_sync"] = synced_at
 
-    def record_applied_form(self, user_name: str, kind: str, entry: dict, recorded_at: str) -> None:
+    def record_applied_form(
+        self, user_name: str, kind: str, entry: dict, recorded_at: str
+    ) -> None:
         """Record a locally submitted form without changing last_full_sync."""
         if user_name not in self.state_data["users"]:
             self.state_data["users"][user_name] = {
@@ -150,7 +163,9 @@ class AttendanceStateManager:
                 return
         entries.append(rec)
 
-    def is_form_already_applied(self, user_name: str, kind: str, candidate: dict) -> bool:
+    def is_form_already_applied(
+        self, user_name: str, kind: str, candidate: dict
+    ) -> bool:
         """True if the candidate (date/start/end) is already submitted."""
         target = self._applied_form_key(candidate)
         for existing in self.get_applied_forms(user_name, kind):
@@ -175,13 +190,18 @@ class AttendanceStateManager:
         new_start = datetime.strptime(new_start_date, "%Y-%m-%d").date()
         new_end = datetime.strptime(new_end_date, "%Y-%m-%d").date()
         for range_info in existing_ranges:
-            existing_start = datetime.strptime(range_info["start_date"], "%Y-%m-%d").date()
+            existing_start = datetime.strptime(
+                range_info["start_date"], "%Y-%m-%d"
+            ).date()
             existing_end = datetime.strptime(range_info["end_date"], "%Y-%m-%d").date()
             if new_start <= existing_end and new_end >= existing_start:
                 overlap_start = max(new_start, existing_start)
                 overlap_end = min(new_end, existing_end)
                 overlaps.append(
-                    (overlap_start.strftime("%Y-%m-%d"), overlap_end.strftime("%Y-%m-%d"))
+                    (
+                        overlap_start.strftime("%Y-%m-%d"),
+                        overlap_end.strftime("%Y-%m-%d"),
+                    )
                 )
         return overlaps
 

--- a/lib/state.py
+++ b/lib/state.py
@@ -49,11 +49,7 @@ class AttendanceStateManager:
     def get_forget_punch_usage(self, user_name: str, year_month: str) -> int:
         if user_name not in self.state_data["users"]:
             return 0
-        return (
-            self.state_data["users"][user_name]
-            .get("forget_punch_usage", {})
-            .get(year_month, 0)
-        )
+        return self.state_data["users"][user_name].get("forget_punch_usage", {}).get(year_month, 0)
 
     def get_last_analysis_time(self, user_name: str) -> str:
         if user_name not in self.state_data.get("users", {}):
@@ -142,9 +138,7 @@ class AttendanceStateManager:
             applied[kind] = cleaned
         applied["last_full_sync"] = synced_at
 
-    def record_applied_form(
-        self, user_name: str, kind: str, entry: dict, recorded_at: str
-    ) -> None:
+    def record_applied_form(self, user_name: str, kind: str, entry: dict, recorded_at: str) -> None:
         """Record a locally submitted form without changing last_full_sync."""
         if user_name not in self.state_data["users"]:
             self.state_data["users"][user_name] = {
@@ -163,9 +157,7 @@ class AttendanceStateManager:
                 return
         entries.append(rec)
 
-    def is_form_already_applied(
-        self, user_name: str, kind: str, candidate: dict
-    ) -> bool:
+    def is_form_already_applied(self, user_name: str, kind: str, candidate: dict) -> bool:
         """True if the candidate (date/start/end) is already submitted."""
         target = self._applied_form_key(candidate)
         for existing in self.get_applied_forms(user_name, kind):
@@ -190,9 +182,7 @@ class AttendanceStateManager:
         new_start = datetime.strptime(new_start_date, "%Y-%m-%d").date()
         new_end = datetime.strptime(new_end_date, "%Y-%m-%d").date()
         for range_info in existing_ranges:
-            existing_start = datetime.strptime(
-                range_info["start_date"], "%Y-%m-%d"
-            ).date()
+            existing_start = datetime.strptime(range_info["start_date"], "%Y-%m-%d").date()
             existing_end = datetime.strptime(range_info["end_date"], "%Y-%m-%d").date()
             if new_start <= existing_end and new_end >= existing_start:
                 overlap_start = max(new_start, existing_start)

--- a/lib/weekend_ot.py
+++ b/lib/weekend_ot.py
@@ -16,6 +16,7 @@ Approach (no Slack here — same constraint as `lib/reasons.py`):
 Slack evidence is layered on top by the same agent skill that
 handles reasons — it has MCP access we deliberately don't ship here.
 """
+
 from __future__ import annotations
 
 import logging
@@ -30,7 +31,10 @@ logger = logging.getLogger(__name__)
 
 
 def list_weekend_holiday_dates(
-    start: date, end: date, *, holidays: set[date] | None = None,
+    start: date,
+    end: date,
+    *,
+    holidays: set[date] | None = None,
 ) -> list[date]:
     """Enumerate non-working days in [start, end]: Saturdays, Sundays, and
     any explicit holiday date passed in `holidays`."""
@@ -71,9 +75,7 @@ def detect_candidates(
         "evidence": {"git": [<commits>]}
       }
     """
-    repos = repos if repos is not None else discover_repos(
-        list(roots) if roots else ()
-    )
+    repos = repos if repos is not None else discover_repos(list(roots) if roots else ())
     holidays = holidays or set()
     candidates: list[dict] = []
     for d in list_weekend_holiday_dates(start, end, holidays=holidays):
@@ -85,23 +87,26 @@ def detect_candidates(
         commits.sort(key=lambda c: c["time"])
         first = datetime.fromisoformat(commits[0]["time"])
         last = datetime.fromisoformat(commits[-1]["time"])
-        total_min = max(min_minutes,
-                        int((last - first).total_seconds() // 60) + min_minutes)
+        total_min = max(
+            min_minutes, int((last - first).total_seconds() // 60) + min_minutes
+        )
         hours = max(1, math.floor(total_min / 60))
         start_hhmm = f"{first.hour:02d}{(first.minute // 30) * 30:02d}"
         end_total = first.hour * 60 + (first.minute // 30) * 30 + hours * 60
         end_hhmm = f"{end_total // 60:02d}{end_total % 60:02d}"
-        candidates.append({
-            "date": d.strftime("%Y/%m/%d"),
-            "weekday": "一二三四五六日"[d.weekday()],
-            "is_holiday": d in holidays,
-            "start_time": start_hhmm,
-            "end_time": end_hhmm,
-            "hours": hours,
-            "location": default_location,
-            "source": "git",
-            "evidence": {"git": commits},
-        })
+        candidates.append(
+            {
+                "date": d.strftime("%Y/%m/%d"),
+                "weekday": "一二三四五六日"[d.weekday()],
+                "is_holiday": d in holidays,
+                "start_time": start_hhmm,
+                "end_time": end_hhmm,
+                "hours": hours,
+                "location": default_location,
+                "source": "git",
+                "evidence": {"git": commits},
+            }
+        )
     return candidates
 
 
@@ -119,14 +124,16 @@ def merge_into_analysis(analysis: dict, candidates: list[dict]) -> int:
         key = (c["date"], c["start_time"], c["end_time"])
         if key in existing:
             continue
-        analysis.setdefault("overtime", []).append({
-            "date": c["date"],
-            "start_time": c["start_time"],
-            "end_time": c["end_time"],
-            "hours": c["hours"],
-            "location": c["location"],
-            "reason": "(待補,週末/假日工作)",
-        })
+        analysis.setdefault("overtime", []).append(
+            {
+                "date": c["date"],
+                "start_time": c["start_time"],
+                "end_time": c["end_time"],
+                "hours": c["hours"],
+                "location": c["location"],
+                "reason": "(待補,週末/假日工作)",
+            }
+        )
         added += 1
     if added:
         analysis.setdefault("summary", {})

--- a/lib/weekend_ot.py
+++ b/lib/weekend_ot.py
@@ -87,9 +87,7 @@ def detect_candidates(
         commits.sort(key=lambda c: c["time"])
         first = datetime.fromisoformat(commits[0]["time"])
         last = datetime.fromisoformat(commits[-1]["time"])
-        total_min = max(
-            min_minutes, int((last - first).total_seconds() // 60) + min_minutes
-        )
+        total_min = max(min_minutes, int((last - first).total_seconds() // 60) + min_minutes)
         hours = max(1, math.floor(total_min / 60))
         start_hhmm = f"{first.hour:02d}{(first.minute // 30) * 30:02d}"
         end_total = first.hour * 60 + (first.minute // 30) * 30 + hours * 60
@@ -115,10 +113,7 @@ def merge_into_analysis(analysis: dict, candidates: list[dict]) -> int:
 
     Skips candidates that already match an existing entry by (date,
     start_time, end_time). Returns the number added."""
-    existing = {
-        (e["date"], e["start_time"], e["end_time"])
-        for e in analysis.get("overtime", [])
-    }
+    existing = {(e["date"], e["start_time"], e["end_time"]) for e in analysis.get("overtime", [])}
     added = 0
     for c in candidates:
         key = (c["date"], c["start_time"], c["end_time"])
@@ -138,7 +133,5 @@ def merge_into_analysis(analysis: dict, candidates: list[dict]) -> int:
     if added:
         analysis.setdefault("summary", {})
         analysis["summary"]["overtime_count"] = len(analysis["overtime"])
-        analysis["summary"]["overtime_hours"] = sum(
-            e["hours"] for e in analysis["overtime"]
-        )
+        analysis["summary"]["overtime_hours"] = sum(e["hours"] for e in analysis["overtime"])
     return added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,17 @@ ignore = [
   # Allow long lines in tests/docs if needed; keep to E501 elsewhere
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# 測試常有不可拆的固定字串（如 9 欄出勤 header）— 允許長行
+"test/*" = ["E501"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["attendance_analyzer", "lib", "server", "tools", "test"]
 combine-as-imports = true
 
-[tool.black]
-line-length = 100
-target-version = ['py311']
-include = '\\.pyi?$'
-exclude = '/(coverage_report|build|dist|fhr.egg-info|.venv|venv)/'
+[tool.ruff.format]
+# 取代 black：行長度沿用 [tool.ruff] 的 line-length = 100
+quote-style = "double"
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-black>=24.3
 ruff>=0.5
 pre-commit>=3.5
 commitizen>=4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff>=0.5
+ruff==0.15.18  # 釘死版本：format 結果隨版本變，CI/本機/pre-commit 須一致
 pre-commit>=3.5
 commitizen>=4.0
 openpyxl>=3.1

--- a/server/main.py
+++ b/server/main.py
@@ -114,11 +114,7 @@ def _issues_to_dtos(analyzer: AttendanceAnalyzer, limit: int = 50) -> list[Issue
                 time_range=getattr(issue, "time_range", ""),
                 calculation=getattr(issue, "calculation", ""),
                 status=(
-                    (
-                        "[NEW] 本次新發現"
-                        if getattr(issue, "is_new", False)
-                        else "已存在"
-                    )
+                    ("[NEW] 本次新發現" if getattr(issue, "is_new", False) else "已存在")
                     if analyzer.incremental_mode
                     else None
                 ),
@@ -152,9 +148,7 @@ def _sanitize_stem(filename: str | None) -> str:
     return base or "analysis"
 
 
-def _canonical_output_path(
-    filename: str | None, output: Literal["csv", "excel"]
-) -> str:
+def _canonical_output_path(filename: str | None, output: Literal["csv", "excel"]) -> str:
     stem = _sanitize_stem(filename)
     ext = ".xlsx" if output == "excel" else ".csv"
     preferred = os.path.join(CANONICAL_OUTPUT_DIR, f"{stem}_analysis{ext}")
@@ -276,9 +270,7 @@ def _snapshots_cleanup_compatible(
     current_snapshot: dict,
     export_policy: Literal["merge", "archive"],
 ) -> bool:
-    if preview_snapshot.get("delete_canonical") != current_snapshot.get(
-        "delete_canonical"
-    ):
+    if preview_snapshot.get("delete_canonical") != current_snapshot.get("delete_canonical"):
         return False
     if preview_snapshot.get("export_policy") != current_snapshot.get("export_policy"):
         return False
@@ -399,13 +391,9 @@ def create_app() -> FastAPI:
         if debug_mode and not GLOBAL_DEBUG_MODE:
             logger.setLevel(logging.DEBUG)
             analyzer_logger.setLevel(logging.DEBUG)
-            logger.debug(
-                "🐞 FHR Debug 模式（請求層級）啟用：服務將跳過狀態寫入並輸出詳細日誌。"
-            )
+            logger.debug("🐞 FHR Debug 模式（請求層級）啟用：服務將跳過狀態寫入並輸出詳細日誌。")
 
-        session_id = (
-            datetime.utcnow().strftime("%Y%m%dT%H%M%S") + "_" + uuid.uuid4().hex[:8]
-        )
+        session_id = datetime.utcnow().strftime("%Y%m%dT%H%M%S") + "_" + uuid.uuid4().hex[:8]
         session_dir = os.path.join(UPLOAD_DIR, session_id)
         os.makedirs(session_dir, exist_ok=True)
         upload_path = _save_upload(file, session_dir)
@@ -414,21 +402,15 @@ def create_app() -> FastAPI:
         cleanup_exports = bool(cleanup_exports)
         provided_snapshot: dict | None = None
         canonical_requested_output = output
-        canonical_path = _canonical_output_path(
-            file.filename, canonical_requested_output
-        )
+        canonical_path = _canonical_output_path(file.filename, canonical_requested_output)
 
         if cleanup_exports:
             if not cleanup_token or not cleanup_snapshot:
                 raise HTTPException(status_code=400, detail="cleanup_preview_required")
             try:
                 provided_snapshot = json.loads(cleanup_snapshot)
-            except (
-                json.JSONDecodeError
-            ) as exc:  # pragma: no cover - malformed client input
-                raise HTTPException(
-                    status_code=400, detail="invalid_cleanup_snapshot"
-                ) from exc
+            except json.JSONDecodeError as exc:  # pragma: no cover - malformed client input
+                raise HTTPException(status_code=400, detail="invalid_cleanup_snapshot") from exc
 
             if _snapshot_token(provided_snapshot) != cleanup_token:
                 raise HTTPException(status_code=400, detail="cleanup_token_mismatch")
@@ -444,9 +426,7 @@ def create_app() -> FastAPI:
                     },
                 )
 
-            expected_snapshot = _build_snapshot_payload(
-                canonical_path, debug_mode, export_policy
-            )
+            expected_snapshot = _build_snapshot_payload(canonical_path, debug_mode, export_policy)
             if not _snapshots_strict_equal(provided_snapshot, expected_snapshot):
                 raise HTTPException(
                     status_code=409,
@@ -581,11 +561,7 @@ def create_app() -> FastAPI:
             return AnalyzeResponse(
                 analysis_id=session_id,
                 user=user_name,
-                mode=(
-                    "full"
-                    if first_time_user or requested_mode == "full"
-                    else "incremental"
-                ),
+                mode=("full" if first_time_user or requested_mode == "full" else "incremental"),
                 requested_mode=requested_mode,
                 requested_format=output,
                 actual_format=actual_format,
@@ -609,15 +585,8 @@ def create_app() -> FastAPI:
     @app.get("/api/download/{session_id}/{filename}")
     def download(session_id: str, filename: str):
         # Validate both session_id and filename to prevent path traversal
-        if (
-            "/" in session_id
-            or ".." in session_id
-            or "/" in filename
-            or ".." in filename
-        ):
-            raise HTTPException(
-                status_code=400, detail="Invalid session_id or filename"
-            )
+        if "/" in session_id or ".." in session_id or "/" in filename or ".." in filename:
+            raise HTTPException(status_code=400, detail="Invalid session_id or filename")
 
         # Use Path.resolve() to ensure the final path is within OUTPUT_ROOT
         file_path = Path(OUTPUT_ROOT) / session_id / filename

--- a/server/main.py
+++ b/server/main.py
@@ -113,9 +113,15 @@ def _issues_to_dtos(analyzer: AttendanceAnalyzer, limit: int = 50) -> list[Issue
                 description=issue.description,
                 time_range=getattr(issue, "time_range", ""),
                 calculation=getattr(issue, "calculation", ""),
-                status=("[NEW] 本次新發現" if getattr(issue, "is_new", False) else "已存在")
-                if analyzer.incremental_mode
-                else None,
+                status=(
+                    (
+                        "[NEW] 本次新發現"
+                        if getattr(issue, "is_new", False)
+                        else "已存在"
+                    )
+                    if analyzer.incremental_mode
+                    else None
+                ),
             )
         )
     return items
@@ -123,6 +129,7 @@ def _issues_to_dtos(analyzer: AttendanceAnalyzer, limit: int = 50) -> list[Issue
 
 def _totals(analyzer: AttendanceAnalyzer) -> dict:
     from collections import Counter
+
     c = Counter([i.type.value for i in analyzer.issues])
     return {
         "FORGET_PUNCH": c.get(IssueType.FORGET_PUNCH.value, 0),
@@ -145,7 +152,9 @@ def _sanitize_stem(filename: str | None) -> str:
     return base or "analysis"
 
 
-def _canonical_output_path(filename: str | None, output: Literal["csv", "excel"]) -> str:
+def _canonical_output_path(
+    filename: str | None, output: Literal["csv", "excel"]
+) -> str:
     stem = _sanitize_stem(filename)
     ext = ".xlsx" if output == "excel" else ".csv"
     preferred = os.path.join(CANONICAL_OUTPUT_DIR, f"{stem}_analysis{ext}")
@@ -267,7 +276,9 @@ def _snapshots_cleanup_compatible(
     current_snapshot: dict,
     export_policy: Literal["merge", "archive"],
 ) -> bool:
-    if preview_snapshot.get("delete_canonical") != current_snapshot.get("delete_canonical"):
+    if preview_snapshot.get("delete_canonical") != current_snapshot.get(
+        "delete_canonical"
+    ):
         return False
     if preview_snapshot.get("export_policy") != current_snapshot.get("export_policy"):
         return False
@@ -335,7 +346,7 @@ def create_app() -> FastAPI:
         title="fhr Service",
         version="0.1.0",
         description="Attendance analyzer web service",
-        lifespan=_lifespan
+        lifespan=_lifespan,
     )
 
     # Allow local dev tools by default
@@ -388,9 +399,13 @@ def create_app() -> FastAPI:
         if debug_mode and not GLOBAL_DEBUG_MODE:
             logger.setLevel(logging.DEBUG)
             analyzer_logger.setLevel(logging.DEBUG)
-            logger.debug("🐞 FHR Debug 模式（請求層級）啟用：服務將跳過狀態寫入並輸出詳細日誌。")
+            logger.debug(
+                "🐞 FHR Debug 模式（請求層級）啟用：服務將跳過狀態寫入並輸出詳細日誌。"
+            )
 
-        session_id = datetime.utcnow().strftime("%Y%m%dT%H%M%S") + "_" + uuid.uuid4().hex[:8]
+        session_id = (
+            datetime.utcnow().strftime("%Y%m%dT%H%M%S") + "_" + uuid.uuid4().hex[:8]
+        )
         session_dir = os.path.join(UPLOAD_DIR, session_id)
         os.makedirs(session_dir, exist_ok=True)
         upload_path = _save_upload(file, session_dir)
@@ -399,28 +414,39 @@ def create_app() -> FastAPI:
         cleanup_exports = bool(cleanup_exports)
         provided_snapshot: dict | None = None
         canonical_requested_output = output
-        canonical_path = _canonical_output_path(file.filename, canonical_requested_output)
+        canonical_path = _canonical_output_path(
+            file.filename, canonical_requested_output
+        )
 
         if cleanup_exports:
             if not cleanup_token or not cleanup_snapshot:
                 raise HTTPException(status_code=400, detail="cleanup_preview_required")
             try:
                 provided_snapshot = json.loads(cleanup_snapshot)
-            except json.JSONDecodeError as exc:  # pragma: no cover - malformed client input
-                raise HTTPException(status_code=400, detail="invalid_cleanup_snapshot") from exc
+            except (
+                json.JSONDecodeError
+            ) as exc:  # pragma: no cover - malformed client input
+                raise HTTPException(
+                    status_code=400, detail="invalid_cleanup_snapshot"
+                ) from exc
 
             if _snapshot_token(provided_snapshot) != cleanup_token:
                 raise HTTPException(status_code=400, detail="cleanup_token_mismatch")
 
             if provided_snapshot.get("export_policy") != export_policy:
-                raise HTTPException(status_code=409, detail={
-                    "reason": "export_policy_changed",
-                    "preview": _build_preview_response(
-                        file.filename, output, debug_mode, export_policy
-                    ).dict(),
-                })
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "reason": "export_policy_changed",
+                        "preview": _build_preview_response(
+                            file.filename, output, debug_mode, export_policy
+                        ).dict(),
+                    },
+                )
 
-            expected_snapshot = _build_snapshot_payload(canonical_path, debug_mode, export_policy)
+            expected_snapshot = _build_snapshot_payload(
+                canonical_path, debug_mode, export_policy
+            )
             if not _snapshots_strict_equal(provided_snapshot, expected_snapshot):
                 raise HTTPException(
                     status_code=409,
@@ -449,7 +475,7 @@ def create_app() -> FastAPI:
             first_time_user = False
             if user_name:
                 ranges = sm.get_user_processed_ranges(user_name)
-                first_time_user = (not ranges)
+                first_time_user = not ranges
 
             requested_mode = mode
             # If first-time user is recognized, we still run analyzer in incremental mode
@@ -466,7 +492,7 @@ def create_app() -> FastAPI:
             os.makedirs(out_session, exist_ok=True)
             base = os.path.basename(upload_path)
             ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-            stem = base[:-4] if base.lower().endswith('.txt') else base
+            stem = base[:-4] if base.lower().endswith(".txt") else base
             backup_path = None
 
             if output == "csv":
@@ -488,8 +514,7 @@ def create_app() -> FastAPI:
                         actual_format = "csv"
                     else:
                         raise HTTPException(
-                            status_code=500,
-                            detail="Failed to generate output file"
+                            status_code=500, detail="Failed to generate output file"
                         )
                 else:
                     actual_format = "excel"
@@ -545,7 +570,9 @@ def create_app() -> FastAPI:
             if incremental and not analyzer.issues and status_tuple:
                 last_date, complete_days, last_time = status_tuple
                 status_info = StatusDTO(
-                    last_date=last_date, complete_days=complete_days, last_analysis_time=last_time
+                    last_date=last_date,
+                    complete_days=complete_days,
+                    last_analysis_time=last_time,
                 )
 
             download_rel = os.path.relpath(out_path, APP_ROOT)
@@ -554,7 +581,11 @@ def create_app() -> FastAPI:
             return AnalyzeResponse(
                 analysis_id=session_id,
                 user=user_name,
-                mode=("full" if first_time_user or requested_mode == "full" else "incremental"),
+                mode=(
+                    "full"
+                    if first_time_user or requested_mode == "full"
+                    else "incremental"
+                ),
                 requested_mode=requested_mode,
                 requested_format=output,
                 actual_format=actual_format,
@@ -578,18 +609,25 @@ def create_app() -> FastAPI:
     @app.get("/api/download/{session_id}/{filename}")
     def download(session_id: str, filename: str):
         # Validate both session_id and filename to prevent path traversal
-        if "/" in session_id or ".." in session_id or "/" in filename or ".." in filename:
-            raise HTTPException(status_code=400, detail="Invalid session_id or filename")
-        
+        if (
+            "/" in session_id
+            or ".." in session_id
+            or "/" in filename
+            or ".." in filename
+        ):
+            raise HTTPException(
+                status_code=400, detail="Invalid session_id or filename"
+            )
+
         # Use Path.resolve() to ensure the final path is within OUTPUT_ROOT
         file_path = Path(OUTPUT_ROOT) / session_id / filename
         resolved_path = file_path.resolve()
         output_root_resolved = Path(OUTPUT_ROOT).resolve()
-        
+
         # Check that the resolved path is within OUTPUT_ROOT
         if not str(resolved_path).startswith(str(output_root_resolved)):
             raise HTTPException(status_code=400, detail="Access denied")
-        
+
         if not resolved_path.exists():
             raise HTTPException(status_code=404, detail="File not found")
         return FileResponse(str(resolved_path), filename=filename)

--- a/test/test_analyzer_internal_branches.py
+++ b/test/test_analyzer_internal_branches.py
@@ -15,33 +15,48 @@ class TestAnalyzerInternalBranches(unittest.TestCase):
     def test__load_previous_forget_punch_usage_early_return(self):
         an = AttendanceAnalyzer()
         # Default: state_manager is None, incremental_mode True -> early return path
-        an._load_previous_forget_punch_usage('誰')
+        an._load_previous_forget_punch_usage("誰")
         self.assertEqual(dict(an.forget_punch_usage), {})
 
     def test__parse_attendance_line_none(self):
         an = AttendanceAnalyzer()
-        self.assertIsNone(an._parse_attendance_line('invalid'))
+        self.assertIsNone(an._parse_attendance_line("invalid"))
 
     def test__analyze_single_workday_friday_returns_early(self):
         an = AttendanceAnalyzer()
         # Construct a Friday workday (2025-07-04 is Friday)
         date = datetime(2025, 7, 4)
         rec_in = AttendanceRecord(
-            date=date, scheduled_time=date.replace(hour=9, minute=0),
+            date=date,
+            scheduled_time=date.replace(hour=9, minute=0),
             actual_time=date.replace(hour=9, minute=5),
             type=AttendanceType.CHECKIN,
-            card_number='1', source='門禁', status='',
-            processed='', operation='', note=''
+            card_number="1",
+            source="門禁",
+            status="",
+            processed="",
+            operation="",
+            note="",
         )
         rec_out = AttendanceRecord(
-            date=date, scheduled_time=date.replace(hour=18, minute=0),
+            date=date,
+            scheduled_time=date.replace(hour=18, minute=0),
             actual_time=date.replace(hour=19, minute=0),
             type=AttendanceType.CHECKOUT,
-            card_number='1', source='門禁', status='',
-            processed='', operation='', note=''
+            card_number="1",
+            source="門禁",
+            status="",
+            processed="",
+            operation="",
+            note="",
         )
-        wd = WorkDay(date=date, checkin_record=rec_in, checkout_record=rec_out,
-                     is_friday=True, is_holiday=False)
+        wd = WorkDay(
+            date=date,
+            checkin_record=rec_in,
+            checkout_record=rec_out,
+            is_friday=True,
+            is_holiday=False,
+        )
         an._analyze_single_workday(wd, Rules())
         # Friday: analyzer suggests WFH (even with attendance records)
         self.assertEqual(len(an.issues), 1)
@@ -56,18 +71,20 @@ class TestAnalyzerInternalBranches(unittest.TestCase):
         # Guard 2: has state/user but no complete days
         class DummyState:
             def __init__(self):
-                self.state_data = {'users': {}}
+                self.state_data = {"users": {}}
+
             def update_user_state(self, *a, **k):
-                raise AssertionError('should not be called')
+                raise AssertionError("should not be called")
+
             def save_state(self):
-                raise AssertionError('should not be called')
+                raise AssertionError("should not be called")
 
         an.state_manager = DummyState()
-        an.current_user = '測試'
+        an.current_user = "測試"
         an._update_processing_state()  # still early return due to no complete days
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Analyzer
 Purpose: Cover analyzer internal guards and branches (friday return, state guards)."""

--- a/test/test_analyzer_sourcefile_fallback.py
+++ b/test/test_analyzer_sourcefile_fallback.py
@@ -10,9 +10,11 @@ class TestAnalyzerSourceFileFallback(unittest.TestCase):
     def test_source_file_name_fallback_on_exception(self):
         # Prepare a minimal valid file (only header) so parsing proceeds
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'any.txt')
-            with open(path, 'w', encoding='utf-8') as f:
-                f.write('應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n')
+            path = os.path.join(tmp, "any.txt")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+                )
 
             an = AttendanceAnalyzer()
 
@@ -20,16 +22,16 @@ class TestAnalyzerSourceFileFallback(unittest.TestCase):
             class _DummyPath:
                 @staticmethod
                 def basename(_):
-                    raise RuntimeError('boom')
+                    raise RuntimeError("boom")
 
             class _DummyOS:
                 path = _DummyPath()
 
-            with mock.patch('attendance_analyzer.os', new=_DummyOS()):
+            with mock.patch("attendance_analyzer.os", new=_DummyOS()):
                 an.parse_attendance_file(path, incremental=False)
 
             self.assertIsNone(an.source_file_name)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_analyzer_uncovered_branches.py
+++ b/test/test_analyzer_uncovered_branches.py
@@ -16,10 +16,12 @@ class TestAnalyzerUncoveredBranches(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         # Create sample attendance data
         self.test_file = os.path.join(self.temp_dir, "test_data.txt")
-        with open(self.test_file, 'w', encoding='utf-8') as f:
-            f.write('應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n')
-            f.write('2025/07/01 09:00\t2025/07/01 09:00\t上班\t1\t刷卡匯入\t\t\t\t\n')
-            f.write('2025/07/01 18:00\t2025/07/01 18:00\t下班\t1\t刷卡匯入\t\t\t\t\n')
+        with open(self.test_file, "w", encoding="utf-8") as f:
+            f.write(
+                "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+            )
+            f.write("2025/07/01 09:00\t2025/07/01 09:00\t上班\t1\t刷卡匯入\t\t\t\t\n")
+            f.write("2025/07/01 18:00\t2025/07/01 18:00\t下班\t1\t刷卡匯入\t\t\t\t\n")
 
     def tearDown(self):
         """Clean up test fixtures."""
@@ -31,16 +33,16 @@ class TestAnalyzerUncoveredBranches(unittest.TestCase):
         """Test _get_unprocessed_dates when not in incremental mode."""
         analyzer = AttendanceAnalyzer()
         analyzer.incremental_mode = False
-        
+
         # Parse the file to populate records
         analyzer.parse_attendance_file(self.test_file, incremental=False)
-        
+
         # Get complete work days
         complete_days = analyzer._identify_complete_work_days()
-        
+
         # Test _get_unprocessed_dates in non-incremental mode
         unprocessed = analyzer._get_unprocessed_dates("test_user", complete_days)
-        
+
         # In non-incremental mode, should return all complete days
         self.assertEqual(unprocessed, complete_days)
 
@@ -49,18 +51,18 @@ class TestAnalyzerUncoveredBranches(unittest.TestCase):
         analyzer = AttendanceAnalyzer()
         analyzer.state_manager = None
         analyzer.incremental_mode = True  # Enable incremental but no state manager
-        
+
         # Parse the file to populate records
         # Don't initialize state manager
         analyzer.parse_attendance_file(self.test_file, incremental=False)
         analyzer.state_manager = None  # Explicitly set to None
-        
+
         # Get complete work days
         complete_days = analyzer._identify_complete_work_days()
-        
+
         # Test _get_unprocessed_dates with no state manager
         unprocessed = analyzer._get_unprocessed_dates("test_user", complete_days)
-        
+
         # Should return all complete days when no state manager
         self.assertEqual(unprocessed, complete_days)
 
@@ -69,10 +71,10 @@ class TestAnalyzerUncoveredBranches(unittest.TestCase):
         analyzer = AttendanceAnalyzer()
         analyzer.state_manager = None
         analyzer.incremental_mode = True
-        
+
         # Should return early without error
         analyzer._load_previous_forget_punch_usage("test_user")
-        
+
         # Should maintain empty defaultdict
         self.assertEqual(len(analyzer.forget_punch_usage), 0)
 
@@ -80,59 +82,61 @@ class TestAnalyzerUncoveredBranches(unittest.TestCase):
         """Test _load_previous_forget_punch_usage when not in incremental mode."""
         analyzer = AttendanceAnalyzer()
         analyzer.incremental_mode = False
-        
+
         # Should return early without error
         analyzer._load_previous_forget_punch_usage("test_user")
-        
+
         # Should maintain empty defaultdict
         self.assertEqual(len(analyzer.forget_punch_usage), 0)
 
     def test_load_taiwan_holidays_with_none(self):
         """Test _load_taiwan_holidays with years=None."""
         analyzer = AttendanceAnalyzer()
-        
+
         # Test with None to trigger default year (2025)
         analyzer._load_taiwan_holidays(years=None)
-        
+
         # Should have loaded 2025 holidays
         self.assertIn(2025, analyzer.loaded_holiday_years)
 
     def test_try_load_from_gov_api_unsupported_scheme(self):
         """Test _try_load_from_gov_api with unsupported URL scheme."""
         analyzer = AttendanceAnalyzer()
-        
+
         # Patch urlparse to return unsupported scheme
-        with patch('attendance_analyzer.urlparse') as mock_urlparse:
+        with patch("attendance_analyzer.urlparse") as mock_urlparse:
             mock_urlparse.return_value.scheme = "ftp"  # Unsupported scheme
-            
+
             result = analyzer._try_load_from_gov_api(2025)
-            
+
             # Should return False for unsupported scheme
             self.assertFalse(result)
 
     def test_parse_attendance_file_source_filename_exception(self):
         """Test parse_attendance_file when setting source_file_name raises exception."""
         analyzer = AttendanceAnalyzer()
-        
+
         # Test that the source_file_name is set correctly normally
         analyzer.parse_attendance_file(self.test_file, incremental=False)
-        
+
         # Should set source_file_name to the basename
         self.assertEqual(analyzer.source_file_name, "test_data.txt")
 
     def test_parse_attendance_file_no_user_from_filename(self):
         """Test parse_attendance_file when filename parsing returns no user."""
         analyzer = AttendanceAnalyzer()
-        
+
         # Use a filename that won't match the pattern
         bad_filename = os.path.join(self.temp_dir, "bad_format.txt")
-        with open(bad_filename, 'w', encoding='utf-8') as f:
-            f.write('應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n')
-            f.write('2025/07/01 09:00\t2025/07/01 09:00\t上班\t1\t刷卡匯入\t\t\t\t\n')
-        
+        with open(bad_filename, "w", encoding="utf-8") as f:
+            f.write(
+                "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+            )
+            f.write("2025/07/01 09:00\t2025/07/01 09:00\t上班\t1\t刷卡匯入\t\t\t\t\n")
+
         try:
             analyzer.parse_attendance_file(bad_filename, incremental=True)
-            
+
             # Should not set current_user when parsing fails
             self.assertIsNone(analyzer.current_user)
         finally:
@@ -140,5 +144,5 @@ class TestAnalyzerUncoveredBranches(unittest.TestCase):
                 os.unlink(bad_filename)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_attendance_analyzer.py
+++ b/test/test_attendance_analyzer.py
@@ -13,9 +13,7 @@ class TestExcelExporter(unittest.TestCase):
     def test_write_and_save_workbook(self) -> None:
         wb, ws, header_font, header_fill, border, align = excel_exporter.init_workbook()
         headers = ["日期", "類型", "時長(分鐘)", "說明", "時段", "計算式", "狀態"]
-        excel_exporter.write_headers(
-            ws, headers, header_font, header_fill, border, align
-        )
+        excel_exporter.write_headers(ws, headers, header_font, header_fill, border, align)
         issue = Issue(
             date=datetime(2025, 9, 1),
             type=IssueType.LATE,
@@ -63,9 +61,7 @@ class TestHolidayLoading(unittest.TestCase):
         from urllib.parse import ParseResult
 
         def fake_urlparse(_url: str) -> ParseResult:
-            return ParseResult(
-                scheme="file", netloc="", path="", params="", query="", fragment=""
-            )
+            return ParseResult(scheme="file", netloc="", path="", params="", query="", fragment="")
 
         with (
             patch("attendance_analyzer.urlparse", side_effect=fake_urlparse),

--- a/test/test_attendance_analyzer.py
+++ b/test/test_attendance_analyzer.py
@@ -12,29 +12,32 @@ from lib import excel_exporter
 class TestExcelExporter(unittest.TestCase):
     def test_write_and_save_workbook(self) -> None:
         wb, ws, header_font, header_fill, border, align = excel_exporter.init_workbook()
-        headers = ['日期', '類型', '時長(分鐘)', '說明', '時段', '計算式', '狀態']
-        excel_exporter.write_headers(ws, headers, header_font, header_fill, border, align)
+        headers = ["日期", "類型", "時長(分鐘)", "說明", "時段", "計算式", "狀態"]
+        excel_exporter.write_headers(
+            ws, headers, header_font, header_fill, border, align
+        )
         issue = Issue(
             date=datetime(2025, 9, 1),
             type=IssueType.LATE,
             duration_minutes=10,
-            description='遲到10分鐘',
-            time_range='09:10-09:20',
-            calculation='09:10-09:00',
+            description="遲到10分鐘",
+            time_range="09:10-09:20",
+            calculation="09:10-09:00",
             is_new=True,
         )
         excel_exporter.write_issue_rows(ws, [issue], 2, True, border, align)
         excel_exporter.set_column_widths(ws, True)
-        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp:
             excel_exporter.save_workbook(wb, tmp.name)
             saved_path = tmp.name
         from openpyxl import load_workbook
+
         wb2 = load_workbook(saved_path)
         ws2 = wb2.active
-        self.assertEqual(ws2['A1'].value, '日期')
-        self.assertEqual(ws2['A2'].value, '2025/09/01')
-        self.assertEqual(ws2['B2'].value, '遲到')
-        self.assertEqual(ws2['G2'].value, '[NEW] 本次新發現')
+        self.assertEqual(ws2["A1"].value, "日期")
+        self.assertEqual(ws2["A2"].value, "2025/09/01")
+        self.assertEqual(ws2["B2"].value, "遲到")
+        self.assertEqual(ws2["G2"].value, "[NEW] 本次新發現")
         os.remove(saved_path)
 
 
@@ -42,12 +45,14 @@ class TestHolidayLoading(unittest.TestCase):
     def test_try_load_from_gov_api_handles_malformed_date(self) -> None:
         analyzer = AttendanceAnalyzer()
         invalid_data = [
-            {'date': 'bad-date', 'week': '?', 'isHoliday': True, 'description': ''},
+            {"date": "bad-date", "week": "?", "isHoliday": True, "description": ""},
         ]
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(invalid_data).encode('utf-8')
-        with patch('urllib.request.urlopen') as mock_urlopen, \
-                patch('lib.holidays.time.sleep'):
+        mock_response.read.return_value = json.dumps(invalid_data).encode("utf-8")
+        with (
+            patch("urllib.request.urlopen") as mock_urlopen,
+            patch("lib.holidays.time.sleep"),
+        ):
             mock_urlopen.return_value.__enter__.return_value = mock_response
             success = analyzer._try_load_from_gov_api(2025)
         self.assertFalse(success)
@@ -58,16 +63,20 @@ class TestHolidayLoading(unittest.TestCase):
         from urllib.parse import ParseResult
 
         def fake_urlparse(_url: str) -> ParseResult:
-            return ParseResult(scheme='file', netloc='', path='', params='', query='', fragment='')
+            return ParseResult(
+                scheme="file", netloc="", path="", params="", query="", fragment=""
+            )
 
-        with patch('attendance_analyzer.urlparse', side_effect=fake_urlparse), \
-                patch('urllib.request.urlopen') as mock_urlopen:
+        with (
+            patch("attendance_analyzer.urlparse", side_effect=fake_urlparse),
+            patch("urllib.request.urlopen") as mock_urlopen,
+        ):
             success = analyzer._try_load_from_gov_api(2025)
             mock_urlopen.assert_not_called()
         self.assertFalse(success)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Excel Exporter
 Purpose: Validate styled Excel writing and analyzer gov API helper behavior."""

--- a/test/test_attendance_analyzer_main_guard.py
+++ b/test/test_attendance_analyzer_main_guard.py
@@ -5,13 +5,13 @@ from unittest import mock
 
 class TestMainGuard(unittest.TestCase):
     def test_module_main_invokes_cli_run(self):
-        with mock.patch('lib.cli.run') as mock_run:
+        with mock.patch("lib.cli.run") as mock_run:
             # Execute attendance_analyzer as if __main__ to cover main() guard
-            runpy.run_module('attendance_analyzer', run_name='__main__')
+            runpy.run_module("attendance_analyzer", run_name="__main__")
             mock_run.assert_called_once()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Analyzer
 Purpose: Execute module under __main__ to cover CLI handoff."""

--- a/test/test_backup.py
+++ b/test/test_backup.py
@@ -8,24 +8,24 @@ from lib.backup import backup_with_timestamp
 class TestBackup(unittest.TestCase):
     def test_backup_with_timestamp(self):
         with tempfile.TemporaryDirectory() as td:
-            path = os.path.join(td, 'report.csv')
-            with open(path, 'w', encoding='utf-8') as f:
-                f.write('data')
+            path = os.path.join(td, "report.csv")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("data")
 
             backup = backup_with_timestamp(path)
             self.assertIsNotNone(backup)
             self.assertFalse(os.path.exists(path))
             self.assertTrue(os.path.exists(backup))
-            self.assertTrue(backup.endswith('.csv'))
+            self.assertTrue(backup.endswith(".csv"))
             # name contains timestamp suffix
-            self.assertIn('_', os.path.basename(backup).replace('report', ''))
+            self.assertIn("_", os.path.basename(backup).replace("report", ""))
 
     def test_no_backup_when_absent(self):
-        backup = backup_with_timestamp('/non/existent/file.csv')
+        backup = backup_with_timestamp("/non/existent/file.csv")
         self.assertIsNone(backup)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Backup
 Purpose: Ensure timestamped backup behavior and no-op when missing."""

--- a/test/test_cascade.py
+++ b/test/test_cascade.py
@@ -1,4 +1,5 @@
 """Tests for `lib/cascade.py` allocation logic."""
+
 import unittest
 
 from lib.cascade import (
@@ -13,13 +14,15 @@ def _balances(*, bukyu=7, tehuei=81, sick_paid=0, sick_half=None):
     """Build a balances dict matching `lib/portal/balances.fetch_balances()`."""
     items = {
         "補休假": {"remaining": bukyu},
-        "事假(含家庭照顧假)": {"remaining": None},   # 法定上限,not capped here
+        "事假(含家庭照顧假)": {"remaining": None},  # 法定上限,not capped here
     }
     if sick_paid is not None:
         items["有薪病假"] = {"remaining": sick_paid}
     if sick_half is not None:
         items["半薪病假"] = {"remaining": sick_half}
-    items["異地辦公(8hr一週)"] = {"remaining": None}  # monthly-capped, see MONTHLY_CAPS_HOURS
+    items["異地辦公(8hr一週)"] = {
+        "remaining": None
+    }  # monthly-capped, see MONTHLY_CAPS_HOURS
     return {"items": items, "annual_leave": {"remaining_hours": tehuei}}
 
 
@@ -35,8 +38,11 @@ def _late(date_str: str, hours: int) -> dict:
 
 def _wfh(date_str: str) -> dict:
     return {
-        "date": date_str, "start_time": "0930",
-        "end_time": "1830", "hours": 9, "type_hint": "WFH",
+        "date": date_str,
+        "start_time": "0930",
+        "end_time": "1830",
+        "hours": 9,
+        "type_hint": "WFH",
     }
 
 
@@ -92,18 +98,23 @@ class TestCascadeWFH(unittest.TestCase):
     def test_monthly_cap_split_across_months(self):
         # 40h/month cap on 異地辦公(8hr一週). Five 9h Fridays in May = 45h —
         # exceeds the cap; 5th request should be insufficient.
-        entries = [_wfh(d) for d in (
-            "2026/05/01", "2026/05/08", "2026/05/15", "2026/05/22", "2026/05/29",
-        )]
+        entries = [
+            _wfh(d)
+            for d in (
+                "2026/05/01",
+                "2026/05/08",
+                "2026/05/15",
+                "2026/05/22",
+                "2026/05/29",
+            )
+        ]
         out = allocate(entries, _balances())
         wfh_assigned = [d for d in out.decisions if d.leave_type == "異地辦公(8hr一週)"]
         # 4 × 9h = 36h <= 40h ✓; 5th overflows
         self.assertEqual(len(wfh_assigned), 4)
         self.assertTrue(any(d.insufficient for d in out.decisions))
         # Month tracker reflects what was actually charged
-        self.assertEqual(
-            out.monthly_used.get(("異地辦公(8hr一週)", "2026-05")), 36
-        )
+        self.assertEqual(out.monthly_used.get(("異地辦公(8hr一週)", "2026-05")), 36)
 
 
 class TestAlreadyApplied(unittest.TestCase):
@@ -112,8 +123,15 @@ class TestAlreadyApplied(unittest.TestCase):
         # the same 補休 entry back via `already_applied` MUST NOT decrement
         # `remaining` again. (Bukyu balance still reads 7h after the
         # synced 1h applied form.)
-        applied = [{"date": "2026/04/16", "start_time": "0930", "end_time": "1030",
-                    "hours": 1, "leave_type": "補休假"}]
+        applied = [
+            {
+                "date": "2026/04/16",
+                "start_time": "0930",
+                "end_time": "1030",
+                "hours": 1,
+                "leave_type": "補休假",
+            }
+        ]
         entries = [_late("2026/05/06", 7)]
         out = allocate(entries, _balances(bukyu=7), already_applied=applied)
         self.assertEqual(out.decisions[0].leave_type, "補休假")
@@ -125,13 +143,19 @@ class TestAlreadyApplied(unittest.TestCase):
         # already reflects them, double-counting and forcing fallback
         # tiers. Verify a 1h applied form does NOT eat into the 7h
         # remaining that came from the Portal.
-        applied = [{"date": "2026/04/16", "start_time": "0930", "end_time": "1030",
-                    "hours": 1, "leave_type": "補休假"}]
+        applied = [
+            {
+                "date": "2026/04/16",
+                "start_time": "0930",
+                "end_time": "1030",
+                "hours": 1,
+                "leave_type": "補休假",
+            }
+        ]
         entries = [_late("2026/05/06", 1)]
         out_with = allocate(entries, _balances(bukyu=7), already_applied=applied)
         out_without = allocate(entries, _balances(bukyu=7))
-        self.assertEqual(out_with.remaining["補休假"],
-                         out_without.remaining["補休假"])
+        self.assertEqual(out_with.remaining["補休假"], out_without.remaining["補休假"])
         # Both pick 補休 — applied form shouldn't change cascade outcome
         self.assertEqual(out_with.decisions[0].leave_type, "補休假")
 
@@ -139,10 +163,20 @@ class TestAlreadyApplied(unittest.TestCase):
         # 04 月 already used 18h (04/10 + 04/17 WFH). Adding 04/24 leaves 27h
         # used <= 40h, so still fits.
         applied = [
-            {"date": "2026/04/10", "start_time": "0930", "end_time": "1830",
-             "hours": 9, "leave_type": "異地辦公(8hr一週)"},
-            {"date": "2026/04/17", "start_time": "0930", "end_time": "1830",
-             "hours": 9, "leave_type": "異地辦公(8hr一週)"},
+            {
+                "date": "2026/04/10",
+                "start_time": "0930",
+                "end_time": "1830",
+                "hours": 9,
+                "leave_type": "異地辦公(8hr一週)",
+            },
+            {
+                "date": "2026/04/17",
+                "start_time": "0930",
+                "end_time": "1830",
+                "hours": 9,
+                "leave_type": "異地辦公(8hr一週)",
+            },
         ]
         entries = [_wfh("2026/04/24")]
         out = allocate(entries, _balances(), already_applied=applied)

--- a/test/test_cascade.py
+++ b/test/test_cascade.py
@@ -20,9 +20,7 @@ def _balances(*, bukyu=7, tehuei=81, sick_paid=0, sick_half=None):
         items["有薪病假"] = {"remaining": sick_paid}
     if sick_half is not None:
         items["半薪病假"] = {"remaining": sick_half}
-    items["異地辦公(8hr一週)"] = {
-        "remaining": None
-    }  # monthly-capped, see MONTHLY_CAPS_HOURS
+    items["異地辦公(8hr一週)"] = {"remaining": None}  # monthly-capped, see MONTHLY_CAPS_HOURS
     return {"items": items, "annual_leave": {"remaining_hours": tehuei}}
 
 

--- a/test/test_cli_additional_branches.py
+++ b/test/test_cli_additional_branches.py
@@ -11,21 +11,27 @@ class TestCliAdditionalBranches(unittest.TestCase):
     def test_reset_state_user_not_present_logs_info(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             # state file with a different user
-            state_path = os.path.join(tmpdir, 'attendance_state.json')
-            state = {"users": {"別人": {"processed_date_ranges": [], "forget_punch_usage": {}}}}
-            with open(state_path, 'w', encoding='utf-8') as f:
+            state_path = os.path.join(tmpdir, "attendance_state.json")
+            state = {
+                "users": {
+                    "別人": {"processed_date_ranges": [], "forget_punch_usage": {}}
+                }
+            }
+            with open(state_path, "w", encoding="utf-8") as f:
                 json.dump(state, f)
 
-            file_path = os.path.join(tmpdir, '202508-阿明-出勤資料.txt')
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write("應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n")
+            file_path = os.path.join(tmpdir, "202508-阿明-出勤資料.txt")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(
+                    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+                )
 
             cwd = os.getcwd()
             os.chdir(tmpdir)
             try:
-                argv = ['attendance_analyzer.py', file_path, '--reset-state']
-                with self.assertLogs(level='INFO') as cm:
-                    with mock.patch('sys.argv', argv):
+                argv = ["attendance_analyzer.py", file_path, "--reset-state"]
+                with self.assertLogs(level="INFO") as cm:
+                    with mock.patch("sys.argv", argv):
                         mod.main()
                 logs = "\n".join(cm.output)
                 self.assertIn("沒有現有狀態需要清除", logs)
@@ -35,24 +41,26 @@ class TestCliAdditionalBranches(unittest.TestCase):
     def test_runtime_exception_in_cli_exits(self):
         # Force an exception during CLI run to hit error handler
         with tempfile.TemporaryDirectory() as tmpdir:
-            file_path = os.path.join(tmpdir, 'sample-attendance-data.txt')
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write("應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n")
-            argv = ['attendance_analyzer.py', file_path, 'csv']
+            file_path = os.path.join(tmpdir, "sample-attendance-data.txt")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(
+                    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+                )
+            argv = ["attendance_analyzer.py", file_path, "csv"]
             # Patch the analyzer method that CLI calls to raise
             with mock.patch(
-                'attendance_analyzer.AttendanceAnalyzer.parse_attendance_file',
-                side_effect=RuntimeError('boom')
+                "attendance_analyzer.AttendanceAnalyzer.parse_attendance_file",
+                side_effect=RuntimeError("boom"),
             ):
-                with self.assertLogs(level='ERROR') as cm:
+                with self.assertLogs(level="ERROR") as cm:
                     with self.assertRaises(SystemExit) as se:
-                        with mock.patch('sys.argv', argv):
+                        with mock.patch("sys.argv", argv):
                             mod.main()
                 self.assertEqual(se.exception.code, 1)
-                self.assertIn('錯誤: boom', "\n".join(cm.output))
+                self.assertIn("錯誤: boom", "\n".join(cm.output))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: CLI
 Purpose: Exercise CLI side branches (reset-state no user, runtime exceptions)."""

--- a/test/test_cli_additional_branches.py
+++ b/test/test_cli_additional_branches.py
@@ -12,11 +12,7 @@ class TestCliAdditionalBranches(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             # state file with a different user
             state_path = os.path.join(tmpdir, "attendance_state.json")
-            state = {
-                "users": {
-                    "別人": {"processed_date_ranges": [], "forget_punch_usage": {}}
-                }
-            }
+            state = {"users": {"別人": {"processed_date_ranges": [], "forget_punch_usage": {}}}}
             with open(state_path, "w", encoding="utf-8") as f:
                 json.dump(state, f)
 

--- a/test/test_cli_basic.py
+++ b/test/test_cli_basic.py
@@ -12,7 +12,7 @@ class TestCliBasic(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
 
-    def _copy_sample(self, name='sample-attendance-data.txt'):
+    def _copy_sample(self, name="sample-attendance-data.txt"):
         src = os.path.join(os.getcwd(), name)
         dst = os.path.join(self.tmp.name, name)
         shutil.copy(src, dst)
@@ -20,61 +20,61 @@ class TestCliBasic(unittest.TestCase):
 
     def test_full_csv_export_creates_file(self):
         f = self._copy_sample()
-        argv = ['attendance_analyzer.py', f, 'csv', '--full']
+        argv = ["attendance_analyzer.py", f, "csv", "--full"]
         cwd = os.getcwd()
         os.chdir(self.tmp.name)
         try:
-            with self.assertLogs(level='INFO'):
+            with self.assertLogs(level="INFO"):
                 cli_run(argv)
-            self.assertTrue(os.path.exists(f.replace('.txt', '_analysis.csv')))
+            self.assertTrue(os.path.exists(f.replace(".txt", "_analysis.csv")))
         finally:
             os.chdir(cwd)
 
     def test_incremental_default_csv(self):
         f = self._copy_sample()
-        argv = ['attendance_analyzer.py', f, 'csv']
+        argv = ["attendance_analyzer.py", f, "csv"]
         cwd = os.getcwd()
         os.chdir(self.tmp.name)
         try:
-            with self.assertLogs(level='INFO'):
+            with self.assertLogs(level="INFO"):
                 cli_run(argv)
-            self.assertTrue(os.path.exists(f.replace('.txt', '_analysis.csv')))
+            self.assertTrue(os.path.exists(f.replace(".txt", "_analysis.csv")))
         finally:
             os.chdir(cwd)
 
     def test_debug_cleanup_exports_removes_output(self):
         f = self._copy_sample()
-        argv = ['attendance_analyzer.py', f, 'csv', '--debug', '--cleanup-exports']
+        argv = ["attendance_analyzer.py", f, "csv", "--debug", "--cleanup-exports"]
         cwd = os.getcwd()
         os.chdir(self.tmp.name)
         try:
-            with patch('builtins.input', return_value='y'):
-                with self.assertLogs(level='INFO'):
+            with patch("builtins.input", return_value="y"):
+                with self.assertLogs(level="INFO"):
                     cli_run(argv)
-            self.assertFalse(os.path.exists(f.replace('.txt', '_analysis.csv')))
+            self.assertFalse(os.path.exists(f.replace(".txt", "_analysis.csv")))
         finally:
             os.chdir(cwd)
 
     def test_cleanup_exports_non_debug_keeps_canonical(self):
         f = self._copy_sample()
-        canonical = f.replace('.txt', '_analysis.csv')
-        with open(canonical, 'w', encoding='utf-8') as temp_export:
-            temp_export.write('placeholder')
+        canonical = f.replace(".txt", "_analysis.csv")
+        with open(canonical, "w", encoding="utf-8") as temp_export:
+            temp_export.write("placeholder")
 
         argv = [
-            'attendance_analyzer.py',
+            "attendance_analyzer.py",
             f,
-            'csv',
-            '--export-policy',
-            'archive',
-            '--cleanup-exports',
+            "csv",
+            "--export-policy",
+            "archive",
+            "--cleanup-exports",
         ]
 
         cwd = os.getcwd()
         os.chdir(self.tmp.name)
         try:
-            with patch('builtins.input', return_value='y'):
-                with self.assertLogs(level='INFO'):
+            with patch("builtins.input", return_value="y"):
+                with self.assertLogs(level="INFO"):
                     cli_run(argv)
 
             self.assertTrue(os.path.exists(canonical))
@@ -82,14 +82,15 @@ class TestCliBasic(unittest.TestCase):
             backups = [
                 name
                 for name in os.listdir(self.tmp.name)
-                if name.startswith('sample-attendance-data_analysis_') and name.endswith('.csv')
+                if name.startswith("sample-attendance-data_analysis_")
+                and name.endswith(".csv")
             ]
             self.assertFalse(backups)
         finally:
             os.chdir(cwd)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: CLI
 Purpose: Basic CLI flows for full and incremental CSV export."""

--- a/test/test_cli_basic.py
+++ b/test/test_cli_basic.py
@@ -82,8 +82,7 @@ class TestCliBasic(unittest.TestCase):
             backups = [
                 name
                 for name in os.listdir(self.tmp.name)
-                if name.startswith("sample-attendance-data_analysis_")
-                and name.endswith(".csv")
+                if name.startswith("sample-attendance-data_analysis_") and name.endswith(".csv")
             ]
             self.assertFalse(backups)
         finally:

--- a/test/test_cli_errors.py
+++ b/test/test_cli_errors.py
@@ -9,24 +9,24 @@ import attendance_analyzer as mod
 class TestCliErrors(unittest.TestCase):
     def test_reset_state_with_unparsable_filename_exits(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            bad = os.path.join(tmpdir, 'sample-attendance-data.txt')
-            with open(bad, 'w', encoding='utf-8') as f:
-                f.write('header\n')
+            bad = os.path.join(tmpdir, "sample-attendance-data.txt")
+            with open(bad, "w", encoding="utf-8") as f:
+                f.write("header\n")
             cwd = os.getcwd()
             os.chdir(tmpdir)
             try:
-                argv = ['attendance_analyzer.py', bad, '--reset-state']
-                with self.assertLogs(level='WARNING') as cm:
+                argv = ["attendance_analyzer.py", bad, "--reset-state"]
+                with self.assertLogs(level="WARNING") as cm:
                     with self.assertRaises(SystemExit) as se:
-                        with mock.patch('sys.argv', argv):
+                        with mock.patch("sys.argv", argv):
                             mod.main()
                 self.assertEqual(se.exception.code, 1)
-                self.assertIn('無法從檔名識別使用者', "\n".join(cm.output))
+                self.assertIn("無法從檔名識別使用者", "\n".join(cm.output))
             finally:
                 os.chdir(cwd)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: CLI
 Purpose: Error handling paths for CLI (unparsable filename, sys.exit)."""

--- a/test/test_cli_legacy_compat.py
+++ b/test/test_cli_legacy_compat.py
@@ -17,9 +17,7 @@ class TestLooksLikeLegacy(unittest.TestCase):
         self.assertTrue(_looks_like_legacy_invocation(["202508-王小明-出勤資料.txt"]))
 
     def test_file_then_format(self):
-        self.assertTrue(
-            _looks_like_legacy_invocation(["202508-王小明-出勤資料.txt", "csv"])
-        )
+        self.assertTrue(_looks_like_legacy_invocation(["202508-王小明-出勤資料.txt", "csv"]))
 
     def test_flag_first(self):
         # The bug: --full sample.txt csv used to NOT be treated as legacy
@@ -27,9 +25,7 @@ class TestLooksLikeLegacy(unittest.TestCase):
 
     def test_multiple_flags_first(self):
         self.assertTrue(
-            _looks_like_legacy_invocation(
-                ["--debug", "--reset-state", "sample.txt", "csv"]
-            )
+            _looks_like_legacy_invocation(["--debug", "--reset-state", "sample.txt", "csv"])
         )
 
     def test_subcommand_first(self):
@@ -38,9 +34,7 @@ class TestLooksLikeLegacy(unittest.TestCase):
     def test_subcommand_anywhere(self):
         # Defensive: even if a user types `--debug analyze ...` we should
         # NOT silently rewrite their line; argparse will handle it.
-        self.assertFalse(
-            _looks_like_legacy_invocation(["--debug", "analyze", "sample.txt"])
-        )
+        self.assertFalse(_looks_like_legacy_invocation(["--debug", "analyze", "sample.txt"]))
 
     def test_dash_h_falls_through(self):
         # Top-level --help should hit the subcommand parser, not get

--- a/test/test_cli_legacy_compat.py
+++ b/test/test_cli_legacy_compat.py
@@ -6,6 +6,7 @@ the subcommand split because the heuristic only checked argv[0]. The
 fix scans every token for a subcommand keyword; absent any, the whole
 line is rewritten as `analyze ...`.
 """
+
 import unittest
 
 from lib.cli import KNOWN_SUBCOMMANDS, _looks_like_legacy_invocation
@@ -13,31 +14,33 @@ from lib.cli import KNOWN_SUBCOMMANDS, _looks_like_legacy_invocation
 
 class TestLooksLikeLegacy(unittest.TestCase):
     def test_pure_file_path(self):
-        self.assertTrue(_looks_like_legacy_invocation(
-            ["202508-王小明-出勤資料.txt"]))
+        self.assertTrue(_looks_like_legacy_invocation(["202508-王小明-出勤資料.txt"]))
 
     def test_file_then_format(self):
-        self.assertTrue(_looks_like_legacy_invocation(
-            ["202508-王小明-出勤資料.txt", "csv"]))
+        self.assertTrue(
+            _looks_like_legacy_invocation(["202508-王小明-出勤資料.txt", "csv"])
+        )
 
     def test_flag_first(self):
         # The bug: --full sample.txt csv used to NOT be treated as legacy
-        self.assertTrue(_looks_like_legacy_invocation(
-            ["--full", "sample.txt", "csv"]))
+        self.assertTrue(_looks_like_legacy_invocation(["--full", "sample.txt", "csv"]))
 
     def test_multiple_flags_first(self):
-        self.assertTrue(_looks_like_legacy_invocation(
-            ["--debug", "--reset-state", "sample.txt", "csv"]))
+        self.assertTrue(
+            _looks_like_legacy_invocation(
+                ["--debug", "--reset-state", "sample.txt", "csv"]
+            )
+        )
 
     def test_subcommand_first(self):
-        self.assertFalse(_looks_like_legacy_invocation(
-            ["analyze", "sample.txt"]))
+        self.assertFalse(_looks_like_legacy_invocation(["analyze", "sample.txt"]))
 
     def test_subcommand_anywhere(self):
         # Defensive: even if a user types `--debug analyze ...` we should
         # NOT silently rewrite their line; argparse will handle it.
-        self.assertFalse(_looks_like_legacy_invocation(
-            ["--debug", "analyze", "sample.txt"]))
+        self.assertFalse(
+            _looks_like_legacy_invocation(["--debug", "analyze", "sample.txt"])
+        )
 
     def test_dash_h_falls_through(self):
         # Top-level --help should hit the subcommand parser, not get
@@ -46,8 +49,15 @@ class TestLooksLikeLegacy(unittest.TestCase):
         self.assertFalse(_looks_like_legacy_invocation(["-h"]))
 
     def test_portal_subcommands_recognized(self):
-        for c in ("portal-fetch", "portal-sync",
-                  "portal-balances", "portal-apply", "reasons", "export", "import"):
+        for c in (
+            "portal-fetch",
+            "portal-sync",
+            "portal-balances",
+            "portal-apply",
+            "reasons",
+            "export",
+            "import",
+        ):
             self.assertIn(c, KNOWN_SUBCOMMANDS)
 
 

--- a/test/test_cli_reset_state.py
+++ b/test/test_cli_reset_state.py
@@ -12,11 +12,7 @@ class TestCliResetState(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             state_path = os.path.join(tmpdir, "attendance_state.json")
             user_name = "阿明"
-            state = {
-                "users": {
-                    user_name: {"processed_date_ranges": [], "forget_punch_usage": {}}
-                }
-            }
+            state = {"users": {user_name: {"processed_date_ranges": [], "forget_punch_usage": {}}}}
             with open(state_path, "w", encoding="utf-8") as f:
                 json.dump(state, f)
 

--- a/test/test_cli_reset_state.py
+++ b/test/test_cli_reset_state.py
@@ -10,23 +10,29 @@ import attendance_analyzer as mod
 class TestCliResetState(unittest.TestCase):
     def test_reset_state_logs_confirmation(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            state_path = os.path.join(tmpdir, 'attendance_state.json')
-            user_name = '阿明'
-            state = {"users": {user_name: {"processed_date_ranges": [], "forget_punch_usage": {}}}}
-            with open(state_path, 'w', encoding='utf-8') as f:
+            state_path = os.path.join(tmpdir, "attendance_state.json")
+            user_name = "阿明"
+            state = {
+                "users": {
+                    user_name: {"processed_date_ranges": [], "forget_punch_usage": {}}
+                }
+            }
+            with open(state_path, "w", encoding="utf-8") as f:
                 json.dump(state, f)
 
-            file_path = os.path.join(tmpdir, '202508-阿明-出勤資料.txt')
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write("應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n")
+            file_path = os.path.join(tmpdir, "202508-阿明-出勤資料.txt")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(
+                    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+                )
 
             cwd = os.getcwd()
             os.chdir(tmpdir)
             try:
-                argv = ['attendance_analyzer.py', file_path, '--reset-state']
+                argv = ["attendance_analyzer.py", file_path, "--reset-state"]
                 with mock.patch.dict(os.environ, {"FHR_STATE_FILE": state_path}):
-                    with self.assertLogs(level='INFO') as cm:
-                        with mock.patch('sys.argv', argv):
+                    with self.assertLogs(level="INFO") as cm:
+                        with mock.patch("sys.argv", argv):
                             mod.main()
                 logs = "\n".join(cm.output)
                 self.assertIn("狀態檔 'attendance_state.json' 已清除使用者", logs)
@@ -36,7 +42,7 @@ class TestCliResetState(unittest.TestCase):
                 os.chdir(cwd)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: CLI
 Purpose: Reset-state command path and logs."""

--- a/test/test_config_error_handling.py
+++ b/test/test_config_error_handling.py
@@ -9,28 +9,28 @@ class TestConfigErrorHandling(unittest.TestCase):
     def test_missing_config_logs_info_and_uses_defaults(self):
         with tempfile.TemporaryDirectory() as tmp:
             # Point analyzer to a non-existent config file
-            cfg = os.path.join(tmp, 'no-such-config.json')
-            with self.assertLogs(level='INFO') as cm:
+            cfg = os.path.join(tmp, "no-such-config.json")
+            with self.assertLogs(level="INFO") as cm:
                 an = AttendanceAnalyzer(config_path=cfg)
             logs = "\n".join(cm.output)
-            self.assertIn('找不到設定檔', logs)
+            self.assertIn("找不到設定檔", logs)
             # Verify a known default remains in effect
-            self.assertEqual(an.config.latest_checkin, '10:00')
+            self.assertEqual(an.config.latest_checkin, "10:00")
 
     def test_invalid_json_logs_warning(self):
         with tempfile.TemporaryDirectory() as tmp:
-            cfg = os.path.join(tmp, 'bad.json')
-            with open(cfg, 'w', encoding='utf-8') as f:
-                f.write('{ invalid json ')  # malformed
-            with self.assertLogs(level='WARNING') as cm:
+            cfg = os.path.join(tmp, "bad.json")
+            with open(cfg, "w", encoding="utf-8") as f:
+                f.write("{ invalid json ")  # malformed
+            with self.assertLogs(level="WARNING") as cm:
                 an = AttendanceAnalyzer(config_path=cfg)
             logs = "\n".join(cm.output)
-            self.assertIn('無法讀取設定檔', logs)
+            self.assertIn("無法讀取設定檔", logs)
             # Defaults still intact
             self.assertEqual(an.config.min_overtime_minutes, 60)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Config
 Purpose: Config file overrides and error handling (missing/invalid JSON)."""

--- a/test/test_csv_exporter.py
+++ b/test/test_csv_exporter.py
@@ -9,7 +9,13 @@ from lib import csv_exporter
 
 
 def make_issue(
-    date_str: str, typ_value: str, minutes: int, desc: str, rng: str, calc: str, is_new=True
+    date_str: str,
+    typ_value: str,
+    minutes: int,
+    desc: str,
+    rng: str,
+    calc: str,
+    is_new=True,
 ):
     return SimpleNamespace(
         date=datetime.strptime(date_str, "%Y/%m/%d"),
@@ -28,7 +34,9 @@ class TestCsvExporter(unittest.TestCase):
             path = tmp.name
         try:
             issues = []
-            csv_exporter.save_csv(path, issues, True, ("2025/07/31", 22, "2025-09-13T10:00:00"))
+            csv_exporter.save_csv(
+                path, issues, True, ("2025/07/31", 22, "2025-09-13T10:00:00")
+            )
             with open(path, encoding="utf-8-sig") as f:
                 rows = list(csv.reader(f, delimiter=";"))
             self.assertGreaterEqual(len(rows), 2)
@@ -42,7 +50,9 @@ class TestCsvExporter(unittest.TestCase):
             path = tmp.name
         try:
             issues = [
-                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
+                make_issue(
+                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True
+                )
             ]
             csv_exporter.save_csv(path, issues, True, None)
             with open(path, encoding="utf-8-sig") as f:
@@ -57,12 +67,16 @@ class TestCsvExporter(unittest.TestCase):
             path = tmp.name
         try:
             first_issue = [
-                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
+                make_issue(
+                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True
+                )
             ]
             csv_exporter.save_csv(path, first_issue, True, None)
 
             updated_issue = [
-                make_issue("2025/09/01", "遲到", 15, "遲到15分鐘", "10:30-10:45", "calc", False)
+                make_issue(
+                    "2025/09/01", "遲到", 15, "遲到15分鐘", "10:30-10:45", "calc", False
+                )
             ]
             csv_exporter.save_csv(path, updated_issue, True, None, merge=True)
 
@@ -82,14 +96,20 @@ class TestCsvExporter(unittest.TestCase):
         try:
             # First save with two issues
             first_issues = [
-                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc1", True),
-                make_issue("2025/09/02", "加班", 60, "加班60分鐘", "18:00-19:00", "calc2", True),
+                make_issue(
+                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc1", True
+                ),
+                make_issue(
+                    "2025/09/02", "加班", 60, "加班60分鐘", "18:00-19:00", "calc2", True
+                ),
             ]
             csv_exporter.save_csv(path, first_issues, True, None)
 
             # Then merge with one new issue
             new_issues = [
-                make_issue("2025/09/03", "WFH", 540, "WFH 9小時", "09:00-18:00", "calc3", True)
+                make_issue(
+                    "2025/09/03", "WFH", 540, "WFH 9小時", "09:00-18:00", "calc3", True
+                )
             ]
             csv_exporter.save_csv(path, new_issues, True, None, merge=True)
 
@@ -108,12 +128,28 @@ class TestCsvExporter(unittest.TestCase):
         status = csv_exporter._status_row("2025/09/30", 22, "2025-10-01T10:00:00")
         existing = [
             header,
-            ["2025/09/05", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "已存在"],
+            [
+                "2025/09/05",
+                "WFH假",
+                "540",
+                "Friday WFH",
+                "09:00-18:00",
+                "calc",
+                "已存在",
+            ],
         ]
         new_rows = [
             header,
             status,
-            ["2025/09/12", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "[NEW] 本次新發現"],
+            [
+                "2025/09/12",
+                "WFH假",
+                "540",
+                "Friday WFH",
+                "09:00-18:00",
+                "calc",
+                "[NEW] 本次新發現",
+            ],
         ]
 
         rows = csv_exporter._merge_rows(existing, new_rows)
@@ -126,12 +162,28 @@ class TestCsvExporter(unittest.TestCase):
         status = csv_exporter._status_row("2025/09/30", 22, "2025-10-01T10:00:00")
         existing = [
             header,
-            ["2025/09/05", "WFH假", "540", "Friday WFH", "09:00-18:00", "calc", "已存在"],
+            [
+                "2025/09/05",
+                "WFH假",
+                "540",
+                "Friday WFH",
+                "09:00-18:00",
+                "calc",
+                "已存在",
+            ],
         ]
         new_rows = [
             header,
             status,
-            ["2025/09/12", "遲到", "10", "遲到10分鐘", "10:00-10:10", "calc", "[NEW] 本次新發現"],
+            [
+                "2025/09/12",
+                "遲到",
+                "10",
+                "遲到10分鐘",
+                "10:00-10:10",
+                "calc",
+                "[NEW] 本次新發現",
+            ],
         ]
 
         rows = csv_exporter._merge_rows(existing, new_rows)
@@ -146,7 +198,9 @@ class TestCsvExporter(unittest.TestCase):
         # File is now deleted
         try:
             issues = [
-                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
+                make_issue(
+                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True
+                )
             ]
             csv_exporter.save_csv(path, issues, True, None, merge=True)
 

--- a/test/test_csv_exporter.py
+++ b/test/test_csv_exporter.py
@@ -34,9 +34,7 @@ class TestCsvExporter(unittest.TestCase):
             path = tmp.name
         try:
             issues = []
-            csv_exporter.save_csv(
-                path, issues, True, ("2025/07/31", 22, "2025-09-13T10:00:00")
-            )
+            csv_exporter.save_csv(path, issues, True, ("2025/07/31", 22, "2025-09-13T10:00:00"))
             with open(path, encoding="utf-8-sig") as f:
                 rows = list(csv.reader(f, delimiter=";"))
             self.assertGreaterEqual(len(rows), 2)
@@ -50,9 +48,7 @@ class TestCsvExporter(unittest.TestCase):
             path = tmp.name
         try:
             issues = [
-                make_issue(
-                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True
-                )
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, issues, True, None)
             with open(path, encoding="utf-8-sig") as f:
@@ -67,16 +63,12 @@ class TestCsvExporter(unittest.TestCase):
             path = tmp.name
         try:
             first_issue = [
-                make_issue(
-                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True
-                )
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, first_issue, True, None)
 
             updated_issue = [
-                make_issue(
-                    "2025/09/01", "遲到", 15, "遲到15分鐘", "10:30-10:45", "calc", False
-                )
+                make_issue("2025/09/01", "遲到", 15, "遲到15分鐘", "10:30-10:45", "calc", False)
             ]
             csv_exporter.save_csv(path, updated_issue, True, None, merge=True)
 
@@ -96,20 +88,14 @@ class TestCsvExporter(unittest.TestCase):
         try:
             # First save with two issues
             first_issues = [
-                make_issue(
-                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc1", True
-                ),
-                make_issue(
-                    "2025/09/02", "加班", 60, "加班60分鐘", "18:00-19:00", "calc2", True
-                ),
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc1", True),
+                make_issue("2025/09/02", "加班", 60, "加班60分鐘", "18:00-19:00", "calc2", True),
             ]
             csv_exporter.save_csv(path, first_issues, True, None)
 
             # Then merge with one new issue
             new_issues = [
-                make_issue(
-                    "2025/09/03", "WFH", 540, "WFH 9小時", "09:00-18:00", "calc3", True
-                )
+                make_issue("2025/09/03", "WFH", 540, "WFH 9小時", "09:00-18:00", "calc3", True)
             ]
             csv_exporter.save_csv(path, new_issues, True, None, merge=True)
 
@@ -198,9 +184,7 @@ class TestCsvExporter(unittest.TestCase):
         # File is now deleted
         try:
             issues = [
-                make_issue(
-                    "2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True
-                )
+                make_issue("2025/09/01", "遲到", 10, "遲到10分鐘", "10:30-10:40", "calc", True)
             ]
             csv_exporter.save_csv(path, issues, True, None, merge=True)
 

--- a/test/test_diff_screenshots.py
+++ b/test/test_diff_screenshots.py
@@ -3,21 +3,28 @@
 Requires Pillow (declared in `requirements-dev.txt`). Tests skip when
 Pillow is not installed so the suite still passes in stripped-down envs.
 """
+
 import tempfile
 import unittest
 from pathlib import Path
 
 try:
     from PIL import Image, ImageDraw  # noqa: F401
+
     _HAS_PIL = True
 except ImportError:
     _HAS_PIL = False
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SAMPLE_PNG = (REPO_ROOT / "tests" / "fixtures" /
-              "screenshot_baselines" / "dry-run" /
-              "overtime-20260420-1830-2030.png")
+SAMPLE_PNG = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "screenshot_baselines"
+    / "dry-run"
+    / "overtime-20260420-1830-2030.png"
+)
 
 
 @unittest.skipUnless(_HAS_PIL, "Pillow not installed")
@@ -27,10 +34,12 @@ class TestDiffScreenshots(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _copy(self) -> str:
         import shutil
+
         dest = Path(self.tmpdir) / "copy.png"
         shutil.copyfile(SAMPLE_PNG, dest)
         return str(dest)
@@ -38,6 +47,7 @@ class TestDiffScreenshots(unittest.TestCase):
     def _paint(self, fraction: float) -> str:
         """Paint `fraction` of the canvas (top stripe) with red. Returns path."""
         from PIL import Image, ImageDraw  # type: ignore
+
         img = Image.open(SAMPLE_PNG).copy()
         w, h = img.size
         ImageDraw.Draw(img).rectangle([0, 0, w, int(h * fraction)], fill="red")
@@ -47,19 +57,23 @@ class TestDiffScreenshots(unittest.TestCase):
 
     def test_identical_returns_zero(self):
         from tools.diff_screenshots import diff
+
         res = diff(self._copy(), str(SAMPLE_PNG))
         self.assertEqual(res.diff_ratio, 0.0)
         self.assertFalse(res.size_mismatch)
 
     def test_small_change_under_threshold(self):
         from tools.diff_screenshots import diff
+
         res = diff(self._paint(0.01), str(SAMPLE_PNG))
         # Painted 1% of canvas → diff ratio should be ~0.01
-        self.assertTrue(res.is_within(0.05),
-                        f"diff_ratio={res.diff_ratio} should be within 5%")
+        self.assertTrue(
+            res.is_within(0.05), f"diff_ratio={res.diff_ratio} should be within 5%"
+        )
 
     def test_big_change_over_threshold(self):
         from tools.diff_screenshots import diff
+
         res = diff(self._paint(0.5), str(SAMPLE_PNG))
         # Top 50% painted → diff ratio ≈ 0.5
         self.assertFalse(res.is_within(0.05))
@@ -69,6 +83,7 @@ class TestDiffScreenshots(unittest.TestCase):
         from PIL import Image  # type: ignore
 
         from tools.diff_screenshots import diff
+
         small = Path(self.tmpdir) / "small.png"
         Image.new("RGB", (10, 10), "white").save(small)
         res = diff(str(small), str(SAMPLE_PNG))
@@ -83,21 +98,33 @@ class TestDiffScreenshotsCLI(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_cli_exit_codes(self):
         import subprocess
         import sys
-        cmd = [sys.executable, str(REPO_ROOT / "tools" / "diff_screenshots.py"),
-               str(SAMPLE_PNG), str(SAMPLE_PNG), "--quiet"]
+
+        cmd = [
+            sys.executable,
+            str(REPO_ROOT / "tools" / "diff_screenshots.py"),
+            str(SAMPLE_PNG),
+            str(SAMPLE_PNG),
+            "--quiet",
+        ]
         result = subprocess.run(cmd, capture_output=True, text=True)
         self.assertEqual(result.returncode, 0)
 
     def test_cli_missing_file(self):
         import subprocess
         import sys
-        cmd = [sys.executable, str(REPO_ROOT / "tools" / "diff_screenshots.py"),
-               "/no/such/file.png", str(SAMPLE_PNG)]
+
+        cmd = [
+            sys.executable,
+            str(REPO_ROOT / "tools" / "diff_screenshots.py"),
+            "/no/such/file.png",
+            str(SAMPLE_PNG),
+        ]
         result = subprocess.run(cmd, capture_output=True, text=True)
         self.assertEqual(result.returncode, 2)
 

--- a/test/test_diff_screenshots.py
+++ b/test/test_diff_screenshots.py
@@ -67,9 +67,7 @@ class TestDiffScreenshots(unittest.TestCase):
 
         res = diff(self._paint(0.01), str(SAMPLE_PNG))
         # Painted 1% of canvas → diff ratio should be ~0.01
-        self.assertTrue(
-            res.is_within(0.05), f"diff_ratio={res.diff_ratio} should be within 5%"
-        )
+        self.assertTrue(res.is_within(0.05), f"diff_ratio={res.diff_ratio} should be within 5%")
 
     def test_big_change_over_threshold(self):
         from tools.diff_screenshots import diff

--- a/test/test_e2e_portal_replay.py
+++ b/test/test_e2e_portal_replay.py
@@ -8,6 +8,7 @@ This catches CLI/wiring regressions that mock-based unit tests miss —
 e.g. arg-parser drift, env-var loading, JSON I/O edges, the integration
 between PortalSession + apply_forms + state cache.
 """
+
 import json
 import os
 import shutil
@@ -55,22 +56,35 @@ class TestPortalApplyDryRunReplay(unittest.TestCase):
 
     def _run(self, *extra: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [sys.executable, "attendance_analyzer.py",
-             "portal-apply",
-             "--user", "Tester",
-             "--input", str(self.analysis),
-             "--auto", "--dry-run", "--dry-run-pause-secs", "0",
-             "--no-sync", "--overtime-only",
-             *extra],
-            cwd=REPO_ROOT, env=self._env(),
-            capture_output=True, text=True, check=False,
+            [
+                sys.executable,
+                "attendance_analyzer.py",
+                "portal-apply",
+                "--user",
+                "Tester",
+                "--input",
+                str(self.analysis),
+                "--auto",
+                "--dry-run",
+                "--dry-run-pause-secs",
+                "0",
+                "--no-sync",
+                "--overtime-only",
+                *extra,
+            ],
+            cwd=REPO_ROOT,
+            env=self._env(),
+            capture_output=True,
+            text=True,
+            check=False,
         )
 
     def test_dry_run_overtime_succeeds(self):
         result = self._run()
         # Exit 0 + DRY RUN result line
         self.assertEqual(
-            result.returncode, 0,
+            result.returncode,
+            0,
             msg=f"stderr: {result.stderr}\nstdout: {result.stdout}",
         )
         self.assertIn("DRY RUN", result.stdout + result.stderr)
@@ -94,13 +108,15 @@ class TestPortalApplyDryRunReplay(unittest.TestCase):
         state = json.loads(self.state_path.read_text(encoding="utf-8"))
         applied = state.get("users", {}).get("Tester", {}).get("applied_forms", {})
         # OT list should be empty / missing — dry-run must NOT write here.
-        self.assertFalse(applied.get("overtime"),
-                         "applied_forms.overtime polluted by dry-run")
+        self.assertFalse(
+            applied.get("overtime"), "applied_forms.overtime polluted by dry-run"
+        )
 
     def test_screenshot_emitted(self):
         # Screenshots default under cwd/tmp/dry-run-screenshots/<ts>/
         self._run(
-            "--screenshot-dir", str(Path(self.workdir) / "shots"),
+            "--screenshot-dir",
+            str(Path(self.workdir) / "shots"),
         )
         shots = list((Path(self.workdir) / "shots").glob("*.png"))
         self.assertGreaterEqual(len(shots), 1, "no screenshot copied")
@@ -115,6 +131,7 @@ class TestPortalApplyDryRunReplay(unittest.TestCase):
 
 try:
     from PIL import Image  # noqa: F401
+
     _HAS_PIL = True
 except ImportError:
     _HAS_PIL = False
@@ -153,19 +170,35 @@ class TestPortalApplyScreenshotsMatchBaseline(unittest.TestCase):
             "EHR_URL": "http://fake.local/ehrPortal",
         }
         subprocess.run(
-            [sys.executable, "attendance_analyzer.py", "portal-apply",
-             "--user", "Tester", "--input", str(self.analysis),
-             "--auto", "--dry-run", "--dry-run-pause-secs", "0",
-             "--no-sync", "--overtime-only",
-             "--screenshot-dir", str(self.shot_dir)],
-            cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=True,
+            [
+                sys.executable,
+                "attendance_analyzer.py",
+                "portal-apply",
+                "--user",
+                "Tester",
+                "--input",
+                str(self.analysis),
+                "--auto",
+                "--dry-run",
+                "--dry-run-pause-secs",
+                "0",
+                "--no-sync",
+                "--overtime-only",
+                "--screenshot-dir",
+                str(self.shot_dir),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         from tools.diff_screenshots import diff
+
         shots = sorted(self.shot_dir.glob("*-overtime-*.png"))
         self.assertEqual(len(shots), 1, "expected exactly one overtime screenshot")
         baseline = BASELINE_DIR / "overtime-20260420-1830-2030.png"
-        self.assertTrue(baseline.is_file(),
-                        f"missing baseline: {baseline}")
+        self.assertTrue(baseline.is_file(), f"missing baseline: {baseline}")
         res = diff(str(shots[0]), str(baseline))
         self.assertTrue(
             res.is_within(0.05),

--- a/test/test_e2e_portal_replay.py
+++ b/test/test_e2e_portal_replay.py
@@ -108,9 +108,7 @@ class TestPortalApplyDryRunReplay(unittest.TestCase):
         state = json.loads(self.state_path.read_text(encoding="utf-8"))
         applied = state.get("users", {}).get("Tester", {}).get("applied_forms", {})
         # OT list should be empty / missing — dry-run must NOT write here.
-        self.assertFalse(
-            applied.get("overtime"), "applied_forms.overtime polluted by dry-run"
-        )
+        self.assertFalse(applied.get("overtime"), "applied_forms.overtime polluted by dry-run")
 
     def test_screenshot_emitted(self):
         # Screenshots default under cwd/tmp/dry-run-screenshots/<ts>/

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1,4 +1,5 @@
 """Tests for `lib/env.py` (.env loader)."""
+
 import os
 import tempfile
 import unittest

--- a/test/test_excel_column_widths.py
+++ b/test/test_excel_column_widths.py
@@ -16,9 +16,7 @@ class TestExcelColumnWidths(unittest.TestCase):
         excel_exporter.set_column_widths(ws, False)
         self.assertEqual(ws.column_dimensions["D"].width, 30)
         self.assertEqual(ws.column_dimensions["F"].width, 35)
-        self.assertFalse(
-            "G" in ws.column_dimensions and ws.column_dimensions["G"].width
-        )
+        self.assertFalse("G" in ws.column_dimensions and ws.column_dimensions["G"].width)
 
 
 if __name__ == "__main__":

--- a/test/test_excel_column_widths.py
+++ b/test/test_excel_column_widths.py
@@ -7,19 +7,21 @@ class TestExcelColumnWidths(unittest.TestCase):
     def test_widths_incremental_true(self):
         wb, ws, *_ = excel_exporter.init_workbook()
         excel_exporter.set_column_widths(ws, True)
-        self.assertEqual(ws.column_dimensions['D'].width, 30)
-        self.assertEqual(ws.column_dimensions['F'].width, 40)
-        self.assertEqual(ws.column_dimensions['G'].width, 24)
+        self.assertEqual(ws.column_dimensions["D"].width, 30)
+        self.assertEqual(ws.column_dimensions["F"].width, 40)
+        self.assertEqual(ws.column_dimensions["G"].width, 24)
 
     def test_widths_incremental_false(self):
         wb, ws, *_ = excel_exporter.init_workbook()
         excel_exporter.set_column_widths(ws, False)
-        self.assertEqual(ws.column_dimensions['D'].width, 30)
-        self.assertEqual(ws.column_dimensions['F'].width, 35)
-        self.assertFalse('G' in ws.column_dimensions and ws.column_dimensions['G'].width)
+        self.assertEqual(ws.column_dimensions["D"].width, 30)
+        self.assertEqual(ws.column_dimensions["F"].width, 35)
+        self.assertFalse(
+            "G" in ws.column_dimensions and ws.column_dimensions["G"].width
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/Excel
 Purpose: Column width rules for incremental and full modes."""

--- a/test/test_export_cleanup.py
+++ b/test/test_export_cleanup.py
@@ -8,25 +8,28 @@ from lib.export_cleanup import cleanup_exports, list_backups
 class TestExportCleanup(unittest.TestCase):
     def test_list_backups(self):
         with tempfile.TemporaryDirectory() as tmp:
-            base = os.path.join(tmp, 'sample_analysis.csv')
-            open(os.path.join(tmp, 'sample_analysis_20250930_120000.csv'), 'w').close()
-            open(os.path.join(tmp, 'sample_analysis_20250930_120500.csv'), 'w').close()
-            open(os.path.join(tmp, 'other_file.csv'), 'w').close()
+            base = os.path.join(tmp, "sample_analysis.csv")
+            open(os.path.join(tmp, "sample_analysis_20250930_120000.csv"), "w").close()
+            open(os.path.join(tmp, "sample_analysis_20250930_120500.csv"), "w").close()
+            open(os.path.join(tmp, "other_file.csv"), "w").close()
 
             backups = list_backups(base)
             names = {os.path.basename(p) for p in backups}
             self.assertEqual(
                 names,
-                {'sample_analysis_20250930_120000.csv', 'sample_analysis_20250930_120500.csv'},
+                {
+                    "sample_analysis_20250930_120000.csv",
+                    "sample_analysis_20250930_120500.csv",
+                },
             )
 
     def test_cleanup_exports_optionally_includes_canonical(self):
         with tempfile.TemporaryDirectory() as tmp:
-            base = os.path.join(tmp, 'sample_analysis.csv')
+            base = os.path.join(tmp, "sample_analysis.csv")
             canonical = base
-            open(canonical, 'w').close()
-            ts_path = os.path.join(tmp, 'sample_analysis_20250930_120000.csv')
-            open(ts_path, 'w').close()
+            open(canonical, "w").close()
+            ts_path = os.path.join(tmp, "sample_analysis_20250930_120000.csv")
+            open(ts_path, "w").close()
 
             removed = cleanup_exports(base)
             self.assertEqual([ts_path], removed)
@@ -40,35 +43,36 @@ class TestExportCleanup(unittest.TestCase):
     def test_list_backups_rejects_directory_traversal(self):
         """Test that list_backups rejects paths with directory traversal"""
         with self.assertRaises(ValueError) as ctx:
-            list_backups('../etc/passwd')
-        self.assertIn('directory traversal', str(ctx.exception))
+            list_backups("../etc/passwd")
+        self.assertIn("directory traversal", str(ctx.exception))
 
         with self.assertRaises(ValueError) as ctx:
-            list_backups('foo/../../etc/passwd')
-        self.assertIn('directory traversal', str(ctx.exception))
+            list_backups("foo/../../etc/passwd")
+        self.assertIn("directory traversal", str(ctx.exception))
 
     def test_list_backups_ignores_subdirectories(self):
         """Test that list_backups only considers files in the same directory"""
         with tempfile.TemporaryDirectory() as tmp:
-            base = os.path.join(tmp, 'sample_analysis.csv')
+            base = os.path.join(tmp, "sample_analysis.csv")
             # Create a valid backup
-            open(os.path.join(tmp, 'sample_analysis_20250930_120000.csv'), 'w').close()
+            open(os.path.join(tmp, "sample_analysis_20250930_120000.csv"), "w").close()
             # Try to create a malicious filename with path separator (should be ignored)
             # Note: This is just for testing - actual filesystems won't allow this
             backups = list_backups(base)
             # Should only find the legitimate backup
             self.assertEqual(len(backups), 1)
-            self.assertTrue(backups[0].endswith('sample_analysis_20250930_120000.csv'))
+            self.assertTrue(backups[0].endswith("sample_analysis_20250930_120000.csv"))
 
     def test_cleanup_handles_permission_errors(self):
         """Test that cleanup handles permission errors gracefully"""
         with tempfile.TemporaryDirectory() as tmp:
-            base = os.path.join(tmp, 'sample_analysis.csv')
-            backup = os.path.join(tmp, 'sample_analysis_20250930_120000.csv')
-            open(backup, 'w').close()
+            base = os.path.join(tmp, "sample_analysis.csv")
+            backup = os.path.join(tmp, "sample_analysis_20250930_120000.csv")
+            open(backup, "w").close()
 
             # Make the directory read-only to prevent file deletion
             import stat
+
             os.chmod(tmp, stat.S_IRUSR | stat.S_IXUSR)
 
             try:
@@ -84,7 +88,7 @@ class TestExportCleanup(unittest.TestCase):
                 os.unlink(backup)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/Cleanup
 Purpose: Ensure timestamped backups are detected and removed when requested."""

--- a/test/test_export_excel_fallback.py
+++ b/test/test_export_excel_fallback.py
@@ -9,10 +9,11 @@ from attendance_analyzer import AttendanceAnalyzer
 class TestExportExcelFallback(unittest.TestCase):
     def test_import_error_falls_back_to_csv(self):
         with tempfile.TemporaryDirectory() as tmp:
-            src = os.path.join(os.getcwd(), 'sample-attendance-data.txt')
-            path = os.path.join(tmp, 'sample-attendance-data.txt')
-            with (open(src, encoding='utf-8') as fsrc,
-                  open(path, 'w', encoding='utf-8') as fdst):
+            src = os.path.join(os.getcwd(), "sample-attendance-data.txt")
+            path = os.path.join(tmp, "sample-attendance-data.txt")
+            with open(src, encoding="utf-8") as fsrc, open(
+                path, "w", encoding="utf-8"
+            ) as fdst:
                 fdst.write(fsrc.read())
 
             an = AttendanceAnalyzer()
@@ -22,23 +23,24 @@ class TestExportExcelFallback(unittest.TestCase):
 
             # Patch import to raise ImportError when importing lib.excel_exporter
             import builtins as _builtins
+
             real_import = _builtins.__import__
 
             def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-                if name == 'lib' and ('excel_exporter' in fromlist):
-                    raise ImportError('no openpyxl')
+                if name == "lib" and ("excel_exporter" in fromlist):
+                    raise ImportError("no openpyxl")
                 return real_import(name, globals, locals, fromlist, level)
 
-            xlsx = path.replace('.txt', '_analysis.xlsx')
-            csv = path.replace('.txt', '_analysis.csv')
-            with mock.patch('builtins.__import__', side_effect=fake_import):
-                with self.assertLogs(level='WARNING') as cm:
+            xlsx = path.replace(".txt", "_analysis.xlsx")
+            csv = path.replace(".txt", "_analysis.csv")
+            with mock.patch("builtins.__import__", side_effect=fake_import):
+                with self.assertLogs(level="WARNING") as cm:
                     an.export_excel(xlsx)
             self.assertTrue(os.path.exists(csv))
-            self.assertIn('未安裝 openpyxl，回退使用CSV格式', "\n".join(cm.output))
+            self.assertIn("未安裝 openpyxl，回退使用CSV格式", "\n".join(cm.output))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/Excel
 Purpose: Fallback to CSV when openpyxl is unavailable."""

--- a/test/test_export_excel_fallback.py
+++ b/test/test_export_excel_fallback.py
@@ -11,9 +11,7 @@ class TestExportExcelFallback(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             src = os.path.join(os.getcwd(), "sample-attendance-data.txt")
             path = os.path.join(tmp, "sample-attendance-data.txt")
-            with open(src, encoding="utf-8") as fsrc, open(
-                path, "w", encoding="utf-8"
-            ) as fdst:
+            with open(src, encoding="utf-8") as fsrc, open(path, "w", encoding="utf-8") as fdst:
                 fdst.write(fsrc.read())
 
             an = AttendanceAnalyzer()

--- a/test/test_export_excel_incremental_issue_row.py
+++ b/test/test_export_excel_incremental_issue_row.py
@@ -11,13 +11,13 @@ class TestExportExcelIncrementalIssueRow(unittest.TestCase):
     def test_issue_row_includes_status_when_incremental(self):
         # Build a minimal file that will produce at least one issue (late)
         text = (
-            '應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n'
-            '2025/07/01 08:30\t2025/07/01 12:45\t上班\t1\t刷卡匯入\t\t\t\t\n'
-            '2025/07/01 17:30\t2025/07/01 18:00\t下班\t1\t刷卡匯入\t\t\t\t\n'
+            "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+            "2025/07/01 08:30\t2025/07/01 12:45\t上班\t1\t刷卡匯入\t\t\t\t\n"
+            "2025/07/01 17:30\t2025/07/01 18:00\t下班\t1\t刷卡匯入\t\t\t\t\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
-            src = os.path.join(tmp, '202507-測試人-出勤資料.txt')
-            with open(src, 'w', encoding='utf-8') as f:
+            src = os.path.join(tmp, "202507-測試人-出勤資料.txt")
+            with open(src, "w", encoding="utf-8") as f:
                 f.write(text)
 
             an = AttendanceAnalyzer()
@@ -30,18 +30,18 @@ class TestExportExcelIncrementalIssueRow(unittest.TestCase):
             self.assertGreater(len(an.issues), 0)
             an.incremental_mode = True
 
-            out_xlsx = os.path.join(tmp, 'out.xlsx')
+            out_xlsx = os.path.join(tmp, "out.xlsx")
             an.export_excel(out_xlsx)
 
             wb = load_workbook(out_xlsx)
             ws = wb.active
             # Header should include status column
-            self.assertEqual(ws['G1'].value, '狀態')
+            self.assertEqual(ws["G1"].value, "狀態")
             # First data row should be the issue, with status value present
-            self.assertIn(ws['G2'].value, ('[NEW] 本次新發現', '已存在'))
+            self.assertIn(ws["G2"].value, ("[NEW] 本次新發現", "已存在"))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/Excel
 Purpose: Ensure incremental export writes status column on issue rows."""

--- a/test/test_export_helpers.py
+++ b/test/test_export_helpers.py
@@ -29,9 +29,7 @@ class TestExportParserArgs(unittest.TestCase):
         return parser.parse_args(argv)
 
     def test_export_defaults(self):
-        ns = self._parse(
-            "export", "--to=code-agent-hr", "sample.txt", "--out", "tmp/out.json"
-        )
+        ns = self._parse("export", "--to=code-agent-hr", "sample.txt", "--out", "tmp/out.json")
         self.assertEqual(ns.cmd, "export")
         self.assertEqual(ns.to, "code-agent-hr")
         self.assertEqual(ns.filepath, "sample.txt")

--- a/test/test_export_helpers.py
+++ b/test/test_export_helpers.py
@@ -1,4 +1,5 @@
 """Unit tests for `lib/commands/export.py` helpers (Tier 1)."""
+
 import argparse
 import unittest
 from datetime import date
@@ -23,12 +24,14 @@ class TestExportParserArgs(unittest.TestCase):
 
     def _parse(self, *argv):
         from lib.cli import build_parser
+
         parser = build_parser()
         return parser.parse_args(argv)
 
     def test_export_defaults(self):
-        ns = self._parse("export", "--to=code-agent-hr", "sample.txt",
-                         "--out", "tmp/out.json")
+        ns = self._parse(
+            "export", "--to=code-agent-hr", "sample.txt", "--out", "tmp/out.json"
+        )
         self.assertEqual(ns.cmd, "export")
         self.assertEqual(ns.to, "code-agent-hr")
         self.assertEqual(ns.filepath, "sample.txt")
@@ -40,15 +43,23 @@ class TestExportParserArgs(unittest.TestCase):
 
     def test_export_with_dates(self):
         ns = self._parse(
-            "export", "--to=code-agent-hr", "x.txt", "--out", "y.json",
-            "--cutoff", "2026/04/17", "--today", "2026/05/19",
+            "export",
+            "--to=code-agent-hr",
+            "x.txt",
+            "--out",
+            "y.json",
+            "--cutoff",
+            "2026/04/17",
+            "--today",
+            "2026/05/19",
         )
         self.assertEqual(ns.cutoff, date(2026, 4, 17))
         self.assertEqual(ns.today, date(2026, 5, 19))
 
     def test_export_opt_in_incremental(self):
-        ns = self._parse("export", "--to=code-agent-hr", "x.txt",
-                         "--out", "y.json", "--incremental")
+        ns = self._parse(
+            "export", "--to=code-agent-hr", "x.txt", "--out", "y.json", "--incremental"
+        )
         self.assertTrue(ns.incremental)
 
 

--- a/test/test_export_state_independence.py
+++ b/test/test_export_state_independence.py
@@ -10,6 +10,7 @@ then had nothing to act on.
 The fix: export defaults to full analysis. Users who want incremental
 behavior pass `--incremental` explicitly.
 """
+
 import json
 import os
 import shutil
@@ -45,13 +46,14 @@ class TestExportStateIndependence(unittest.TestCase):
         repo = Path(__file__).resolve().parents[1]
         result = subprocess.run(
             [sys.executable, "attendance_analyzer.py", *args],
-            cwd=repo, env=self.env,
-            capture_output=True, text=True, check=False,
+            cwd=repo,
+            env=self.env,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         if result.returncode != 0:
-            self.fail(
-                f"command failed: {' '.join(args)}\nstderr: {result.stderr}"
-            )
+            self.fail(f"command failed: {' '.join(args)}\nstderr: {result.stderr}")
         return result.stdout
 
     def test_export_emits_entries_even_after_analyze_marked_dates(self):
@@ -60,13 +62,17 @@ class TestExportStateIndependence(unittest.TestCase):
 
         # 2. Now export — should still emit the 04/20 OT + leave entries
         self._run(
-            "export", "--to=code-agent-hr", str(self.attendance),
-            "--out", str(self.out),
+            "export",
+            "--to=code-agent-hr",
+            str(self.attendance),
+            "--out",
+            str(self.out),
         )
         payload = json.loads(self.out.read_text(encoding="utf-8"))
         self.assertEqual(payload["schema_version"], "attendance-analysis/v1")
-        self.assertGreaterEqual(len(payload["overtime"]), 1,
-                                "export must emit OT despite state cache")
+        self.assertGreaterEqual(
+            len(payload["overtime"]), 1, "export must emit OT despite state cache"
+        )
         # 04/20 11:26 上班 is a clear 遲到 → leave with type_hint=late
         self.assertTrue(any(e.get("type_hint") == "late" for e in payload["leave"]))
 

--- a/test/test_exporters_code_agent_hr.py
+++ b/test/test_exporters_code_agent_hr.py
@@ -3,6 +3,7 @@
 Cover end-time math (`start + hours`), filters (cutoff / future),
 WFH synthesis, and the schema_version stamp.
 """
+
 import json
 import os
 import tempfile
@@ -51,6 +52,17 @@ def _wfh(date_str: str) -> Issue:
     )
 
 
+def _full_day(date_str: str) -> Issue:
+    return Issue(
+        date=datetime.strptime(date_str, "%Y/%m/%d"),
+        type=IssueType.WEEKDAY_LEAVE,
+        duration_minutes=480,
+        description="整天沒進公司，建議請假",
+        time_range="",
+        calculation="",
+    )
+
+
 class TestOvertimeMath(unittest.TestCase):
     def test_end_time_is_start_plus_hours_not_actual_punch(self):
         # 04/20 18:30-21:05 actual punch → 2h applicable, end = 18:30+2h = 20:30
@@ -73,10 +85,12 @@ class TestOvertimeMath(unittest.TestCase):
 
     def test_floor_to_whole_hours(self):
         # 178min → 2h (not 3); 200min → 3h
-        out = issues_to_analysis([
-            _ot("2026/04/22", "18:30~21:28", 178),
-            _ot("2026/04/27", "18:30~21:50", 200),
-        ])
+        out = issues_to_analysis(
+            [
+                _ot("2026/04/22", "18:30~21:28", 178),
+                _ot("2026/04/27", "18:30~21:50", 200),
+            ]
+        )
         self.assertEqual(out["overtime"][0]["hours"], 2)
         self.assertEqual(out["overtime"][1]["hours"], 3)
 
@@ -109,19 +123,41 @@ class TestWFH(unittest.TestCase):
         self.assertEqual(e["reason"], "WFH")
 
     def test_respects_schedule_overrides(self):
-        out = issues_to_analysis([_wfh("2026/04/24")],
-                                 ExportOptions(schedule_start_hhmm="0900",
-                                               schedule_end_hhmm="1800"))
+        out = issues_to_analysis(
+            [_wfh("2026/04/24")],
+            ExportOptions(schedule_start_hhmm="0900", schedule_end_hhmm="1800"),
+        )
         e = out["leave"][0]
         self.assertEqual(e["start_time"], "0900")
         self.assertEqual(e["end_time"], "1800")
         self.assertEqual(e["hours"], 9)
 
 
+class TestFullDayLeave(unittest.TestCase):
+    def test_weekday_full_day_emitted_as_leave(self):
+        # 平日整日缺勤須輸出成可申請的整天請假（修復先前 silently ignored）
+        out = issues_to_analysis([_full_day("2026/06/10")])
+        self.assertEqual(len(out["leave"]), 1)
+        e = out["leave"][0]
+        self.assertEqual(e["date"], "2026/06/10")
+        self.assertEqual(e["start_time"], "0930")
+        self.assertEqual(e["end_time"], "1830")
+        self.assertEqual(e["hours"], 8)  # 午休不計
+        self.assertEqual(e["type_hint"], "full_day")
+
+    def test_full_day_counts_in_summary(self):
+        out = issues_to_analysis([_full_day("2026/06/10"), _full_day("2026/06/15")])
+        self.assertEqual(out["summary"]["leave_count"], 2)
+        self.assertEqual(out["summary"]["leave_hours"], 16)
+
+
 class TestFilters(unittest.TestCase):
     def test_cutoff_drops_on_or_before(self):
         out = issues_to_analysis(
-            [_ot("2026/04/17", "18:30~20:30", 120), _ot("2026/04/18", "18:30~20:30", 120)],
+            [
+                _ot("2026/04/17", "18:30~20:30", 120),
+                _ot("2026/04/18", "18:30~20:30", 120),
+            ],
             ExportOptions(cutoff_date=date(2026, 4, 17)),
         )
         self.assertEqual(len(out["overtime"]), 1)
@@ -130,7 +166,10 @@ class TestFilters(unittest.TestCase):
 
     def test_future_drops_after_today(self):
         out = issues_to_analysis(
-            [_ot("2026/05/19", "18:30~20:30", 120), _ot("2026/05/22", "18:30~20:30", 120)],
+            [
+                _ot("2026/05/19", "18:30~20:30", 120),
+                _ot("2026/05/22", "18:30~20:30", 120),
+            ],
             ExportOptions(today=date(2026, 5, 20)),
         )
         self.assertEqual(len(out["overtime"]), 1)
@@ -145,19 +184,23 @@ class TestPayloadShape(unittest.TestCase):
         self.assertEqual(out["schema_version"], SCHEMA_VERSION)
 
     def test_summary_matches_arrays(self):
-        out = issues_to_analysis([
-            _ot("2026/04/20", "18:30~20:30", 120),
-            _ot("2026/04/22", "18:30~20:30", 120),
-            _late("2026/04/20", "09:30~10:30", 60),
-        ])
+        out = issues_to_analysis(
+            [
+                _ot("2026/04/20", "18:30~20:30", 120),
+                _ot("2026/04/22", "18:30~20:30", 120),
+                _late("2026/04/20", "09:30~10:30", 60),
+            ]
+        )
         self.assertEqual(out["summary"]["overtime_count"], 2)
         self.assertEqual(out["summary"]["overtime_hours"], 4)
         self.assertEqual(out["summary"]["leave_count"], 1)
         self.assertEqual(out["summary"]["leave_hours"], 1)
 
     def test_cutoff_date_in_payload(self):
-        out = issues_to_analysis([_ot("2026/04/20", "18:30~20:30", 120)],
-                                 ExportOptions(cutoff_date=date(2026, 4, 17)))
+        out = issues_to_analysis(
+            [_ot("2026/04/20", "18:30~20:30", 120)],
+            ExportOptions(cutoff_date=date(2026, 4, 17)),
+        )
         self.assertEqual(out["cutoff_date"], "2026/04/17")
 
 

--- a/test/test_filename.py
+++ b/test/test_filename.py
@@ -5,25 +5,25 @@ from lib.filename import parse_range_and_user
 
 class TestFilenameParsing(unittest.TestCase):
     def test_single_month(self):
-        user, start, end = parse_range_and_user('/x/202508-王小明-出勤資料.txt')
-        self.assertEqual(user, '王小明')
-        self.assertEqual(start, '2025-08-01')
-        self.assertEqual(end, '2025-08-31')
+        user, start, end = parse_range_and_user("/x/202508-王小明-出勤資料.txt")
+        self.assertEqual(user, "王小明")
+        self.assertEqual(start, "2025-08-01")
+        self.assertEqual(end, "2025-08-31")
 
     def test_cross_month(self):
-        user, start, end = parse_range_and_user('/x/202508-202509-王小明-出勤資料.txt')
-        self.assertEqual(user, '王小明')
-        self.assertEqual(start, '2025-08-01')
-        self.assertEqual(end, '2025-09-30')
+        user, start, end = parse_range_and_user("/x/202508-202509-王小明-出勤資料.txt")
+        self.assertEqual(user, "王小明")
+        self.assertEqual(start, "2025-08-01")
+        self.assertEqual(end, "2025-09-30")
 
     def test_invalid(self):
-        user, start, end = parse_range_and_user('/x/invalid.txt')
+        user, start, end = parse_range_and_user("/x/invalid.txt")
         self.assertIsNone(user)
         self.assertIsNone(start)
         self.assertIsNone(end)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Filename/Parsing
 Purpose: Parse user and date ranges from filename patterns."""

--- a/test/test_filename_more.py
+++ b/test/test_filename_more.py
@@ -6,9 +6,9 @@ from lib.filename import parse_range_and_user
 class TestFilenameMore(unittest.TestCase):
     def test_bad_patterns_return_none(self):
         for name in [
-            'badname.txt',
-            '2025AA-姓名-出勤資料.txt',
-            '202513-202514-姓名-出勤資料.txt',
+            "badname.txt",
+            "2025AA-姓名-出勤資料.txt",
+            "202513-202514-姓名-出勤資料.txt",
         ]:
             u, s, e = parse_range_and_user(name)
             self.assertIsNone(u)
@@ -17,13 +17,13 @@ class TestFilenameMore(unittest.TestCase):
 
     def test_second_segment_non_digits_becomes_part_of_name(self):
         # According to current parser regex, non-digit 2nd segment is treated as part of the name
-        u, s, e = parse_range_and_user('202512-2025XX-姓名-出勤資料.txt')
-        self.assertEqual(u, '2025XX-姓名')
-        self.assertEqual(s, '2025-12-01')
-        self.assertEqual(e, '2025-12-31')
+        u, s, e = parse_range_and_user("202512-2025XX-姓名-出勤資料.txt")
+        self.assertEqual(u, "2025XX-姓名")
+        self.assertEqual(s, "2025-12-01")
+        self.assertEqual(e, "2025-12-31")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Filename/Parsing
 Purpose: Edge patterns and invalid month handling for filename parsing."""

--- a/test/test_filename_unreachable.py
+++ b/test/test_filename_unreachable.py
@@ -8,21 +8,21 @@ class TestFilenameEdge(unittest.TestCase):
     def test_single_month_next_month_value_error(self):
         real_dt = lf.datetime
 
-        calls = {'n': 0}
+        calls = {"n": 0}
 
         def dt_fn(*args, **kwargs):
-            calls['n'] += 1
-            if calls['n'] == 1:
+            calls["n"] += 1
+            if calls["n"] == 1:
                 return real_dt(*args, **kwargs)
-            raise ValueError('forced')
+            raise ValueError("forced")
 
-        with patch('lib.filename.datetime', dt_fn):
+        with patch("lib.filename.datetime", dt_fn):
             self.assertEqual(
-                lf.parse_range_and_user('202501-姓名-出勤資料.txt'), (None, None, None)
+                lf.parse_range_and_user("202501-姓名-出勤資料.txt"), (None, None, None)
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Filename/Parsing
 Purpose: Force ValueError in single-month end-date calculation path."""

--- a/test/test_filter_unprocessed_dates.py
+++ b/test/test_filter_unprocessed_dates.py
@@ -14,13 +14,13 @@ class TestFilterUnprocessedDates(unittest.TestCase):
         complete_days = [
             datetime(2025, 8, 1),
             datetime(2025, 8, 2),
-            datetime(2025, 8, 3)
+            datetime(2025, 8, 3),
         ]
-        
+
         # Test with None
         result = filter_unprocessed_dates(None, complete_days)
         self.assertEqual(result, complete_days)
-        
+
         # Test with empty list
         result = filter_unprocessed_dates([], complete_days)
         self.assertEqual(result, complete_days)
@@ -28,28 +28,19 @@ class TestFilterUnprocessedDates(unittest.TestCase):
     def test_malformed_date_ranges_skipped(self):
         """Test that malformed date ranges are skipped gracefully."""
         processed_ranges = [
-            {
-                "start_date": "invalid-date",
-                "end_date": "2025-08-31"
-            },
-            {
-                "start_date": "2025-08-01",
-                "end_date": "invalid-date"
-            },
-            {
-                "start_date": "2025-08-15",
-                "end_date": "2025-08-20"
-            }
+            {"start_date": "invalid-date", "end_date": "2025-08-31"},
+            {"start_date": "2025-08-01", "end_date": "invalid-date"},
+            {"start_date": "2025-08-15", "end_date": "2025-08-20"},
         ]
-        
+
         complete_days = [
             datetime(2025, 8, 10),  # Should be unprocessed
             datetime(2025, 8, 16),  # Should be filtered out (in valid range)
-            datetime(2025, 8, 25)   # Should be unprocessed
+            datetime(2025, 8, 25),  # Should be unprocessed
         ]
-        
+
         result = filter_unprocessed_dates(processed_ranges, complete_days)
-        
+
         # Only the day within the valid range should be filtered out
         expected = [datetime(2025, 8, 10), datetime(2025, 8, 25)]
         self.assertEqual(result, expected)
@@ -58,31 +49,28 @@ class TestFilterUnprocessedDates(unittest.TestCase):
         """Test range merging logic for overlapping and adjacent ranges."""
         # Test overlapping ranges
         processed_ranges = [
-            {
-                "start_date": "2025-08-01",
-                "end_date": "2025-08-10"
-            },
+            {"start_date": "2025-08-01", "end_date": "2025-08-10"},
             {
                 "start_date": "2025-08-05",  # Overlaps with first range
-                "end_date": "2025-08-15"
+                "end_date": "2025-08-15",
             },
             {
                 "start_date": "2025-08-20",  # Separate range
-                "end_date": "2025-08-25"
-            }
+                "end_date": "2025-08-25",
+            },
         ]
-        
+
         complete_days = [
-            datetime(2025, 8, 3),   # In merged range (1-15)
-            datetime(2025, 8, 8),   # In merged range (1-15) 
+            datetime(2025, 8, 3),  # In merged range (1-15)
+            datetime(2025, 8, 8),  # In merged range (1-15)
             datetime(2025, 8, 12),  # In merged range (1-15)
             datetime(2025, 8, 18),  # Between ranges - unprocessed
             datetime(2025, 8, 22),  # In second range (20-25)
-            datetime(2025, 8, 30)   # After ranges - unprocessed
+            datetime(2025, 8, 30),  # After ranges - unprocessed
         ]
-        
+
         result = filter_unprocessed_dates(processed_ranges, complete_days)
-        
+
         # Only days 18 and 30 should be unprocessed
         expected = [datetime(2025, 8, 18), datetime(2025, 8, 30)]
         self.assertEqual(result, expected)
@@ -90,26 +78,23 @@ class TestFilterUnprocessedDates(unittest.TestCase):
     def test_adjacent_ranges_merging(self):
         """Test that adjacent ranges are merged correctly."""
         processed_ranges = [
-            {
-                "start_date": "2025-08-01",
-                "end_date": "2025-08-10"
-            },
+            {"start_date": "2025-08-01", "end_date": "2025-08-10"},
             {
                 "start_date": "2025-08-11",  # Adjacent to first range
-                "end_date": "2025-08-20"
-            }
+                "end_date": "2025-08-20",
+            },
         ]
-        
+
         complete_days = [
-            datetime(2025, 8, 5),   # In merged range
+            datetime(2025, 8, 5),  # In merged range
             datetime(2025, 8, 10),  # End of first range
             datetime(2025, 8, 11),  # Start of second range
             datetime(2025, 8, 15),  # In merged range
-            datetime(2025, 8, 25)   # After merged range - unprocessed
+            datetime(2025, 8, 25),  # After merged range - unprocessed
         ]
-        
+
         result = filter_unprocessed_dates(processed_ranges, complete_days)
-        
+
         # Only day 25 should be unprocessed
         expected = [datetime(2025, 8, 25)]
         self.assertEqual(result, expected)
@@ -117,37 +102,31 @@ class TestFilterUnprocessedDates(unittest.TestCase):
     def test_binary_search_edge_cases(self):
         """Test binary search logic with edge cases."""
         processed_ranges = [
-            {
-                "start_date": "2025-08-05",
-                "end_date": "2025-08-10"
-            },
-            {
-                "start_date": "2025-08-15",
-                "end_date": "2025-08-20"
-            }
+            {"start_date": "2025-08-05", "end_date": "2025-08-10"},
+            {"start_date": "2025-08-15", "end_date": "2025-08-20"},
         ]
-        
+
         complete_days = [
-            datetime(2025, 8, 1),   # Before all ranges
-            datetime(2025, 8, 4),   # Just before first range
-            datetime(2025, 8, 5),   # Start of first range
-            datetime(2025, 8, 7),   # Middle of first range
+            datetime(2025, 8, 1),  # Before all ranges
+            datetime(2025, 8, 4),  # Just before first range
+            datetime(2025, 8, 5),  # Start of first range
+            datetime(2025, 8, 7),  # Middle of first range
             datetime(2025, 8, 10),  # End of first range
             datetime(2025, 8, 12),  # Between ranges
             datetime(2025, 8, 15),  # Start of second range
             datetime(2025, 8, 18),  # Middle of second range
             datetime(2025, 8, 20),  # End of second range
-            datetime(2025, 8, 25)   # After all ranges
+            datetime(2025, 8, 25),  # After all ranges
         ]
-        
+
         result = filter_unprocessed_dates(processed_ranges, complete_days)
-        
+
         # Days outside ranges should be unprocessed
         expected = [
             datetime(2025, 8, 1),
             datetime(2025, 8, 4),
             datetime(2025, 8, 12),
-            datetime(2025, 8, 25)
+            datetime(2025, 8, 25),
         ]
         self.assertEqual(result, expected)
 
@@ -156,29 +135,25 @@ class TestFilterUnprocessedDates(unittest.TestCase):
         processed_ranges = [
             {
                 "start_date": "2025-08-05",
-                "end_date": "2025-08-05"  # Single day
+                "end_date": "2025-08-05",  # Single day
             },
             {
                 "start_date": "2025-08-10",
-                "end_date": "2025-08-10"  # Single day
-            }
+                "end_date": "2025-08-10",  # Single day
+            },
         ]
-        
+
         complete_days = [
-            datetime(2025, 8, 4),   # Unprocessed
-            datetime(2025, 8, 5),   # Processed
-            datetime(2025, 8, 6),   # Unprocessed
+            datetime(2025, 8, 4),  # Unprocessed
+            datetime(2025, 8, 5),  # Processed
+            datetime(2025, 8, 6),  # Unprocessed
             datetime(2025, 8, 10),  # Processed
-            datetime(2025, 8, 11)   # Unprocessed
+            datetime(2025, 8, 11),  # Unprocessed
         ]
-        
+
         result = filter_unprocessed_dates(processed_ranges, complete_days)
-        
-        expected = [
-            datetime(2025, 8, 4),
-            datetime(2025, 8, 6),
-            datetime(2025, 8, 11)
-        ]
+
+        expected = [datetime(2025, 8, 4), datetime(2025, 8, 6), datetime(2025, 8, 11)]
         self.assertEqual(result, expected)
 
     def test_out_of_order_ranges(self):
@@ -186,38 +161,33 @@ class TestFilterUnprocessedDates(unittest.TestCase):
         processed_ranges = [
             {
                 "start_date": "2025-08-15",  # Later range listed first
-                "end_date": "2025-08-20"
+                "end_date": "2025-08-20",
             },
             {
                 "start_date": "2025-08-05",  # Earlier range listed second
-                "end_date": "2025-08-10"
-            }
+                "end_date": "2025-08-10",
+            },
         ]
-        
+
         complete_days = [
-            datetime(2025, 8, 7),   # In first chronological range
+            datetime(2025, 8, 7),  # In first chronological range
             datetime(2025, 8, 12),  # Between ranges
-            datetime(2025, 8, 17)   # In second chronological range
+            datetime(2025, 8, 17),  # In second chronological range
         ]
-        
+
         result = filter_unprocessed_dates(processed_ranges, complete_days)
-        
+
         # Only the day between ranges should be unprocessed
         expected = [datetime(2025, 8, 12)]
         self.assertEqual(result, expected)
 
     def test_empty_complete_days(self):
         """Test with empty complete_days list."""
-        processed_ranges = [
-            {
-                "start_date": "2025-08-01",
-                "end_date": "2025-08-31"
-            }
-        ]
-        
+        processed_ranges = [{"start_date": "2025-08-01", "end_date": "2025-08-31"}]
+
         result = filter_unprocessed_dates(processed_ranges, [])
         self.assertEqual(result, [])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -7,6 +7,7 @@ Utilities:
 - urlopen_sequence: build a side_effect for urlopen that yields exceptions
   or DummyResp-wrapped payloads in order.
 """
+
 import json
 import os
 from contextlib import contextmanager
@@ -19,11 +20,12 @@ class DummyResp:
         with urllib.request.urlopen(...) as resp:
             resp.read() -> bytes
     """
+
     def __init__(self, payload):
         self._payload = payload
 
     def read(self):
-        return json.dumps(self._payload).encode('utf-8')
+        return json.dumps(self._payload).encode("utf-8")
 
     def __enter__(self):
         return self

--- a/test/test_holiday_api_resilience.py
+++ b/test/test_holiday_api_resilience.py
@@ -8,56 +8,87 @@ from test.test_helpers import temp_env, urlopen_sequence
 
 class TestHolidayApiResilience(unittest.TestCase):
     def test_timeout_then_success(self):
-        with temp_env(dict(
-            HOLIDAY_API_MAX_RETRIES='2',
-            HOLIDAY_API_BACKOFF_BASE='0',
-            HOLIDAY_API_MAX_BACKOFF='0'
-        )):
+        with temp_env(
+            dict(
+                HOLIDAY_API_MAX_RETRIES="2",
+                HOLIDAY_API_BACKOFF_BASE="0",
+                HOLIDAY_API_MAX_BACKOFF="0",
+            )
+        ):
             an = AttendanceAnalyzer()
             seq = [
-                TimeoutError('timed out'),
-                [{'date': '20271010', 'week': '日', 'isHoliday': True, 'description': '國慶日'}],
+                TimeoutError("timed out"),
+                [
+                    {
+                        "date": "20271010",
+                        "week": "日",
+                        "isHoliday": True,
+                        "description": "國慶日",
+                    }
+                ],
             ]
-            with mock.patch('urllib.request.urlopen', side_effect=urlopen_sequence(seq)):
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
+            ):
                 ok = an._try_load_from_gov_api(2027)
         self.assertTrue(ok)
-        self.assertIn(datetime.strptime('2027/10/10','%Y/%m/%d').date(), an.holidays)
+        self.assertIn(datetime.strptime("2027/10/10", "%Y/%m/%d").date(), an.holidays)
 
     def test_http_5xx_then_success(self):
         from urllib.error import HTTPError
+
         class _HTTPError(HTTPError):
             def __init__(self, code):
-                super().__init__('http://x', code, 'err', hdrs=None, fp=None)
-        with temp_env(dict(
-            HOLIDAY_API_MAX_RETRIES='2',
-            HOLIDAY_API_BACKOFF_BASE='0',
-            HOLIDAY_API_MAX_BACKOFF='0'
-        )):
+                super().__init__("http://x", code, "err", hdrs=None, fp=None)
+
+        with temp_env(
+            dict(
+                HOLIDAY_API_MAX_RETRIES="2",
+                HOLIDAY_API_BACKOFF_BASE="0",
+                HOLIDAY_API_MAX_BACKOFF="0",
+            )
+        ):
             an = AttendanceAnalyzer()
             seq = [
                 _HTTPError(503),
-                [{'date': '20260101', 'week': '四', 'isHoliday': True, 'description': '元旦'}],
+                [
+                    {
+                        "date": "20260101",
+                        "week": "四",
+                        "isHoliday": True,
+                        "description": "元旦",
+                    }
+                ],
             ]
-            with mock.patch('urllib.request.urlopen', side_effect=urlopen_sequence(seq)):
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
+            ):
                 ok = an._try_load_from_gov_api(2026)
         self.assertTrue(ok)
-        self.assertIn(datetime.strptime('2026/01/01','%Y/%m/%d').date(), an.holidays)
+        self.assertIn(datetime.strptime("2026/01/01", "%Y/%m/%d").date(), an.holidays)
 
     def test_non_retryable_4xx_fails(self):
         from urllib.error import HTTPError
+
         class _HTTPError(HTTPError):
             def __init__(self, code):
-                super().__init__('http://x', code, 'err', hdrs=None, fp=None)
+                super().__init__("http://x", code, "err", hdrs=None, fp=None)
+
         def urlopen_side(url, timeout=10, context=None):
             raise _HTTPError(403)
-        with temp_env(dict(
-            HOLIDAY_API_MAX_RETRIES='1',
-            HOLIDAY_API_BACKOFF_BASE='0',
-            HOLIDAY_API_MAX_BACKOFF='0'
-        )):
+
+        with temp_env(
+            dict(
+                HOLIDAY_API_MAX_RETRIES="1",
+                HOLIDAY_API_BACKOFF_BASE="0",
+                HOLIDAY_API_MAX_BACKOFF="0",
+            )
+        ):
             an = AttendanceAnalyzer()
-            with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_side):
                 ok = an._try_load_from_gov_api(2028)
         self.assertFalse(ok)
+
+
 """Category: Holidays/API
 Purpose: Retry and resilience handling for gov open data provider."""

--- a/test/test_holiday_api_resilience.py
+++ b/test/test_holiday_api_resilience.py
@@ -27,9 +27,7 @@ class TestHolidayApiResilience(unittest.TestCase):
                     }
                 ],
             ]
-            with mock.patch(
-                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
-            ):
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
                 ok = an._try_load_from_gov_api(2027)
         self.assertTrue(ok)
         self.assertIn(datetime.strptime("2027/10/10", "%Y/%m/%d").date(), an.holidays)
@@ -60,9 +58,7 @@ class TestHolidayApiResilience(unittest.TestCase):
                     }
                 ],
             ]
-            with mock.patch(
-                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
-            ):
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
                 ok = an._try_load_from_gov_api(2026)
         self.assertTrue(ok)
         self.assertIn(datetime.strptime("2026/01/01", "%Y/%m/%d").date(), an.holidays)

--- a/test/test_holiday_api_retry.py
+++ b/test/test_holiday_api_retry.py
@@ -32,15 +32,11 @@ class TestHolidayApiRetry(unittest.TestCase):
                     },
                 ],
             ]
-            with mock.patch(
-                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
-            ):
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
                 ok = analyzer._try_load_from_gov_api(2026)
 
         self.assertTrue(ok)
-        self.assertIn(
-            datetime.strptime("2026/01/01", "%Y/%m/%d").date(), analyzer.holidays
-        )
+        self.assertIn(datetime.strptime("2026/01/01", "%Y/%m/%d").date(), analyzer.holidays)
 
     def test_retry_exhaustion_then_fallback(self):
         with temp_env(
@@ -49,9 +45,7 @@ class TestHolidayApiRetry(unittest.TestCase):
             HOLIDAY_API_MAX_BACKOFF="0",
         ):
             analyzer = AttendanceAnalyzer()
-            with mock.patch(
-                "urllib.request.urlopen", side_effect=Exception("network down")
-            ):
+            with mock.patch("urllib.request.urlopen", side_effect=Exception("network down")):
                 ok = analyzer._try_load_from_gov_api(2027)
 
         self.assertFalse(ok)
@@ -74,9 +68,7 @@ class TestHolidayApiRetry(unittest.TestCase):
                     }
                 ],
             ]
-            with mock.patch(
-                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
-            ):
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
                 ok = analyzer._try_load_from_gov_api(2027)
         self.assertTrue(ok)
 

--- a/test/test_holiday_api_retry.py
+++ b/test/test_holiday_api_retry.py
@@ -11,31 +11,47 @@ class TestHolidayApiRetry(unittest.TestCase):
         with temp_env(
             HOLIDAY_API_MAX_RETRIES="3",
             HOLIDAY_API_BACKOFF_BASE="0",
-            HOLIDAY_API_MAX_BACKOFF="0"
+            HOLIDAY_API_MAX_BACKOFF="0",
         ):
             analyzer = AttendanceAnalyzer()
             seq = [
                 Exception("temporary failure"),
                 Exception("temporary failure"),
                 [
-                    {"date": "20260101", "week": "四", "isHoliday": True, "description": "元旦"},
-                    {"date": "20260102", "week": "五", "isHoliday": False, "description": ""},
+                    {
+                        "date": "20260101",
+                        "week": "四",
+                        "isHoliday": True,
+                        "description": "元旦",
+                    },
+                    {
+                        "date": "20260102",
+                        "week": "五",
+                        "isHoliday": False,
+                        "description": "",
+                    },
                 ],
             ]
-            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
+            ):
                 ok = analyzer._try_load_from_gov_api(2026)
 
         self.assertTrue(ok)
-        self.assertIn(datetime.strptime("2026/01/01", "%Y/%m/%d").date(), analyzer.holidays)
+        self.assertIn(
+            datetime.strptime("2026/01/01", "%Y/%m/%d").date(), analyzer.holidays
+        )
 
     def test_retry_exhaustion_then_fallback(self):
         with temp_env(
             HOLIDAY_API_MAX_RETRIES="2",
             HOLIDAY_API_BACKOFF_BASE="0",
-            HOLIDAY_API_MAX_BACKOFF="0"
+            HOLIDAY_API_MAX_BACKOFF="0",
         ):
             analyzer = AttendanceAnalyzer()
-            with mock.patch("urllib.request.urlopen", side_effect=Exception("network down")):
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=Exception("network down")
+            ):
                 ok = analyzer._try_load_from_gov_api(2027)
 
         self.assertFalse(ok)
@@ -44,15 +60,26 @@ class TestHolidayApiRetry(unittest.TestCase):
         with temp_env(
             HOLIDAY_API_MAX_RETRIES="2",
             HOLIDAY_API_BACKOFF_BASE="0",
-            HOLIDAY_API_MAX_BACKOFF="0"
+            HOLIDAY_API_MAX_BACKOFF="0",
         ):
             analyzer = AttendanceAnalyzer()
             seq = [
                 TimeoutError("timed out"),
-                [{"date": "20271010", "week": "日", "isHoliday": True, "description": "國慶日"}],
+                [
+                    {
+                        "date": "20271010",
+                        "week": "日",
+                        "isHoliday": True,
+                        "description": "國慶日",
+                    }
+                ],
             ]
-            with mock.patch("urllib.request.urlopen", side_effect=urlopen_sequence(seq)):
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=urlopen_sequence(seq)
+            ):
                 ok = analyzer._try_load_from_gov_api(2027)
         self.assertTrue(ok)
+
+
 """Category: Holidays/API
 Purpose: Analyzer facade retry path via _try_load_from_gov_api."""

--- a/test/test_holidays_extra_coverage.py
+++ b/test/test_holidays_extra_coverage.py
@@ -19,46 +19,52 @@ class TestHolidaysExtraCoverage(unittest.TestCase):
 
         class DTProxy:
             calls = 0
+
             @classmethod
             def strptime(cls, s, fmt):
                 cls.calls += 1
                 if cls.calls == 1:
-                    raise ValueError('boom')
+                    raise ValueError("boom")
                 return real_dt.strptime(s, fmt)
 
-        with mock.patch('lib.holidays.datetime', new=DTProxy):
+        with mock.patch("lib.holidays.datetime", new=DTProxy):
             out = H.Hardcoded2025Provider().load(2025)
         # still returns a set (with first date skipped)
         self.assertTrue(any(d.year == 2025 for d in out))
 
     def test_basic_fixed_handles_value_error(self):
         real_dt = H.datetime
+
         class DTProxy:
             calls = 0
+
             @classmethod
             def strptime(cls, s, fmt):
                 cls.calls += 1
                 if cls.calls == 1:
-                    raise ValueError('bad-basic')
+                    raise ValueError("bad-basic")
                 return real_dt.strptime(s, fmt)
-        with mock.patch('lib.holidays.datetime', new=DTProxy):
+
+        with mock.patch("lib.holidays.datetime", new=DTProxy):
             out = H.BasicFixedProvider().load(2027)
         self.assertTrue(any(d.year == 2027 for d in out))
 
     def test_service_returns_gov_when_nonempty(self):
         with temp_env(
-            HOLIDAY_API_MAX_RETRIES='0',
-            HOLIDAY_API_BACKOFF_BASE='0',
-            HOLIDAY_API_MAX_BACKOFF='0'
+            HOLIDAY_API_MAX_RETRIES="0",
+            HOLIDAY_API_BACKOFF_BASE="0",
+            HOLIDAY_API_MAX_BACKOFF="0",
         ):
             svc = H.HolidayService()
             fake_set = {datetime(2026, 1, 1).date()}
-            with mock.patch.object(H.TaiwanGovOpenDataProvider, 'load', return_value=fake_set):
+            with mock.patch.object(
+                H.TaiwanGovOpenDataProvider, "load", return_value=fake_set
+            ):
                 out = svc.load_year(2026)
         self.assertEqual(out, fake_set)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Holidays/Providers
 Purpose: Provider edge handling and service behavior when gov returns data."""

--- a/test/test_holidays_extra_coverage.py
+++ b/test/test_holidays_extra_coverage.py
@@ -57,9 +57,7 @@ class TestHolidaysExtraCoverage(unittest.TestCase):
         ):
             svc = H.HolidayService()
             fake_set = {datetime(2026, 1, 1).date()}
-            with mock.patch.object(
-                H.TaiwanGovOpenDataProvider, "load", return_value=fake_set
-            ):
+            with mock.patch.object(H.TaiwanGovOpenDataProvider, "load", return_value=fake_set):
                 out = svc.load_year(2026)
         self.assertEqual(out, fake_set)
 

--- a/test/test_holidays_missing_records.py
+++ b/test/test_holidays_missing_records.py
@@ -34,9 +34,7 @@ class TestHolidaysMissingRecords(unittest.TestCase):
         self.assertEqual(out, set())
         logs = "\n".join(cm.output)
         self.assertIn("資訊: 嘗試載入 2026 年假日 (第 1/1 次)...", logs)
-        self.assertIn(
-            "錯誤: 嘗試 1 次後仍無法載入 2026 年假日資料。回退到基本假日。", logs
-        )
+        self.assertIn("錯誤: 嘗試 1 次後仍無法載入 2026 年假日資料。回退到基本假日。", logs)
 
 
 if __name__ == "__main__":

--- a/test/test_holidays_missing_records.py
+++ b/test/test_holidays_missing_records.py
@@ -10,31 +10,36 @@ from test.test_helpers import DummyResp, temp_env
 class TestHolidaysMissingRecords(unittest.TestCase):
     def test_missing_result_or_records_returns_empty(self):
         # Speed up tests by removing backoff and limiting retries
-        with temp_env({
-            'HOLIDAY_API_MAX_RETRIES': '1',
-            'HOLIDAY_API_BACKOFF_BASE': '0',
-            'HOLIDAY_API_MAX_BACKOFF': '0'
-        }):
+        with temp_env(
+            {
+                "HOLIDAY_API_MAX_RETRIES": "1",
+                "HOLIDAY_API_BACKOFF_BASE": "0",
+                "HOLIDAY_API_MAX_BACKOFF": "0",
+            }
+        ):
             # First attempt: no 'result' key
             payload1 = {}
             # Second attempt: 'result' present but no 'records'
-            payload2 = {'result': {}}
+            payload2 = {"result": {}}
             seq = [DummyResp(payload1), DummyResp(payload2)]
+
             def urlopen_side(url, timeout=10, context=None):
                 return seq.pop(0)
 
             p = TaiwanGovOpenDataProvider()
-            with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
-                with self.assertLogs('lib.holidays', level='INFO') as cm:
+            with mock.patch("urllib.request.urlopen", side_effect=urlopen_side):
+                with self.assertLogs("lib.holidays", level="INFO") as cm:
                     out = p.load(2026)
         # Should gracefully return empty set after retries exhausted
         self.assertEqual(out, set())
         logs = "\n".join(cm.output)
-        self.assertIn('資訊: 嘗試載入 2026 年假日 (第 1/1 次)...', logs)
-        self.assertIn('錯誤: 嘗試 1 次後仍無法載入 2026 年假日資料。回退到基本假日。', logs)
+        self.assertIn("資訊: 嘗試載入 2026 年假日 (第 1/1 次)...", logs)
+        self.assertIn(
+            "錯誤: 嘗試 1 次後仍無法載入 2026 年假日資料。回退到基本假日。", logs
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Holidays/API
 Purpose: Missing 'result' / 'records' handling with retry exhaustion."""

--- a/test/test_holidays_more.py
+++ b/test/test_holidays_more.py
@@ -9,9 +9,9 @@ from test.test_helpers import DummyResp, temp_env
 
 # Environment settings for testing to avoid long lines
 TEST_ENV_SETTINGS = {
-    'HOLIDAY_API_MAX_RETRIES': '1',
-    'HOLIDAY_API_BACKOFF_BASE': '0',
-    'HOLIDAY_API_MAX_BACKOFF': '0'
+    "HOLIDAY_API_MAX_RETRIES": "1",
+    "HOLIDAY_API_BACKOFF_BASE": "0",
+    "HOLIDAY_API_MAX_BACKOFF": "0",
 }
 
 
@@ -21,33 +21,37 @@ class FakeParse:
 
 
 class TestHolidaysMore(unittest.TestCase):
-
     def test_invalid_date_record_is_skipped(self):
         payload = [
-            {'date': 'bad-date', 'week': '?', 'isHoliday': True, 'description': ''},
-            {'date': '20261010', 'week': '六', 'isHoliday': True, 'description': '國慶日'},
-            {'date': '20260102', 'week': '五', 'isHoliday': False, 'description': ''},
+            {"date": "bad-date", "week": "?", "isHoliday": True, "description": ""},
+            {
+                "date": "20261010",
+                "week": "六",
+                "isHoliday": True,
+                "description": "國慶日",
+            },
+            {"date": "20260102", "week": "五", "isHoliday": False, "description": ""},
         ]
         with temp_env(TEST_ENV_SETTINGS):
             p = TaiwanGovOpenDataProvider()
-            with mock.patch('urllib.request.urlopen', return_value=DummyResp(payload)):
-                with self.assertLogs('lib.holidays', level='WARNING') as cm:
+            with mock.patch("urllib.request.urlopen", return_value=DummyResp(payload)):
+                with self.assertLogs("lib.holidays", level="WARNING") as cm:
                     out = p.load(2026)
-        self.assertIn(datetime.strptime('2026/10/10','%Y/%m/%d').date(), out)
+        self.assertIn(datetime.strptime("2026/10/10", "%Y/%m/%d").date(), out)
         logs = "\n".join(cm.output)
-        self.assertIn('跳過無效的日期格式', logs)
+        self.assertIn("跳過無效的日期格式", logs)
 
     def test_unsupported_scheme_returns_empty(self):
         with temp_env(TEST_ENV_SETTINGS):
             p = TaiwanGovOpenDataProvider()
-            with mock.patch('lib.holidays.urlparse', return_value=FakeParse('file')):
-                with self.assertLogs('lib.holidays', level='WARNING') as cm:
+            with mock.patch("lib.holidays.urlparse", return_value=FakeParse("file")):
+                with self.assertLogs("lib.holidays", level="WARNING") as cm:
                     out = p.load(2026)
         self.assertEqual(out, set())
-        self.assertIn('不支援的 URL scheme', "\n".join(cm.output))
+        self.assertIn("不支援的 URL scheme", "\n".join(cm.output))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Holidays/API
 Purpose: Invalid record filtering and scheme rejection paths."""

--- a/test/test_holidays_providers.py
+++ b/test/test_holidays_providers.py
@@ -92,9 +92,7 @@ class TestHolidaysProviders(unittest.TestCase):
 
     def test_service_fallbacks_to_basic_when_gov_empty(self):
         s = HolidayService()
-        with mock.patch(
-            "lib.holidays.TaiwanGovOpenDataProvider.load", return_value=set()
-        ):
+        with mock.patch("lib.holidays.TaiwanGovOpenDataProvider.load", return_value=set()):
             out = s.load_year(2029)
         self.assertIn(datetime.strptime("2029/01/01", "%Y/%m/%d").date(), out)
 

--- a/test/test_holidays_providers.py
+++ b/test/test_holidays_providers.py
@@ -17,9 +17,9 @@ class TestHolidaysProviders(unittest.TestCase):
     def setUp(self):
         # Speed up backoff during tests
         self._env = dict(os.environ)
-        os.environ['HOLIDAY_API_MAX_RETRIES'] = '2'
-        os.environ['HOLIDAY_API_BACKOFF_BASE'] = '0'
-        os.environ['HOLIDAY_API_MAX_BACKOFF'] = '0'
+        os.environ["HOLIDAY_API_MAX_RETRIES"] = "2"
+        os.environ["HOLIDAY_API_BACKOFF_BASE"] = "0"
+        os.environ["HOLIDAY_API_MAX_BACKOFF"] = "0"
 
     def tearDown(self):
         os.environ.clear()
@@ -28,27 +28,34 @@ class TestHolidaysProviders(unittest.TestCase):
     def test_hardcoded_2025_contains_known_date(self):
         p = Hardcoded2025Provider()
         s = p.load(2025)
-        self.assertIn(datetime.strptime('2025/10/10', '%Y/%m/%d').date(), s)
+        self.assertIn(datetime.strptime("2025/10/10", "%Y/%m/%d").date(), s)
         self.assertEqual(len(p.load(2024)), 0)
 
     def test_basic_fixed_provider_jan1_and_national_day(self):
         p = BasicFixedProvider()
         s = p.load(2026)
-        self.assertIn(datetime.strptime('2026/01/01', '%Y/%m/%d').date(), s)
-        self.assertIn(datetime.strptime('2026/10/10', '%Y/%m/%d').date(), s)
+        self.assertIn(datetime.strptime("2026/01/01", "%Y/%m/%d").date(), s)
+        self.assertIn(datetime.strptime("2026/10/10", "%Y/%m/%d").date(), s)
 
     def test_gov_provider_timeout_then_success(self):
         seq = []
-        seq.append(TimeoutError('timed out'))
+        seq.append(TimeoutError("timed out"))
         payload = [
-            {'date': '20271010', 'week': '日', 'isHoliday': True, 'description': '國慶日'},
+            {
+                "date": "20271010",
+                "week": "日",
+                "isHoliday": True,
+                "description": "國慶日",
+            },
         ]
 
         class DummyResp:
             def read(self):
-                return json.dumps(payload).encode('utf-8')
+                return json.dumps(payload).encode("utf-8")
+
             def __enter__(self):
                 return self
+
             def __exit__(self, *args):
                 return False
 
@@ -61,36 +68,38 @@ class TestHolidaysProviders(unittest.TestCase):
             return v
 
         p = TaiwanGovOpenDataProvider()
-        with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen_side):
             out = p.load(2027)
-        self.assertIn(datetime.strptime('2027/10/10', '%Y/%m/%d').date(), out)
+        self.assertIn(datetime.strptime("2027/10/10", "%Y/%m/%d").date(), out)
 
     def test_gov_provider_non_retryable_403(self):
         class _HTTPError(HTTPError):
             def __init__(self, code):
-                super().__init__('http://x', code, 'err', hdrs=None, fp=None)
+                super().__init__("http://x", code, "err", hdrs=None, fp=None)
 
         def urlopen_side(url, timeout=10, context=None):
             raise _HTTPError(403)
 
         p = TaiwanGovOpenDataProvider()
-        with mock.patch('urllib.request.urlopen', side_effect=urlopen_side):
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen_side):
             out = p.load(2028)
         self.assertEqual(len(out), 0)
 
     def test_service_uses_hardcoded_for_2025(self):
         s = HolidayService()
         out = s.load_year(2025)
-        self.assertIn(datetime.strptime('2025/01/01', '%Y/%m/%d').date(), out)
+        self.assertIn(datetime.strptime("2025/01/01", "%Y/%m/%d").date(), out)
 
     def test_service_fallbacks_to_basic_when_gov_empty(self):
         s = HolidayService()
-        with mock.patch('lib.holidays.TaiwanGovOpenDataProvider.load', return_value=set()):
+        with mock.patch(
+            "lib.holidays.TaiwanGovOpenDataProvider.load", return_value=set()
+        ):
             out = s.load_year(2029)
-        self.assertIn(datetime.strptime('2029/01/01', '%Y/%m/%d').date(), out)
+        self.assertIn(datetime.strptime("2029/01/01", "%Y/%m/%d").date(), out)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Holidays/Providers
 Purpose: Validate hardcoded/basic providers and service fallbacks."""

--- a/test/test_import_helpers.py
+++ b/test/test_import_helpers.py
@@ -11,9 +11,7 @@ class TestImportParserArgs(unittest.TestCase):
         return parser.parse_args(argv)
 
     def test_minimal(self):
-        ns = self._parse(
-            "import", "snap.json", "--from=portal-json", "--out", "out.txt"
-        )
+        ns = self._parse("import", "snap.json", "--from=portal-json", "--out", "out.txt")
         self.assertEqual(ns.cmd, "import")
         self.assertEqual(ns.snapshot, "snap.json")
         self.assertEqual(ns.source, "portal-json")

--- a/test/test_import_helpers.py
+++ b/test/test_import_helpers.py
@@ -1,16 +1,19 @@
 """Unit tests for `lib/commands/import_.py` parser surface (Tier 1)."""
+
 import unittest
 
 
 class TestImportParserArgs(unittest.TestCase):
     def _parse(self, *argv):
         from lib.cli import build_parser
+
         parser = build_parser()
         return parser.parse_args(argv)
 
     def test_minimal(self):
-        ns = self._parse("import", "snap.json",
-                         "--from=portal-json", "--out", "out.txt")
+        ns = self._parse(
+            "import", "snap.json", "--from=portal-json", "--out", "out.txt"
+        )
         self.assertEqual(ns.cmd, "import")
         self.assertEqual(ns.snapshot, "snap.json")
         self.assertEqual(ns.source, "portal-json")
@@ -18,8 +21,9 @@ class TestImportParserArgs(unittest.TestCase):
         self.assertFalse(ns.legacy)
 
     def test_legacy_flag(self):
-        ns = self._parse("import", "snap.json",
-                         "--from=portal-json", "--out", "out.txt", "--legacy")
+        ns = self._parse(
+            "import", "snap.json", "--from=portal-json", "--out", "out.txt", "--legacy"
+        )
         self.assertTrue(ns.legacy)
 
 

--- a/test/test_importers_portal_json.py
+++ b/test/test_importers_portal_json.py
@@ -161,9 +161,7 @@ class TestSnapshotFromLegacyJson(unittest.TestCase):
 
     def test_legacy_dict_with_records(self):
         # The actual session's agent-browser eval produced this shape.
-        path = self._write(
-            {"totalPages": 4, "recordCount": 62, "records": SAMPLE_RECORDS}
-        )
+        path = self._write({"totalPages": 4, "recordCount": 62, "records": SAMPLE_RECORDS})
         try:
             promoted = snapshot_from_legacy_json(path)
             self.assertEqual(promoted["schema_version"], SCHEMA_VERSION)

--- a/test/test_importers_portal_json.py
+++ b/test/test_importers_portal_json.py
@@ -1,4 +1,5 @@
 """Tests for `lib/importers/portal_json.py`."""
+
 import json
 import os
 import tempfile
@@ -126,8 +127,9 @@ class TestImportFromDict(unittest.TestCase):
 
     def test_rejects_wrong_major(self):
         with self.assertRaises(SchemaVersionError):
-            import_from_dict({"schema_version": f"{SCHEMA_VERSION.split('/')[0]}/v9",
-                              "records": []})
+            import_from_dict(
+                {"schema_version": f"{SCHEMA_VERSION.split('/')[0]}/v9", "records": []}
+            )
 
 
 class TestConvertFile(unittest.TestCase):
@@ -159,7 +161,9 @@ class TestSnapshotFromLegacyJson(unittest.TestCase):
 
     def test_legacy_dict_with_records(self):
         # The actual session's agent-browser eval produced this shape.
-        path = self._write({"totalPages": 4, "recordCount": 62, "records": SAMPLE_RECORDS})
+        path = self._write(
+            {"totalPages": 4, "recordCount": 62, "records": SAMPLE_RECORDS}
+        )
         try:
             promoted = snapshot_from_legacy_json(path)
             self.assertEqual(promoted["schema_version"], SCHEMA_VERSION)

--- a/test/test_more_core_paths.py
+++ b/test/test_more_core_paths.py
@@ -69,9 +69,7 @@ class TestAnalyzerAdditionalPaths(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             src = os.path.join(os.getcwd(), "sample-attendance-data.txt")
             path = os.path.join(tmp, "sample-attendance-data.txt")
-            with open(src, encoding="utf-8") as fsrc, open(
-                path, "w", encoding="utf-8"
-            ) as fdst:
+            with open(src, encoding="utf-8") as fsrc, open(path, "w", encoding="utf-8") as fdst:
                 fdst.write(fsrc.read())
 
             an = AttendanceAnalyzer()
@@ -134,9 +132,7 @@ class TestAnalyzerAdditionalPaths(unittest.TestCase):
         an = AttendanceAnalyzer()
         # No records; direct call to use default years branch
         an._load_taiwan_holidays()
-        self.assertTrue(
-            any(d.strftime("%Y/%m/%d") == "2025/10/10" for d in an.holidays)
-        )
+        self.assertTrue(any(d.strftime("%Y/%m/%d") == "2025/10/10" for d in an.holidays))
 
 
 if __name__ == "__main__":

--- a/test/test_more_core_paths.py
+++ b/test/test_more_core_paths.py
@@ -12,40 +12,42 @@ class TestAnalyzerAdditionalPaths(unittest.TestCase):
     def test_config_overrides(self):
         # Write a temporary config that overrides one value
         with tempfile.TemporaryDirectory() as tmp:
-            cfg_path = os.path.join(tmp, 'config.json')
-            with open(cfg_path, 'w', encoding='utf-8') as f:
+            cfg_path = os.path.join(tmp, "config.json")
+            with open(cfg_path, "w", encoding="utf-8") as f:
                 json.dump({"min_overtime_minutes": 30}, f)
             an = AttendanceAnalyzer(config_path=cfg_path)
             self.assertEqual(an.config.min_overtime_minutes, 30)
 
     def test_parse_file_blank_and_exception_line(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, '202507-小王-出勤資料.txt')
-            with open(path, 'w', encoding='utf-8') as f:
-                f.write('頭\t欄\t位\n')
-                f.write('\n')  # blank triggers continue
-                f.write('x\ty\t上班\n')  # will be fed to patched parser
+            path = os.path.join(tmp, "202507-小王-出勤資料.txt")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("頭\t欄\t位\n")
+                f.write("\n")  # blank triggers continue
+                f.write("x\ty\t上班\n")  # will be fed to patched parser
 
             an = AttendanceAnalyzer()
 
             # Patch internal line parser to raise, to hit except branch
             with patch.object(
-                AttendanceAnalyzer, '_parse_attendance_line', side_effect=ValueError('bad')
+                AttendanceAnalyzer,
+                "_parse_attendance_line",
+                side_effect=ValueError("bad"),
             ):
-                with self.assertLogs(level='WARNING') as cm:
+                with self.assertLogs(level="WARNING") as cm:
                     an.parse_attendance_file(path, incremental=False)
-            self.assertIn('解析失敗', "\n".join(cm.output))
+            self.assertIn("解析失敗", "\n".join(cm.output))
 
     def test_export_report_triggers_backup_and_excel_issue_rows(self):
         # Craft data that yields issues and ensure backup log is printed
         text = (
-            '應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n'
-            '2025/07/01 09:00\t2025/07/01 11:00\t上班\t1\t刷卡匯入\t\t\t\t\n'  # late
-            '2025/07/01 18:00\t2025/07/01 20:15\t下班\t1\t刷卡匯入\t\t\t\t\n'  # overtime
+            "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+            "2025/07/01 09:00\t2025/07/01 11:00\t上班\t1\t刷卡匯入\t\t\t\t\n"  # late
+            "2025/07/01 18:00\t2025/07/01 20:15\t下班\t1\t刷卡匯入\t\t\t\t\n"  # overtime
         )
         with tempfile.TemporaryDirectory() as tmp:
-            in_path = os.path.join(tmp, '202507-王小明-出勤資料.txt')
-            with open(in_path, 'w', encoding='utf-8') as f:
+            in_path = os.path.join(tmp, "202507-王小明-出勤資料.txt")
+            with open(in_path, "w", encoding="utf-8") as f:
                 f.write(text)
 
             an = AttendanceAnalyzer()
@@ -53,21 +55,23 @@ class TestAnalyzerAdditionalPaths(unittest.TestCase):
             an.group_records_by_day()
             an.analyze_attendance()
 
-            out_xlsx = os.path.join(tmp, 'out.xlsx')
+            out_xlsx = os.path.join(tmp, "out.xlsx")
             # Pre-create to force backup
-            open(out_xlsx, 'wb').close()
-            with self.assertLogs(level='INFO') as cm:
-                an.export_report(out_xlsx, 'excel', export_policy='archive')
+            open(out_xlsx, "wb").close()
+            with self.assertLogs(level="INFO") as cm:
+                an.export_report(out_xlsx, "excel", export_policy="archive")
             logs = "\n".join(cm.output)
-            self.assertIn('備份現有檔案', logs)
+            self.assertIn("備份現有檔案", logs)
             self.assertTrue(os.path.exists(out_xlsx))
 
     def test_openpyxl_import_error_branch(self):
         # Ensure the inner openpyxl import error fallback in export_excel is covered
         with tempfile.TemporaryDirectory() as tmp:
-            src = os.path.join(os.getcwd(), 'sample-attendance-data.txt')
-            path = os.path.join(tmp, 'sample-attendance-data.txt')
-            with open(src, encoding='utf-8') as fsrc, open(path, 'w', encoding='utf-8') as fdst:
+            src = os.path.join(os.getcwd(), "sample-attendance-data.txt")
+            path = os.path.join(tmp, "sample-attendance-data.txt")
+            with open(src, encoding="utf-8") as fsrc, open(
+                path, "w", encoding="utf-8"
+            ) as fdst:
                 fdst.write(fsrc.read())
 
             an = AttendanceAnalyzer()
@@ -77,37 +81,40 @@ class TestAnalyzerAdditionalPaths(unittest.TestCase):
 
             # Patch import to raise ImportError when importing openpyxl
             import builtins as _builtins
+
             real_import = _builtins.__import__
 
             def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-                if name == 'openpyxl':
-                    raise ImportError('no openpyxl installed')
+                if name == "openpyxl":
+                    raise ImportError("no openpyxl installed")
                 return real_import(name, globals, locals, fromlist, level)
 
-            xlsx = path.replace('.txt', '_analysis.xlsx')
-            csv = path.replace('.txt', '_analysis.csv')
-            with patch('builtins.__import__', side_effect=fake_import):
-                with self.assertLogs(level='WARNING') as cm:
+            xlsx = path.replace(".txt", "_analysis.xlsx")
+            csv = path.replace(".txt", "_analysis.csv")
+            with patch("builtins.__import__", side_effect=fake_import):
+                with self.assertLogs(level="WARNING") as cm:
                     an.export_excel(xlsx)
             self.assertTrue(os.path.exists(csv))
-            self.assertIn('未安裝 openpyxl，回退使用CSV格式', "\n".join(cm.output))
+            self.assertIn("未安裝 openpyxl，回退使用CSV格式", "\n".join(cm.output))
 
     def test_compute_incremental_status_row_returns_none_when_unprocessed(self):
         # Create one complete day
         with tempfile.TemporaryDirectory() as tmp:
-            p = os.path.join(tmp, '202507-王小明-出勤資料.txt')
-            with open(p, 'w', encoding='utf-8') as f:
-                f.write('h\th\th\n')
-                f.write('2025/07/01 09:00\t2025/07/01 09:00\t上班\t\n')
-                f.write('2025/07/01 18:00\t2025/07/01 18:00\t下班\t\n')
+            p = os.path.join(tmp, "202507-王小明-出勤資料.txt")
+            with open(p, "w", encoding="utf-8") as f:
+                f.write("h\th\th\n")
+                f.write("2025/07/01 09:00\t2025/07/01 09:00\t上班\t\n")
+                f.write("2025/07/01 18:00\t2025/07/01 18:00\t下班\t\n")
 
             class DummyState:
                 def __init__(self):
                     self.state_data = {"users": {}}
+
                 def get_user_processed_ranges(self, user):
                     return []
+
                 def get_last_analysis_time(self, user):
-                    return ''
+                    return ""
 
             an = AttendanceAnalyzer()
             an.parse_attendance_file(p, incremental=True)
@@ -115,20 +122,24 @@ class TestAnalyzerAdditionalPaths(unittest.TestCase):
 
             # Force unprocessed dates to be non-empty
             with patch.object(
-                AttendanceAnalyzer, '_get_unprocessed_dates', return_value=[datetime(2025, 7, 1)]
+                AttendanceAnalyzer,
+                "_get_unprocessed_dates",
+                return_value=[datetime(2025, 7, 1)],
             ):
                 an.state_manager = DummyState()
-                an.current_user = '王小明'
+                an.current_user = "王小明"
                 self.assertIsNone(an._compute_incremental_status_row())
 
     def test_load_taiwan_holidays_default_year(self):
         an = AttendanceAnalyzer()
         # No records; direct call to use default years branch
         an._load_taiwan_holidays()
-        self.assertTrue(any(d.strftime('%Y/%m/%d') == '2025/10/10' for d in an.holidays))
+        self.assertTrue(
+            any(d.strftime("%Y/%m/%d") == "2025/10/10" for d in an.holidays)
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Analyzer/Core
 Purpose: Config overrides, parse errors, backup log, import fallback, and status-row logic."""

--- a/test/test_more_excel_exporter.py
+++ b/test/test_more_excel_exporter.py
@@ -14,9 +14,7 @@ class TestExcelExporterMore(unittest.TestCase):
         xls.write_headers(ws, headers, header_font, header_fill, border, align)
 
         # Write status row and assert returned next row index
-        next_row = xls.write_status_row(
-            ws, "2025/07/31", 22, "2025-09-13T12:00:00", border, align
-        )
+        next_row = xls.write_status_row(ws, "2025/07/31", 22, "2025-09-13T12:00:00", border, align)
         self.assertEqual(next_row, 3)
         self.assertEqual(ws["A2"].value, "2025/07/31")
         self.assertEqual(ws["B2"].value, "狀態資訊")
@@ -34,9 +32,7 @@ class TestExcelExporterMore(unittest.TestCase):
                 True,
             ),
             Issue(datetime(2025, 7, 2), IssueType.WFH, 540, "WFH", "", "", False),
-            Issue(
-                datetime(2025, 7, 3), IssueType.FORGET_PUNCH, 30, "忘刷卡", "", "", True
-            ),
+            Issue(datetime(2025, 7, 3), IssueType.FORGET_PUNCH, 30, "忘刷卡", "", "", True),
         ]
         xls.write_issue_rows(
             ws,

--- a/test/test_more_excel_exporter.py
+++ b/test/test_more_excel_exporter.py
@@ -10,44 +10,59 @@ from lib import excel_exporter as xls
 class TestExcelExporterMore(unittest.TestCase):
     def test_status_row_and_type_colors(self):
         wb, ws, header_font, header_fill, border, align = xls.init_workbook()
-        headers = ['日期', '類型', '時長(分鐘)', '說明', '時段', '計算式', '狀態']
+        headers = ["日期", "類型", "時長(分鐘)", "說明", "時段", "計算式", "狀態"]
         xls.write_headers(ws, headers, header_font, header_fill, border, align)
 
         # Write status row and assert returned next row index
-        next_row = xls.write_status_row(ws, '2025/07/31', 22, '2025-09-13T12:00:00', border, align)
+        next_row = xls.write_status_row(
+            ws, "2025/07/31", 22, "2025-09-13T12:00:00", border, align
+        )
         self.assertEqual(next_row, 3)
-        self.assertEqual(ws['A2'].value, '2025/07/31')
-        self.assertEqual(ws['B2'].value, '狀態資訊')
-        self.assertEqual(ws['G2'].value, '系統狀態')
+        self.assertEqual(ws["A2"].value, "2025/07/31")
+        self.assertEqual(ws["B2"].value, "狀態資訊")
+        self.assertEqual(ws["G2"].value, "系統狀態")
 
         # Prepare issues to hit all color branches
         issues = [
             Issue(
-                datetime(2025, 7, 1), IssueType.OVERTIME, 120, '加班', '18:00~20:00', 'calc', True
+                datetime(2025, 7, 1),
+                IssueType.OVERTIME,
+                120,
+                "加班",
+                "18:00~20:00",
+                "calc",
+                True,
             ),
-            Issue(datetime(2025, 7, 2), IssueType.WFH, 540, 'WFH', '', '', False),
-            Issue(datetime(2025, 7, 3), IssueType.FORGET_PUNCH, 30, '忘刷卡', '', '', True),
+            Issue(datetime(2025, 7, 2), IssueType.WFH, 540, "WFH", "", "", False),
+            Issue(
+                datetime(2025, 7, 3), IssueType.FORGET_PUNCH, 30, "忘刷卡", "", "", True
+            ),
         ]
         xls.write_issue_rows(
-            ws, issues, start_row=next_row, incremental_mode=True, border=border, alignment=align
+            ws,
+            issues,
+            start_row=next_row,
+            incremental_mode=True,
+            border=border,
+            alignment=align,
         )
 
         # Sanity check values written
-        self.assertEqual(ws['B3'].value, '加班')
-        self.assertEqual(ws['B4'].value, 'WFH假')
-        self.assertEqual(ws['B5'].value, '忘刷卡')
-        self.assertEqual(ws['G3'].value, '[NEW] 本次新發現')
-        self.assertEqual(ws['G4'].value, '已存在')
+        self.assertEqual(ws["B3"].value, "加班")
+        self.assertEqual(ws["B4"].value, "WFH假")
+        self.assertEqual(ws["B5"].value, "忘刷卡")
+        self.assertEqual(ws["G3"].value, "[NEW] 本次新發現")
+        self.assertEqual(ws["G4"].value, "已存在")
 
         # Save to ensure no errors in save_workbook path
-        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp:
             xls.save_workbook(wb, tmp.name)
             saved = tmp.name
         self.assertTrue(os.path.exists(saved))
         os.remove(saved)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/Excel
 Purpose: Status row rendering, cell styles, and save routine."""

--- a/test/test_more_utils_and_holidays.py
+++ b/test/test_more_utils_and_holidays.py
@@ -12,20 +12,25 @@ from lib.state import AttendanceStateManager
 
 
 class DummyRec:
-    def __init__(self, date=None, type_name='CHECKOUT'):
+    def __init__(self, date=None, type_name="CHECKOUT"):
         self.date = date
+
         class T:
             name = type_name
+
         self.type = T()
 
 
 class DummyResp:
     def __init__(self, payload: dict):
         self._payload = payload
+
     def read(self):
-        return json.dumps(self._payload).encode('utf-8')
+        return json.dumps(self._payload).encode("utf-8")
+
     def __enter__(self):
         return self
+
     def __exit__(self, *args):
         return False
 
@@ -33,35 +38,39 @@ class DummyResp:
 class TestMiscGaps(unittest.TestCase):
     def test_parser_invalid_datetime_and_type(self):
         # parse_datetime_str invalid
-        self.assertIsNone(parser.parse_datetime_str('not-a-dt'))
+        self.assertIsNone(parser.parse_datetime_str("not-a-dt"))
         # parse_line invalid type returns None
-        self.assertIsNone(parser.parse_line('2025/07/01 09:00\t2025/07/01 09:00\t打卡\t'))
+        self.assertIsNone(
+            parser.parse_line("2025/07/01 09:00\t2025/07/01 09:00\t打卡\t")
+        )
         # parse_line missing scheduled returns None
-        self.assertIsNone(parser.parse_line('\t2025/07/01 09:00\t上班\t'))
+        self.assertIsNone(parser.parse_line("\t2025/07/01 09:00\t上班\t"))
 
     def test_filename_value_error_paths(self):
         # Invalid month causes ValueError path
-        self.assertEqual(parse_range_and_user('20251x-姓名-出勤資料.txt'), (None, None, None))
+        self.assertEqual(
+            parse_range_and_user("20251x-姓名-出勤資料.txt"), (None, None, None)
+        )
         # Force second segment to parse and then fail month math (13th month)
         self.assertEqual(
-            parse_range_and_user('202501-202513-姓名-出勤資料.txt'), (None, None, None)
+            parse_range_and_user("202501-202513-姓名-出勤資料.txt"), (None, None, None)
         )
 
     def test_grouping_skips_none_date(self):
-        out = group_daily([DummyRec(date=None), DummyRec(date=datetime(2025,7,1))])
-        self.assertIn(datetime(2025,7,1), out)
+        out = group_daily([DummyRec(date=None), DummyRec(date=datetime(2025, 7, 1))])
+        self.assertIn(datetime(2025, 7, 1), out)
 
     def test_state_getters_for_missing_user(self):
-        s = AttendanceStateManager(state_file=':memory:')
-        self.assertEqual(s.get_forget_punch_usage('nobody', '2025-07'), 0)
-        self.assertEqual(s.get_last_analysis_time('nobody'), '')
+        s = AttendanceStateManager(state_file=":memory:")
+        self.assertEqual(s.get_forget_punch_usage("nobody", "2025-07"), 0)
+        self.assertEqual(s.get_last_analysis_time("nobody"), "")
 
     def test_holiday_env_parsing_invalid(self):
         old = dict(os.environ)
         try:
-            os.environ['HOLIDAY_API_MAX_RETRIES'] = 'not-int'
-            os.environ['HOLIDAY_API_BACKOFF_BASE'] = 'not-float'
-            os.environ['HOLIDAY_API_MAX_BACKOFF'] = 'not-float'
+            os.environ["HOLIDAY_API_MAX_RETRIES"] = "not-int"
+            os.environ["HOLIDAY_API_BACKOFF_BASE"] = "not-float"
+            os.environ["HOLIDAY_API_MAX_BACKOFF"] = "not-float"
             p = TaiwanGovOpenDataProvider()
             # Defaults applied
             self.assertEqual(p.max_retries, 3)
@@ -73,13 +82,13 @@ class TestMiscGaps(unittest.TestCase):
 
     def test_holiday_service_load_years(self):
         # Mock URL open to return empty valid result for non-2025 to force fallback basic
-        payload = {'result': {'records': []}}
-        with mock.patch('urllib.request.urlopen', return_value=DummyResp(payload)):
+        payload = {"result": {"records": []}}
+        with mock.patch("urllib.request.urlopen", return_value=DummyResp(payload)):
             old = dict(os.environ)
             try:
-                os.environ['HOLIDAY_API_MAX_RETRIES'] = '0'
-                os.environ['HOLIDAY_API_BACKOFF_BASE'] = '0'
-                os.environ['HOLIDAY_API_MAX_BACKOFF'] = '0'
+                os.environ["HOLIDAY_API_MAX_RETRIES"] = "0"
+                os.environ["HOLIDAY_API_BACKOFF_BASE"] = "0"
+                os.environ["HOLIDAY_API_MAX_BACKOFF"] = "0"
                 svc = HolidayService()
                 out = svc.load_years({2025, 2026})
             finally:
@@ -89,7 +98,7 @@ class TestMiscGaps(unittest.TestCase):
         self.assertTrue(any(d.year in (2025, 2026) for d in out))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Utils/Holidays
 Purpose: Parser/filename edges, grouping, state getters, env parsing and load_years."""

--- a/test/test_more_utils_and_holidays.py
+++ b/test/test_more_utils_and_holidays.py
@@ -40,17 +40,13 @@ class TestMiscGaps(unittest.TestCase):
         # parse_datetime_str invalid
         self.assertIsNone(parser.parse_datetime_str("not-a-dt"))
         # parse_line invalid type returns None
-        self.assertIsNone(
-            parser.parse_line("2025/07/01 09:00\t2025/07/01 09:00\t打卡\t")
-        )
+        self.assertIsNone(parser.parse_line("2025/07/01 09:00\t2025/07/01 09:00\t打卡\t"))
         # parse_line missing scheduled returns None
         self.assertIsNone(parser.parse_line("\t2025/07/01 09:00\t上班\t"))
 
     def test_filename_value_error_paths(self):
         # Invalid month causes ValueError path
-        self.assertEqual(
-            parse_range_and_user("20251x-姓名-出勤資料.txt"), (None, None, None)
-        )
+        self.assertEqual(parse_range_and_user("20251x-姓名-出勤資料.txt"), (None, None, None))
         # Force second segment to parse and then fail month math (13th month)
         self.assertEqual(
             parse_range_and_user("202501-202513-姓名-出勤資料.txt"), (None, None, None)

--- a/test/test_overtime_rounding.py
+++ b/test/test_overtime_rounding.py
@@ -11,7 +11,7 @@ def run_case(checkin, checkout):
         f"2025/07/01 08:00\t{checkin}\t上班\t1\t刷卡匯入\t\t\t\t\n"
         f"2025/07/01 17:00\t{checkout}\t下班\t1\t刷卡匯入\t\t\t\t\n"
     )
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
         f.write(text)
         path = f.name
     try:
@@ -40,7 +40,7 @@ class TestOvertimeRounding(unittest.TestCase):
         self.assertEqual(run_case("2025/07/01 09:00", "2025/07/01 20:01"), 120)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Policy/Overtime
 Purpose: Overtime rounding thresholds and increments."""

--- a/test/test_parse_first_line.py
+++ b/test/test_parse_first_line.py
@@ -49,9 +49,7 @@ class TestParseFirstLine(unittest.TestCase):
         try:
             a = AttendanceAnalyzer()
             a.parse_attendance_file(path, incremental=False)
-            self.assertEqual(
-                len(a.records), 2, "first data line must not be dropped as header"
-            )
+            self.assertEqual(len(a.records), 2, "first data line must not be dropped as header")
         finally:
             os.remove(path)
 

--- a/test/test_parse_first_line.py
+++ b/test/test_parse_first_line.py
@@ -3,16 +3,26 @@
 Previously line 1 was unconditionally skipped, silently dropping the first
 record when the input had no header row (e.g. files produced by other tools).
 """
+
 import os
 import tempfile
 import unittest
 
 from attendance_analyzer import AttendanceAnalyzer
 
-HEADER = "\t".join([
-    "應刷卡時段", "當日卡鐘資料", "刷卡別", "卡鐘編號", "資料來源",
-    "異常狀態", "處理狀態", "異常處理作業", "備註",
-])
+HEADER = "\t".join(
+    [
+        "應刷卡時段",
+        "當日卡鐘資料",
+        "刷卡別",
+        "卡鐘編號",
+        "資料來源",
+        "異常狀態",
+        "處理狀態",
+        "異常處理作業",
+        "備註",
+    ]
+)
 ROW_IN = "2025/07/01 09:30\t2025/07/01 10:25\t上班\t1\t刷卡匯入\t遲到\t\t\t"
 ROW_OUT = "2025/07/01 18:30\t2025/07/01 19:49\t下班\t1\t刷卡匯入\t\t\t\t"
 
@@ -39,7 +49,9 @@ class TestParseFirstLine(unittest.TestCase):
         try:
             a = AttendanceAnalyzer()
             a.parse_attendance_file(path, incremental=False)
-            self.assertEqual(len(a.records), 2, "first data line must not be dropped as header")
+            self.assertEqual(
+                len(a.records), 2, "first data line must not be dropped as header"
+            )
         finally:
             os.remove(path)
 

--- a/test/test_parser_more.py
+++ b/test/test_parser_more.py
@@ -6,15 +6,15 @@ from lib import parser
 class TestParserMore(unittest.TestCase):
     def test_too_few_fields_returns_none(self):
         # Fewer than 3 fields after split -> early None
-        self.assertIsNone(parser.parse_line('only-one\tfield'))
+        self.assertIsNone(parser.parse_line("only-one\tfield"))
 
     def test_bad_scheduled_datetime_returns_none(self):
         # scheduled_str present but bad format -> scheduled_dt None -> None
-        line = 'bad-dt\t2025/07/01 09:00\t上班\t卡\t源\t\t\t\t'
+        line = "bad-dt\t2025/07/01 09:00\t上班\t卡\t源\t\t\t\t"
         self.assertIsNone(parser.parse_line(line))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Parsing
 Purpose: Minimal-field handling and bad scheduled datetime."""

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -13,7 +13,9 @@ from lib.policy import (
 
 def mk_record(dt_str_sched: str, dt_str_actual: str, typ: AttendanceType):
     sched = datetime.strptime(dt_str_sched, "%Y/%m/%d %H:%M") if dt_str_sched else None
-    actual = datetime.strptime(dt_str_actual, "%Y/%m/%d %H:%M") if dt_str_actual else None
+    actual = (
+        datetime.strptime(dt_str_actual, "%Y/%m/%d %H:%M") if dt_str_actual else None
+    )
     return AttendanceRecord(
         date=sched.date() if sched else None,
         scheduled_time=sched,
@@ -37,9 +39,7 @@ class TestPolicy(unittest.TestCase):
         # missing actual times on both records
         wd = WorkDay(
             date=date,
-            checkin_record=mk_record(
-                "2025/07/04 08:00", None, AttendanceType.CHECKIN
-            ),
+            checkin_record=mk_record("2025/07/04 08:00", None, AttendanceType.CHECKIN),
             checkout_record=mk_record(
                 "2025/07/04 17:00", None, AttendanceType.CHECKOUT
             ),
@@ -85,28 +85,32 @@ class TestPolicy(unittest.TestCase):
     def test_late_from_schedule_start(self):
         # checkin at 13:30, schedule_start 09:30 -> 240 minutes late
         date = datetime.strptime("2025/07/01", "%Y/%m/%d")
-        wd = WorkDay(date=date,
-                     checkin_record=mk_record(
-                         "2025/07/01 08:00", "2025/07/01 13:30", AttendanceType.CHECKIN
-                     ),
-                     checkout_record=mk_record(
-                         "2025/07/01 17:00", "2025/07/01 22:45", AttendanceType.CHECKOUT
-                     ),
-                     is_friday=False)
+        wd = WorkDay(
+            date=date,
+            checkin_record=mk_record(
+                "2025/07/01 08:00", "2025/07/01 13:30", AttendanceType.CHECKIN
+            ),
+            checkout_record=mk_record(
+                "2025/07/01 17:00", "2025/07/01 22:45", AttendanceType.CHECKOUT
+            ),
+            is_friday=False,
+        )
         minutes, _range, _calc = calculate_late_minutes(wd, self.rules)
         self.assertEqual(minutes, 240)  # 13:30 - 09:30 = 240 min
 
     def test_overtime_rounding(self):
         # checkin 09:00 => expected out 18:00; actual 20:01 => 121m actual, applicable 120m
         date = datetime.strptime("2025/07/01", "%Y/%m/%d")
-        wd = WorkDay(date=date,
-                     checkin_record=mk_record(
-                         "2025/07/01 09:00", "2025/07/01 09:00", AttendanceType.CHECKIN
-                     ),
-                     checkout_record=mk_record(
-                         "2025/07/01 17:00", "2025/07/01 20:01", AttendanceType.CHECKOUT
-                     ),
-                     is_friday=False)
+        wd = WorkDay(
+            date=date,
+            checkin_record=mk_record(
+                "2025/07/01 09:00", "2025/07/01 09:00", AttendanceType.CHECKIN
+            ),
+            checkout_record=mk_record(
+                "2025/07/01 17:00", "2025/07/01 20:01", AttendanceType.CHECKOUT
+            ),
+            is_friday=False,
+        )
         # Calculate expected checkout based on work start at 09:00
         work_start = datetime.strptime("2025/07/01 09:00", "%Y/%m/%d %H:%M")
         expected_checkout = calculate_expected_checkout(wd, self.rules, work_start)
@@ -116,7 +120,7 @@ class TestPolicy(unittest.TestCase):
         self.assertEqual(applicable, 120)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Policy
 Purpose: Late calculation branches and overtime applicability thresholds."""

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -13,9 +13,7 @@ from lib.policy import (
 
 def mk_record(dt_str_sched: str, dt_str_actual: str, typ: AttendanceType):
     sched = datetime.strptime(dt_str_sched, "%Y/%m/%d %H:%M") if dt_str_sched else None
-    actual = (
-        datetime.strptime(dt_str_actual, "%Y/%m/%d %H:%M") if dt_str_actual else None
-    )
+    actual = datetime.strptime(dt_str_actual, "%Y/%m/%d %H:%M") if dt_str_actual else None
     return AttendanceRecord(
         date=sched.date() if sched else None,
         scheduled_time=sched,
@@ -40,9 +38,7 @@ class TestPolicy(unittest.TestCase):
         wd = WorkDay(
             date=date,
             checkin_record=mk_record("2025/07/04 08:00", None, AttendanceType.CHECKIN),
-            checkout_record=mk_record(
-                "2025/07/04 17:00", None, AttendanceType.CHECKOUT
-            ),
+            checkout_record=mk_record("2025/07/04 17:00", None, AttendanceType.CHECKOUT),
             is_friday=True,
         )
         self.assertTrue(is_full_day_absent(wd))

--- a/test/test_policy_more.py
+++ b/test/test_policy_more.py
@@ -1,14 +1,20 @@
 import unittest
 from datetime import datetime
 
-from lib.policy import Rules, calculate_late_minutes, calculate_overtime_minutes
+from lib.policy import (
+    Rules,
+    calculate_late_minutes,
+    calculate_leave_suggestion,
+    calculate_overtime_minutes,
+)
 
 
 class W:
-    def __init__(self, ci=None, co=None, date=datetime(2025,7,1)):
+    def __init__(self, ci=None, co=None, date=datetime(2025, 7, 1)):
         class Rec:
             def __init__(self, t):
                 self.actual_time = t
+
         self.checkin_record = Rec(ci) if ci else None
         self.checkout_record = Rec(co) if co else None
         self.date = date
@@ -18,29 +24,69 @@ class TestPolicyMore(unittest.TestCase):
     def test_late_from_schedule_start_no_lunch_deduction(self):
         # 11:30 arrival, latest_checkin 09:00, schedule_start 09:30
         # -> 120 min late, no lunch deduction
-        rules = Rules(latest_checkin='09:00', schedule_start='09:30')
-        wd = W(ci=datetime(2025,7,1,11,30), co=datetime(2025,7,1,20,0))
+        rules = Rules(latest_checkin="09:00", schedule_start="09:30")
+        wd = W(ci=datetime(2025, 7, 1, 11, 30), co=datetime(2025, 7, 1, 20, 0))
         mins, tr, calc = calculate_late_minutes(wd, rules)
         self.assertEqual(mins, 120)  # 11:30 - 09:30 = 120 min
-        self.assertIn('需請假:', calc)
-        self.assertNotIn('午休', calc)
+        self.assertIn("需請假:", calc)
+        self.assertNotIn("午休", calc)
+
+    def test_leave_suggestion_deducts_lunch_overlap(self):
+        # 13:19 到班：遲到 229 分，但 12:30~13:19 屬午休須扣 49 分
+        # -> 缺工 180 分 -> 進位 3h，請假塊 09:30~12:30（非 4h）
+        rules = Rules(
+            latest_checkin="10:00",
+            schedule_start="09:30",
+            lunch_start="12:30",
+            lunch_end="13:30",
+        )
+        wd = W(
+            ci=datetime(2026, 6, 11, 13, 19),
+            co=datetime(2026, 6, 11, 19, 24),
+            date=datetime(2026, 6, 11),
+        )
+        late, _tr, _calc = calculate_late_minutes(wd, rules)
+        self.assertEqual(late, 229)
+        start, end, hours, effective = calculate_leave_suggestion(wd, rules, late)
+        self.assertEqual((start, end), ("09:30", "12:30"))
+        self.assertEqual(hours, 3)
+        self.assertEqual(effective, 180)
+
+    def test_leave_suggestion_no_lunch_overlap_unchanged(self):
+        # 11:26 到班：遲到 116 分，未碰午休 -> 維持 ceil 2h，缺工=遲到
+        rules = Rules(
+            latest_checkin="10:00",
+            schedule_start="09:30",
+            lunch_start="12:30",
+            lunch_end="13:30",
+        )
+        wd = W(
+            ci=datetime(2026, 6, 9, 11, 26),
+            co=datetime(2026, 6, 9, 19, 42),
+            date=datetime(2026, 6, 9),
+        )
+        late, _tr, _calc = calculate_late_minutes(wd, rules)
+        start, end, hours, effective = calculate_leave_suggestion(wd, rules, late)
+        self.assertEqual((start, end, hours, effective), ("09:30", "11:30", 2, 116))
 
     def test_late_early_return_when_missing_checkin(self):
         rules = Rules()
-        wd = W(ci=None, co=datetime(2025,7,1,18,0))
+        wd = W(ci=None, co=datetime(2025, 7, 1, 18, 0))
         mins, tr, calc = calculate_late_minutes(wd, rules)
-        self.assertEqual((mins, tr, calc), (0, '', ''))
+        self.assertEqual((mins, tr, calc), (0, "", ""))
 
     def test_overtime_early_return_when_incomplete(self):
         rules = Rules()
-        wd = W(ci=datetime(2025,7,1,9,0), co=None)
+        wd = W(ci=datetime(2025, 7, 1, 9, 0), co=None)
         # expected_checkout can be any value since co=None triggers early return
         expected_checkout = datetime(2025, 7, 1, 18, 0)
-        actual, applicable, tr, calc = calculate_overtime_minutes(wd, rules, expected_checkout)
-        self.assertEqual((actual, applicable, tr, calc), (0, 0, '', ''))
+        actual, applicable, tr, calc = calculate_overtime_minutes(
+            wd, rules, expected_checkout
+        )
+        self.assertEqual((actual, applicable, tr, calc), (0, 0, "", ""))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Policy
 Purpose: Additional late/overtime guard branches and no-deduction scenario."""

--- a/test/test_policy_more.py
+++ b/test/test_policy_more.py
@@ -80,9 +80,7 @@ class TestPolicyMore(unittest.TestCase):
         wd = W(ci=datetime(2025, 7, 1, 9, 0), co=None)
         # expected_checkout can be any value since co=None triggers early return
         expected_checkout = datetime(2025, 7, 1, 18, 0)
-        actual, applicable, tr, calc = calculate_overtime_minutes(
-            wd, rules, expected_checkout
-        )
+        actual, applicable, tr, calc = calculate_overtime_minutes(wd, rules, expected_checkout)
         self.assertEqual((actual, applicable, tr, calc), (0, 0, "", ""))
 
 

--- a/test/test_policy_more.py
+++ b/test/test_policy_more.py
@@ -52,6 +52,25 @@ class TestPolicyMore(unittest.TestCase):
         self.assertEqual(hours, 3)
         self.assertEqual(effective, 180)
 
+    def test_leave_suggestion_block_crossing_lunch_advances_end(self):
+        # 14:00 到班：遲到 270 分，扣午休 60 → 缺工 210 → 進位 4h。
+        # 4 工時塊跨午休，終點須加回午休 → 09:30~14:30（否則 Portal 只算 3h）
+        rules = Rules(
+            latest_checkin="10:00",
+            schedule_start="09:30",
+            lunch_start="12:30",
+            lunch_end="13:30",
+        )
+        wd = W(
+            ci=datetime(2026, 6, 18, 14, 0),
+            co=datetime(2026, 6, 18, 19, 0),
+            date=datetime(2026, 6, 18),
+        )
+        late, _tr, _calc = calculate_late_minutes(wd, rules)
+        self.assertEqual(late, 270)
+        start, end, hours, effective = calculate_leave_suggestion(wd, rules, late)
+        self.assertEqual((start, end, hours, effective), ("09:30", "14:30", 4, 210))
+
     def test_leave_suggestion_no_lunch_overlap_unchanged(self):
         # 11:26 到班：遲到 116 分，未碰午休 -> 維持 ceil 2h，缺工=遲到
         rules = Rules(

--- a/test/test_portal_apply_forms.py
+++ b/test/test_portal_apply_forms.py
@@ -135,9 +135,7 @@ class TestSubmitLeave(unittest.TestCase):
             "end_time": "1030",
             "hours": 1,
         }
-        ok = submit_leave(
-            portal, "http://x", entry, leave_type_name="不存在的假別", reason="x"
-        )
+        ok = submit_leave(portal, "http://x", entry, leave_type_name="不存在的假別", reason="x")
         self.assertFalse(ok)
 
     def test_ambiguous_leave_type_returns_false(self):
@@ -159,9 +157,7 @@ class TestSubmitLeave(unittest.TestCase):
             "end_time": "1030",
             "hours": 1,
         }
-        ok = submit_leave(
-            portal, "http://x", entry, leave_type_name="補休假", reason="x"
-        )
+        ok = submit_leave(portal, "http://x", entry, leave_type_name="補休假", reason="x")
         self.assertFalse(ok)
 
 
@@ -249,9 +245,7 @@ class TestDryRunScreenshot(unittest.TestCase):
             "hours": 2,
             "location": "在辦公室",
         }
-        submit_overtime(
-            portal, "http://x", entry, reason="x", dry_run=True, dry_run_pause_secs=0
-        )
+        submit_overtime(portal, "http://x", entry, reason="x", dry_run=True, dry_run_pause_secs=0)
         portal.screenshot.assert_not_called()
 
 
@@ -278,9 +272,7 @@ class TestDryRun(unittest.TestCase):
         self.assertNotIn("確定送出", joined)
         # And no post-submit snapshot read for verification
         snap_calls = [
-            c
-            for c in portal._run.call_args_list
-            if c[0] and c[0][0] and c[0][0][0] == "snapshot"
+            c for c in portal._run.call_args_list if c[0] and c[0][0] and c[0][0][0] == "snapshot"
         ]
         self.assertEqual(snap_calls, [])
 

--- a/test/test_portal_apply_forms.py
+++ b/test/test_portal_apply_forms.py
@@ -3,6 +3,7 @@
 We mock PortalSession; verify the right JS lands at the right time and
 the result flag matches the snapshot heuristic.
 """
+
 import unittest
 from unittest import mock
 
@@ -52,8 +53,11 @@ class TestSubmitOvertime(unittest.TestCase):
     def test_verify_failure_returns_false(self):
         portal = _make_portal(snapshot_after="something else")
         entry = {
-            "date": "2026/04/20", "start_time": "1830", "end_time": "2030",
-            "hours": 2, "location": "在辦公室",
+            "date": "2026/04/20",
+            "start_time": "1830",
+            "end_time": "2030",
+            "hours": 2,
+            "location": "在辦公室",
         }
         self.assertFalse(submit_overtime(portal, "http://x", entry, reason="x"))
 
@@ -62,22 +66,28 @@ class TestSubmitLeave(unittest.TestCase):
     def test_wfh_skips_proxy(self):
         portal = mock.Mock()
         portal.eval_json.side_effect = [
-            {"success": True},                  # open form
+            {"success": True},  # open form
             {"matched": 1, "matches": [{"index": 27, "text": "異地辦公(8hr一週)"}]},
-            {"ok": True},                       # fill datetime
-            None,                               # trigger
-            {"ok": True},                       # reason
-            None,                               # click submit
+            {"ok": True},  # fill datetime
+            None,  # trigger
+            {"ok": True},  # reason
+            None,  # click submit
         ]
         portal._run.return_value = "請假單  主管簽核"
         entry = {
-            "date": "2026/04/24", "start_time": "0930",
-            "end_time": "1830", "hours": 9,
+            "date": "2026/04/24",
+            "start_time": "0930",
+            "end_time": "1830",
+            "hours": 9,
         }
-        ok = submit_leave(portal, "http://x", entry,
-                          leave_type_name="異地辦公(8hr一週)",
-                          reason="WFH",
-                          proxy_employee="賴菁甫")
+        ok = submit_leave(
+            portal,
+            "http://x",
+            entry,
+            leave_type_name="異地辦公(8hr一週)",
+            reason="WFH",
+            proxy_employee="賴菁甫",
+        )
         self.assertTrue(ok)
         joined = "\n".join(str(c[0]) for c in portal.eval_json.call_args_list)
         self.assertNotIn("AGENT_ID_ddlDelegate", joined)
@@ -85,21 +95,29 @@ class TestSubmitLeave(unittest.TestCase):
     def test_non_wfh_selects_proxy(self):
         portal = mock.Mock()
         portal.eval_json.side_effect = [
-            {"success": True},                  # open form
-            {"ok": True},                       # proxy select
+            {"success": True},  # open form
+            {"ok": True},  # proxy select
             {"matched": 1, "matches": [{"index": 30, "text": "補休假"}]},
-            {"ok": True},                       # fill datetime
-            None,                               # trigger
-            {"ok": True},                       # reason
-            None,                               # submit
+            {"ok": True},  # fill datetime
+            None,  # trigger
+            {"ok": True},  # reason
+            None,  # submit
         ]
         portal._run.return_value = "請假單  主管簽核"
-        entry = {"date": "2026/04/20", "start_time": "0930",
-                 "end_time": "1130", "hours": 2}
-        ok = submit_leave(portal, "http://x", entry,
-                          leave_type_name="補休假",
-                          reason="個人事務",
-                          proxy_employee="賴菁甫")
+        entry = {
+            "date": "2026/04/20",
+            "start_time": "0930",
+            "end_time": "1130",
+            "hours": 2,
+        }
+        ok = submit_leave(
+            portal,
+            "http://x",
+            entry,
+            leave_type_name="補休假",
+            reason="個人事務",
+            proxy_employee="賴菁甫",
+        )
         self.assertTrue(ok)
         joined = "\n".join(str(c[0]) for c in portal.eval_json.call_args_list)
         self.assertIn("AGENT_ID_ddlDelegate", joined)
@@ -111,28 +129,39 @@ class TestSubmitLeave(unittest.TestCase):
             {"matched": 0, "matches": []},
         ]
         portal._run.return_value = "請假單"
-        entry = {"date": "2026/04/20", "start_time": "0930",
-                 "end_time": "1030", "hours": 1}
-        ok = submit_leave(portal, "http://x", entry,
-                          leave_type_name="不存在的假別",
-                          reason="x")
+        entry = {
+            "date": "2026/04/20",
+            "start_time": "0930",
+            "end_time": "1030",
+            "hours": 1,
+        }
+        ok = submit_leave(
+            portal, "http://x", entry, leave_type_name="不存在的假別", reason="x"
+        )
         self.assertFalse(ok)
 
     def test_ambiguous_leave_type_returns_false(self):
         portal = mock.Mock()
         portal.eval_json.side_effect = [
             {"success": True},
-            {"matched": 2, "matches": [
-                {"index": 1, "text": "補休假"},
-                {"index": 2, "text": "補休假B"},
-            ]},
+            {
+                "matched": 2,
+                "matches": [
+                    {"index": 1, "text": "補休假"},
+                    {"index": 2, "text": "補休假B"},
+                ],
+            },
         ]
         portal._run.return_value = "請假單"
-        entry = {"date": "2026/04/20", "start_time": "0930",
-                 "end_time": "1030", "hours": 1}
-        ok = submit_leave(portal, "http://x", entry,
-                          leave_type_name="補休假",
-                          reason="x")
+        entry = {
+            "date": "2026/04/20",
+            "start_time": "0930",
+            "end_time": "1030",
+            "hours": 1,
+        }
+        ok = submit_leave(
+            portal, "http://x", entry, leave_type_name="補休假", reason="x"
+        )
         self.assertFalse(ok)
 
 
@@ -142,18 +171,34 @@ class TestBatchSubmit(unittest.TestCase):
         portal.eval_json.return_value = {"success": True}
         portal._run.return_value = "加班單  主管簽核"
         overtime_plan = [
-            {"action": "submit",
-             "entry": {"date": "2026/04/20", "start_time": "1830",
-                       "end_time": "2030", "hours": 2, "location": "在辦公室"},
-             "reason": "上線"},
-            {"action": "skip",
-             "entry": {"date": "2026/04/21", "start_time": "1830",
-                       "end_time": "1930", "hours": 1}},
+            {
+                "action": "submit",
+                "entry": {
+                    "date": "2026/04/20",
+                    "start_time": "1830",
+                    "end_time": "2030",
+                    "hours": 2,
+                    "location": "在辦公室",
+                },
+                "reason": "上線",
+            },
+            {
+                "action": "skip",
+                "entry": {
+                    "date": "2026/04/21",
+                    "start_time": "1830",
+                    "end_time": "1930",
+                    "hours": 1,
+                },
+            },
         ]
         leave_plan = []
         ot_cb = mock.Mock()
         ot_ok, ot_total, lv_ok, lv_total = batch_submit(
-            portal, "http://x", overtime_plan, leave_plan,
+            portal,
+            "http://x",
+            overtime_plan,
+            leave_plan,
             on_overtime_done=ot_cb,
         )
         self.assertEqual((ot_ok, ot_total, lv_ok, lv_total), (1, 1, 0, 0))
@@ -165,31 +210,48 @@ class TestDryRunScreenshot(unittest.TestCase):
     def test_overtime_dry_run_takes_screenshot(self):
         import tempfile
         from pathlib import Path
+
         portal = mock.Mock()
         portal.eval_json.return_value = {"success": True}
         portal._run.return_value = ""
         portal.screenshot.return_value = True
         with tempfile.TemporaryDirectory() as d:
-            entry = {"date": "2026/04/20", "start_time": "1830",
-                     "end_time": "2030", "hours": 2, "location": "在辦公室"}
-            ok = submit_overtime(portal, "http://x", entry,
-                                 reason="x", dry_run=True,
-                                 dry_run_pause_secs=0,
-                                 screenshot_dir=Path(d), screenshot_seq=1)
+            entry = {
+                "date": "2026/04/20",
+                "start_time": "1830",
+                "end_time": "2030",
+                "hours": 2,
+                "location": "在辦公室",
+            }
+            ok = submit_overtime(
+                portal,
+                "http://x",
+                entry,
+                reason="x",
+                dry_run=True,
+                dry_run_pause_secs=0,
+                screenshot_dir=Path(d),
+                screenshot_seq=1,
+            )
             self.assertTrue(ok)
             portal.screenshot.assert_called_once()
             saved_path = portal.screenshot.call_args[0][0]
-            self.assertTrue(saved_path.endswith(
-                "001-overtime-20260420-1830-2030.png"))
+            self.assertTrue(saved_path.endswith("001-overtime-20260420-1830-2030.png"))
 
     def test_no_screenshot_when_dir_is_none(self):
         portal = mock.Mock()
         portal.eval_json.return_value = {"success": True}
         portal._run.return_value = ""
-        entry = {"date": "2026/04/20", "start_time": "1830",
-                 "end_time": "2030", "hours": 2, "location": "在辦公室"}
-        submit_overtime(portal, "http://x", entry,
-                        reason="x", dry_run=True, dry_run_pause_secs=0)
+        entry = {
+            "date": "2026/04/20",
+            "start_time": "1830",
+            "end_time": "2030",
+            "hours": 2,
+            "location": "在辦公室",
+        }
+        submit_overtime(
+            portal, "http://x", entry, reason="x", dry_run=True, dry_run_pause_secs=0
+        )
         portal.screenshot.assert_not_called()
 
 
@@ -200,35 +262,54 @@ class TestDryRun(unittest.TestCase):
         # Sentinel snapshot — wouldn't match the verify heuristic, but
         # dry_run never asks for verification so the result stays True.
         portal._run.return_value = ""
-        entry = {"date": "2026/04/20", "start_time": "1830",
-                 "end_time": "2030", "hours": 2, "location": "在辦公室"}
-        ok = submit_overtime(portal, "http://x", entry,
-                             reason="x", dry_run=True, dry_run_pause_secs=0)
+        entry = {
+            "date": "2026/04/20",
+            "start_time": "1830",
+            "end_time": "2030",
+            "hours": 2,
+            "location": "在辦公室",
+        }
+        ok = submit_overtime(
+            portal, "http://x", entry, reason="x", dry_run=True, dry_run_pause_secs=0
+        )
         self.assertTrue(ok)
         # No 確定送出 JS — none of the eval calls should contain that string
         joined = "\n".join(str(c[0]) for c in portal.eval_json.call_args_list)
         self.assertNotIn("確定送出", joined)
         # And no post-submit snapshot read for verification
-        snap_calls = [c for c in portal._run.call_args_list
-                      if c[0] and c[0][0] and c[0][0][0] == "snapshot"]
+        snap_calls = [
+            c
+            for c in portal._run.call_args_list
+            if c[0] and c[0][0] and c[0][0][0] == "snapshot"
+        ]
         self.assertEqual(snap_calls, [])
 
     def test_leave_skips_submit_click(self):
         portal = mock.Mock()
         portal.eval_json.side_effect = [
-            {"success": True},                          # open form
+            {"success": True},  # open form
             {"matched": 1, "matches": [{"index": 30, "text": "補休假"}]},
-            {"ok": True},                                # fill datetime
-            None,                                        # trigger hour calc
-            {"ok": True},                                # reason fill
+            {"ok": True},  # fill datetime
+            None,  # trigger hour calc
+            {"ok": True},  # reason fill
         ]
         portal._run.return_value = ""
-        entry = {"date": "2026/04/20", "start_time": "0930",
-                 "end_time": "1130", "hours": 2}
-        ok = submit_leave(portal, "http://x", entry,
-                          leave_type_name="補休假", reason="x",
-                          proxy_employee=None,
-                          dry_run=True, dry_run_pause_secs=0)
+        entry = {
+            "date": "2026/04/20",
+            "start_time": "0930",
+            "end_time": "1130",
+            "hours": 2,
+        }
+        ok = submit_leave(
+            portal,
+            "http://x",
+            entry,
+            leave_type_name="補休假",
+            reason="x",
+            proxy_employee=None,
+            dry_run=True,
+            dry_run_pause_secs=0,
+        )
         self.assertTrue(ok)
         joined = "\n".join(str(c[0]) for c in portal.eval_json.call_args_list)
         self.assertNotIn("確定送出", joined)
@@ -237,15 +318,26 @@ class TestDryRun(unittest.TestCase):
         portal = mock.Mock()
         portal.eval_json.return_value = {"success": True}
         portal._run.return_value = ""
-        overtime_plan = [{
-            "action": "submit",
-            "entry": {"date": "2026/04/20", "start_time": "1830",
-                      "end_time": "2030", "hours": 2, "location": "在辦公室"},
-            "reason": "x",
-        }]
+        overtime_plan = [
+            {
+                "action": "submit",
+                "entry": {
+                    "date": "2026/04/20",
+                    "start_time": "1830",
+                    "end_time": "2030",
+                    "hours": 2,
+                    "location": "在辦公室",
+                },
+                "reason": "x",
+            }
+        ]
         ot_ok, ot_total, _, _ = batch_submit(
-            portal, "http://x", overtime_plan, [],
-            dry_run=True, dry_run_pause_secs=0,
+            portal,
+            "http://x",
+            overtime_plan,
+            [],
+            dry_run=True,
+            dry_run_pause_secs=0,
         )
         self.assertEqual((ot_ok, ot_total), (1, 1))
         joined = "\n".join(str(c[0]) for c in portal.eval_json.call_args_list)

--- a/test/test_portal_apply_helpers.py
+++ b/test/test_portal_apply_helpers.py
@@ -146,9 +146,7 @@ class TestFormatEntry(unittest.TestCase):
 
     def test_includes_actual_punches(self):
         att = {"2026/04/22": {"上班": "09:05", "下班": "21:03"}}
-        out = _format_entry(
-            self.ENTRY, att, schedule_start="09:30", latest_checkin="10:00"
-        )
+        out = _format_entry(self.ENTRY, att, schedule_start="09:30", latest_checkin="10:00")
         self.assertIn("實際 上班 09:05", out)
         self.assertIn("下班 21:03", out)
 
@@ -164,9 +162,7 @@ class TestFormatEntry(unittest.TestCase):
         self.assertIn("💡 早到 → 預期下班 18:05", out)
 
     def test_no_attendance_data(self):
-        out = _format_entry(
-            self.ENTRY, {}, schedule_start="09:30", latest_checkin="10:00"
-        )
+        out = _format_entry(self.ENTRY, {}, schedule_start="09:30", latest_checkin="10:00")
         self.assertIn("2026/04/22", out)
         self.assertNotIn("實際", out)
 
@@ -435,9 +431,7 @@ class TestRunAutoMode(unittest.TestCase):
             mock.patch(
                 "lib.portal.balances.fetch_balances", return_value=balances
             ) as fetch_balances,
-            mock.patch(
-                "lib.portal.apply_forms.batch_submit", side_effect=fake_batch_submit
-            ),
+            mock.patch("lib.portal.apply_forms.batch_submit", side_effect=fake_batch_submit),
         ):
             run(self._args())
 

--- a/test/test_portal_apply_helpers.py
+++ b/test/test_portal_apply_helpers.py
@@ -146,7 +146,9 @@ class TestFormatEntry(unittest.TestCase):
 
     def test_includes_actual_punches(self):
         att = {"2026/04/22": {"上班": "09:05", "下班": "21:03"}}
-        out = _format_entry(self.ENTRY, att, schedule_start="09:30", latest_checkin="10:00")
+        out = _format_entry(
+            self.ENTRY, att, schedule_start="09:30", latest_checkin="10:00"
+        )
         self.assertIn("實際 上班 09:05", out)
         self.assertIn("下班 21:03", out)
 
@@ -162,7 +164,9 @@ class TestFormatEntry(unittest.TestCase):
         self.assertIn("💡 早到 → 預期下班 18:05", out)
 
     def test_no_attendance_data(self):
-        out = _format_entry(self.ENTRY, {}, schedule_start="09:30", latest_checkin="10:00")
+        out = _format_entry(
+            self.ENTRY, {}, schedule_start="09:30", latest_checkin="10:00"
+        )
         self.assertIn("2026/04/22", out)
         self.assertNotIn("實際", out)
 
@@ -431,7 +435,9 @@ class TestRunAutoMode(unittest.TestCase):
             mock.patch(
                 "lib.portal.balances.fetch_balances", return_value=balances
             ) as fetch_balances,
-            mock.patch("lib.portal.apply_forms.batch_submit", side_effect=fake_batch_submit),
+            mock.patch(
+                "lib.portal.apply_forms.batch_submit", side_effect=fake_batch_submit
+            ),
         ):
             run(self._args())
 

--- a/test/test_portal_approvals.py
+++ b/test/test_portal_approvals.py
@@ -1,4 +1,5 @@
 """Tests for `lib/portal/approvals.py`."""
+
 import unittest
 from unittest import mock
 
@@ -89,7 +90,10 @@ class TestFetchFormEntries(unittest.TestCase):
             "totalPages": 1,
             "rows": [
                 {"id": "tbWorkSheetDataList_1", "wsdinfotext": SAMPLE_WSD_OT},
-                {"id": "tbWorkSheetDataList_2", "wsdinfotext": ""},  # malformed → skipped
+                {
+                    "id": "tbWorkSheetDataList_2",
+                    "wsdinfotext": "",
+                },  # malformed → skipped
             ],
         }
         entries = fetch_form_entries(portal, "http://x", "加班單")
@@ -97,10 +101,47 @@ class TestFetchFormEntries(unittest.TestCase):
         self.assertEqual(entries[0]["date"], "2026/04/20")
         self.assertEqual(entries[0]["row_id"], "tbWorkSheetDataList_1")
 
+    def test_paginates_one_eval_per_page(self):
+        # 3 頁 → 逐頁讀，各自一次 eval（不再單一超長 eval）
+        portal = mock.Mock()
+        portal._run.return_value = FILTER_SNAPSHOT
+        pages = [
+            {
+                "totalPages": 3,
+                "page": 0,
+                "rows": [{"id": "r0", "wsdinfotext": SAMPLE_WSD_OT}],
+            },
+            {
+                "totalPages": 3,
+                "page": 1,
+                "rows": [{"id": "r1", "wsdinfotext": SAMPLE_WSD_OT}],
+            },
+            {
+                "totalPages": 3,
+                "page": 2,
+                "rows": [
+                    {"id": "r2", "wsdinfotext": SAMPLE_WSD_OT},
+                    {"id": "r1", "wsdinfotext": SAMPLE_WSD_OT},
+                ],
+            },  # 重複 id 去重
+        ]
+        portal.eval_json.side_effect = pages
+        entries = fetch_form_entries(portal, "http://x", "加班單")
+        self.assertEqual(portal.eval_json.call_count, 3)
+        self.assertEqual(len(entries), 3)  # r0,r1,r2（重複的 r1 去重）
+
     def test_eval_error_raises(self):
         portal = mock.Mock()
         portal._run.return_value = FILTER_SNAPSHOT
         portal.eval_json.return_value = {"error": "boom"}
+        with self.assertRaises(RuntimeError):
+            fetch_form_entries(portal, "http://x", "加班單")
+
+    def test_malformed_eval_raises(self):
+        # 回傳 dict 但缺 rows 且非 error → 格式異常
+        portal = mock.Mock()
+        portal._run.return_value = FILTER_SNAPSHOT
+        portal.eval_json.return_value = {"totalPages": 1}
         with self.assertRaises(RuntimeError):
             fetch_form_entries(portal, "http://x", "加班單")
 

--- a/test/test_portal_attendance.py
+++ b/test/test_portal_attendance.py
@@ -3,6 +3,7 @@
 We mock the PortalSession + subprocess primitives — no real
 agent-browser invocation.
 """
+
 import os
 import tempfile
 import unittest
@@ -56,16 +57,34 @@ class TestFetchSnapshot(unittest.TestCase):
             "totalPages": 2,
             "recordCount": 3,
             "records": [
-                {"scheduledTime": "2026/05/01 09:30", "actualTime": "",
-                 "type": "上班", "status": "曠職"},
-                {"scheduledTime": "2026/05/02 09:30", "actualTime": "2026/05/02 09:32",
-                 "type": "上班", "status": ""},
-                {"scheduledTime": "2026/05/02 18:30", "actualTime": "2026/05/02 19:10",
-                 "type": "下班", "status": ""},
+                {
+                    "scheduledTime": "2026/05/01 09:30",
+                    "actualTime": "",
+                    "type": "上班",
+                    "status": "曠職",
+                },
+                {
+                    "scheduledTime": "2026/05/02 09:30",
+                    "actualTime": "2026/05/02 09:32",
+                    "type": "上班",
+                    "status": "",
+                },
+                {
+                    "scheduledTime": "2026/05/02 18:30",
+                    "actualTime": "2026/05/02 19:10",
+                    "type": "下班",
+                    "status": "",
+                },
             ],
         }
-        out = fetch_snapshot(portal, "http://x",
-                             start_year=2026, start_month=4, end_year=2026, end_month=5)
+        out = fetch_snapshot(
+            portal,
+            "http://x",
+            start_year=2026,
+            start_month=4,
+            end_year=2026,
+            end_month=5,
+        )
         self.assertEqual(out["schema_version"], "portal-attendance-snapshot/v1")
         self.assertEqual(out["totalPages"], 2)
         self.assertEqual(out["recordCount"], 3)
@@ -78,16 +97,28 @@ class TestFetchSnapshot(unittest.TestCase):
         self._wire_form_refs(portal)
         portal.eval_json.return_value = {"error": "mainFrame not found"}
         with self.assertRaises(RuntimeError):
-            fetch_snapshot(portal, "http://x",
-                           start_year=2026, start_month=5, end_year=2026, end_month=5)
+            fetch_snapshot(
+                portal,
+                "http://x",
+                start_year=2026,
+                start_month=5,
+                end_year=2026,
+                end_month=5,
+            )
 
     def test_unexpected_shape_raises(self):
         portal = self._portal()
         self._wire_form_refs(portal)
         portal.eval_json.return_value = "not a dict"
         with self.assertRaises(RuntimeError):
-            fetch_snapshot(portal, "http://x",
-                           start_year=2026, start_month=5, end_year=2026, end_month=5)
+            fetch_snapshot(
+                portal,
+                "http://x",
+                start_year=2026,
+                start_month=5,
+                end_year=2026,
+                end_month=5,
+            )
 
 
 class TestFetchToTxt(unittest.TestCase):
@@ -98,15 +129,26 @@ class TestFetchToTxt(unittest.TestCase):
             "totalPages": 1,
             "recordCount": 1,
             "records": [
-                {"scheduledTime": "2026/05/02 09:30", "actualTime": "2026/05/02 09:32",
-                 "type": "上班", "status": ""},
+                {
+                    "scheduledTime": "2026/05/02 09:30",
+                    "actualTime": "2026/05/02 09:32",
+                    "type": "上班",
+                    "status": "",
+                },
             ],
         }
         fd, path = tempfile.mkstemp(suffix=".txt")
         os.close(fd)
         try:
-            n = fetch_to_txt(portal, "http://x", path,
-                             start_year=2026, start_month=5, end_year=2026, end_month=5)
+            n = fetch_to_txt(
+                portal,
+                "http://x",
+                path,
+                start_year=2026,
+                start_month=5,
+                end_year=2026,
+                end_month=5,
+            )
             self.assertEqual(n, 1)
             content = open(path, encoding="utf-8").read()
             # header + 1 data row + trailing \n = 2 newlines

--- a/test/test_portal_balances.py
+++ b/test/test_portal_balances.py
@@ -1,4 +1,5 @@
 """Tests for `lib/portal/balances.py`."""
+
 import unittest
 from unittest import mock
 
@@ -11,19 +12,76 @@ from lib.portal.balances import (
     parse_items_panel,
 )
 
-# Real layout observed in the session (left side cropped — for the tests we
-# only need the column we want to read).
+# Real layout captured live 2026-06: the Portal wraps the grid in nested
+# tables, so eval returns noise rows (a flattened blob + the four metric
+# labels each on their own single-cell row) followed by the clean grid.
+# The grid header has NO leading label cell and the metric rows carry NO
+# label — order is the only anchor (可休總 / 目前可休 / 已休 / 剩餘).
 ITEMS_ROWS = [
-    ["", "加班", "補休假", "事假(含家庭照顧假)", "半薪病假", "有薪病假",
-     "公假-公出", "忘刷忘帶卡", "榮譽假", "異地辦公(12hr一週)",
-     "異地辦公(8hr一週)", "生日假"],
-    ["可休總時數", "", "8 小時", "", "", "40 小時 / 1 年", "",
-     "2 工作天 或 4 次 / 1 年", "0小時 / 自訂期間",
-     "60 小時 / 1 月", "40 小時 / 1 月", "1 工作天 / 1 年"],
-    ["已休(加班)時數", "15 小時", "1 小時", "50 小時", "16 小時", "40 小時",
-     "7 小時", "0.5 工作天 / 1次", "", "", "", "0 工作天"],
-    ["剩餘時數", "", "7 小時", "", "", "0 小時", "",
-     "1.5 工作天 / 3次", "", "", "", "1 工作天"],
+    # Decoy: the real Portal emits a wide flattened blob row that ALSO carries
+    # a standalone "補休假" cell. Header detection must skip it (r[0] != 加班).
+    [
+        "可休總時數\n\n目前可休時數",
+        "",
+        "可休總時數",
+        "已休(加班)時數",
+        "剩餘時數",
+        "",
+        "補休假",
+        "事假",
+        "x",
+        "y",
+    ],
+    ["可休總時數"],
+    ["目前可休時數"],
+    ["已休(加班)時數"],
+    ["剩餘時數"],
+    [""],
+    [
+        "加班",
+        "補休假",
+        "事假(含家庭照顧假)",
+        "半薪病假",
+        "有薪病假",
+        "公假-公出",
+        "忘刷忘帶卡",
+        "榮譽假",
+        "異地辦公(12hr一週)",
+        "異地辦公(8hr一週)",
+        "生日假",
+    ],
+    # 可休總時數
+    [
+        "",
+        "28 小時",
+        "",
+        "",
+        "40 小時 / 1 年",
+        "",
+        "2 工作天 或 4 次 / 1 年",
+        "0小時 / 自訂期間",
+        "60 小時 / 1 月",
+        "40 小時 / 1 月",
+        "1 工作天 / 1 年",
+    ],
+    # 目前可休時數 (blank in this capture)
+    ["", "", "", "", "", "", "", "", "", "", ""],
+    # 已休(加班)時數
+    [
+        "43 小時",
+        "0 小時",
+        "50 小時",
+        "19 小時",
+        "40 小時",
+        "7 小時",
+        "0.5 工作天 / 1次",
+        "",
+        "",
+        "",
+        "0 工作天",
+    ],
+    # 剩餘時數
+    ["", "28 小時", "", "", "0 小時", "", "1.5 工作天 / 3次", "", "", "", "1 工作天"],
 ]
 
 ANNUAL_ROWS = [
@@ -56,21 +114,23 @@ class TestParseHours(unittest.TestCase):
 class TestParseItemsPanel(unittest.TestCase):
     def test_full_matrix(self):
         out = parse_items_panel(ITEMS_ROWS)
-        # 補休假: total 8h, used 1h, remaining 7h
+        # 補休假: total 28h, used 0h, remaining 28h (←真實值，先前解析器讀成全 None)
         bukyu = out["補休假"]
-        self.assertEqual(bukyu["total"], 8)
-        self.assertEqual(bukyu["used"], 1)
-        self.assertEqual(bukyu["remaining"], 7)
+        self.assertEqual(bukyu["total"], 28)
+        self.assertEqual(bukyu["used"], 0)
+        self.assertEqual(bukyu["remaining"], 28)
 
-        # 有薪病假: total 40 (parsed as int via "40 小時 / 1 年"? no -- /1 年 suffix
-        # makes it non-numeric, so we keep the raw and total=None)
+        # 有薪病假: 已用完 — used 40, remaining 0 ("40 小時 / 1 年" 帶後綴 → total None)
         sick = out["有薪病假"]
-        # Used 40 直接 hours, remaining 0
         self.assertEqual(sick["used"], 40)
         self.assertEqual(sick["remaining"], 0)
         self.assertEqual(sick["total_raw"], "40 小時 / 1 年")
 
-        # Workday-style values fall through as raw text only
+        # 半薪病假 / 事假: 法定無上限 → remaining None（cascade 視為可吸收）
+        self.assertIsNone(out["半薪病假"]["remaining"])
+        self.assertIsNone(out["事假(含家庭照顧假)"]["remaining"])
+
+        # Workday-style values fall through as raw text only (non-小時 → None)
         forget = out["忘刷忘帶卡"]
         self.assertEqual(forget["used"], None)
         self.assertEqual(forget["used_raw"], "0.5 工作天 / 1次")
@@ -113,7 +173,7 @@ class TestFetchBalances(unittest.TestCase):
         out = fetch_balances(portal, "http://x")
         self.assertIn("items", out)
         self.assertIn("補休假", out["items"])
-        self.assertEqual(out["items"]["補休假"]["remaining"], 7)
+        self.assertEqual(out["items"]["補休假"]["remaining"], 28)
         self.assertEqual(out["annual_leave"]["remaining_hours"], 81)
 
     def test_missing_items_raises(self):
@@ -130,14 +190,19 @@ class TestFormatBalanceTable(unittest.TestCase):
     def test_includes_補休_and_特休(self):
         portal = mock.Mock()
         portal.eval_json.side_effect = [
-            {"ok": True}, {"rows": ITEMS_ROWS}, {"rows": ANNUAL_ROWS},
+            {"ok": True},
+            {"rows": ITEMS_ROWS},
+            {"rows": ANNUAL_ROWS},
         ]
         balances = fetch_balances(portal, "http://x")
         text = format_balance_table(balances)
         self.assertIn("補休假", text)
-        self.assertIn("7h", text)  # remaining
+        # 不寫死數字：補休假剩餘由 fixture 解析得來，渲染後應出現在表內
+        bukyu_rem = balances["items"]["補休假"]["remaining"]
+        self.assertIn(f"{bukyu_rem}h", text)
         self.assertIn("特休假", text)
-        self.assertIn("81h", text)
+        annual_rem = balances["annual_leave"]["remaining_hours"]
+        self.assertIn(f"{annual_rem}h", text)
 
 
 if __name__ == "__main__":

--- a/test/test_portal_client.py
+++ b/test/test_portal_client.py
@@ -2,6 +2,7 @@
 
 We mock `subprocess.run` so the suite never shells out to a real CLI.
 """
+
 import subprocess
 import unittest
 from unittest import mock
@@ -24,7 +25,9 @@ def _ok(stdout: str = "") -> subprocess.CompletedProcess:
 
 
 def _err(returncode: int = 1, stderr: str = "boom") -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout="", stderr=stderr
+    )
 
 
 class TestEnsureInstalled(unittest.TestCase):
@@ -40,11 +43,11 @@ class TestEnsureInstalled(unittest.TestCase):
 
 class TestParseEvalOutput(unittest.TestCase):
     def test_extracts_dict(self):
-        raw = "✓ Done\n{\"foo\": 1}"
+        raw = '✓ Done\n{"foo": 1}'
         self.assertEqual(_parse_eval_output(raw), {"foo": 1})
 
     def test_extracts_list(self):
-        raw = "[{\"a\": 1}]"
+        raw = '[{"a": 1}]'
         self.assertEqual(_parse_eval_output(raw), [{"a": 1}])
 
     def test_primitive_true(self):
@@ -96,7 +99,7 @@ class TestPortalSession(unittest.TestCase):
 
     def test_eval_json_parses_dict(self):
         portal = self._portal()
-        with mock.patch("subprocess.run", return_value=_ok("✓ Done\n{\"v\": 7}")):
+        with mock.patch("subprocess.run", return_value=_ok('✓ Done\n{"v": 7}')):
             self.assertEqual(portal.eval_json("()"), {"v": 7})
 
     def test_nonzero_raises(self):
@@ -118,8 +121,9 @@ class TestPortalSession(unittest.TestCase):
 
     def test_timeout_raises(self):
         portal = self._portal()
-        with mock.patch("subprocess.run",
-                        side_effect=subprocess.TimeoutExpired(cmd=[], timeout=1)):
+        with mock.patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[], timeout=1)
+        ):
             with self.assertRaises(AgentBrowserError):
                 portal.open("http://x")
 
@@ -128,6 +132,54 @@ class TestPortalSession(unittest.TestCase):
         with portal as p:
             self.assertIs(p, portal)
 
+    def test_simple_wrappers_invoke_cli(self):
+        portal = self._portal()
+        with mock.patch("subprocess.run", return_value=_ok("http://here")) as run:
+            portal.wait(250)
+            self.assertEqual(portal.get_url(), "http://here")
+            portal.click_ref("@e1")
+            portal.select_ref("@e2", "全部")
+        verbs = [c[0][0][1] for c in run.call_args_list]
+        self.assertEqual(verbs, ["wait", "get", "click", "select"])
+
+    def test_close_swallows_error(self):
+        portal = self._portal()
+        with mock.patch("subprocess.run", return_value=_err(1, "no daemon")):
+            portal.close()  # no raise
+
+    def test_close_ok(self):
+        portal = self._portal()
+        with mock.patch("subprocess.run", return_value=_ok()):
+            portal.close()
+
+    def test_screenshot_returns_true_on_success(self):
+        portal = self._portal()
+        with mock.patch("subprocess.run", return_value=_ok()) as run:
+            self.assertTrue(portal.screenshot("/tmp/a.png"))
+            self.assertTrue(portal.screenshot("/tmp/a.png", full=True))
+        self.assertIn("--full", run.call_args[0][0])
+
+    def test_screenshot_returns_false_on_error(self):
+        portal = self._portal()
+        with mock.patch("subprocess.run", return_value=_err(1, "closed")):
+            self.assertFalse(portal.screenshot("/tmp/a.png"))
+
+
+class TestParseEvalEdge(unittest.TestCase):
+    def test_json_like_but_invalid_returns_candidate(self):
+        # 命中 _JSON_RE 但 json.loads 失敗 → 回傳原字串候選
+        out = _parse_eval_output("✓ Done\n{oops not json}")
+        self.assertEqual(out, "{oops not json}")
+
+
+class TestSessionContextManager(unittest.TestCase):
+    def test_session_sugar_yields_portal(self):
+        from lib.portal.client import session
+
+        with session("sess-x", check=False) as portal:
+            self.assertIsInstance(portal, PortalSession)
+            self.assertEqual(portal.session, "sess-x")
+
 
 class TestIsLoggedIn(unittest.TestCase):
     def _portal(self) -> PortalSession:
@@ -135,26 +187,33 @@ class TestIsLoggedIn(unittest.TestCase):
 
     def test_back_on_login_url(self):
         portal = self._portal()
-        with mock.patch.object(portal, "open"), \
-                mock.patch.object(portal, "get_url",
-                                  return_value="http://x/LoginFOrginal.asp"), \
-                mock.patch("time.sleep"):
+        with (
+            mock.patch.object(portal, "open"),
+            mock.patch.object(
+                portal, "get_url", return_value="http://x/LoginFOrginal.asp"
+            ),
+            mock.patch("time.sleep"),
+        ):
             self.assertFalse(is_logged_in(portal, "http://x"))
 
     def test_authenticated_path(self):
         portal = self._portal()
-        with mock.patch.object(portal, "open"), \
-                mock.patch.object(portal, "get_url",
-                                  return_value="http://x/ehrPortal/DEPT/Personal.asp"), \
-                mock.patch("time.sleep"):
+        with (
+            mock.patch.object(portal, "open"),
+            mock.patch.object(
+                portal, "get_url", return_value="http://x/ehrPortal/DEPT/Personal.asp"
+            ),
+            mock.patch("time.sleep"),
+        ):
             self.assertTrue(is_logged_in(portal, "http://x"))
 
     def test_chrome_error(self):
         portal = self._portal()
-        with mock.patch.object(portal, "open"), \
-                mock.patch.object(portal, "get_url",
-                                  return_value="chrome-error://broken"), \
-                mock.patch("time.sleep"):
+        with (
+            mock.patch.object(portal, "open"),
+            mock.patch.object(portal, "get_url", return_value="chrome-error://broken"),
+            mock.patch("time.sleep"),
+        ):
             self.assertFalse(is_logged_in(portal, "http://x"))
 
 
@@ -164,32 +223,41 @@ class TestEnsureLogin(unittest.TestCase):
 
     def test_already_logged_in_no_open(self):
         portal = self._portal()
-        with mock.patch("lib.portal.client.is_logged_in", return_value=True), \
-                mock.patch.object(portal, "open") as op, \
-                mock.patch("time.sleep"):
+        with (
+            mock.patch("lib.portal.client.is_logged_in", return_value=True),
+            mock.patch.object(portal, "open") as op,
+            mock.patch("time.sleep"),
+        ):
             ensure_login(portal, "http://x")
         op.assert_not_called()
 
     def test_transitions_to_logged_in(self):
         portal = self._portal()
-        urls = iter([
-            "http://x/LoginFOrginal.asp",
-            "http://x/LoginFOrginal.asp",
-            "http://x/ehrPortal/DEPT/Home.asp",
-        ])
-        with mock.patch("lib.portal.client.is_logged_in", return_value=False), \
-                mock.patch.object(portal, "open"), \
-                mock.patch.object(portal, "get_url", side_effect=lambda: next(urls)), \
-                mock.patch("time.sleep"):
+        urls = iter(
+            [
+                "http://x/LoginFOrginal.asp",
+                "http://x/LoginFOrginal.asp",
+                "http://x/ehrPortal/DEPT/Home.asp",
+            ]
+        )
+        with (
+            mock.patch("lib.portal.client.is_logged_in", return_value=False),
+            mock.patch.object(portal, "open"),
+            mock.patch.object(portal, "get_url", side_effect=lambda: next(urls)),
+            mock.patch("time.sleep"),
+        ):
             ensure_login(portal, "http://x", poll_interval_secs=0, max_wait_secs=60)
 
     def test_timeout(self):
         portal = self._portal()
-        with mock.patch("lib.portal.client.is_logged_in", return_value=False), \
-                mock.patch.object(portal, "open"), \
-                mock.patch.object(portal, "get_url",
-                                  return_value="http://x/LoginFOrginal.asp"), \
-                mock.patch("time.sleep"):
+        with (
+            mock.patch("lib.portal.client.is_logged_in", return_value=False),
+            mock.patch.object(portal, "open"),
+            mock.patch.object(
+                portal, "get_url", return_value="http://x/LoginFOrginal.asp"
+            ),
+            mock.patch("time.sleep"),
+        ):
             with self.assertRaises(LoginTimeout):
                 ensure_login(portal, "http://x", poll_interval_secs=0, max_wait_secs=0)
 

--- a/test/test_portal_client.py
+++ b/test/test_portal_client.py
@@ -25,9 +25,7 @@ def _ok(stdout: str = "") -> subprocess.CompletedProcess:
 
 
 def _err(returncode: int = 1, stderr: str = "boom") -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(
-        args=[], returncode=returncode, stdout="", stderr=stderr
-    )
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
 
 
 class TestEnsureInstalled(unittest.TestCase):
@@ -121,9 +119,7 @@ class TestPortalSession(unittest.TestCase):
 
     def test_timeout_raises(self):
         portal = self._portal()
-        with mock.patch(
-            "subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[], timeout=1)
-        ):
+        with mock.patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[], timeout=1)):
             with self.assertRaises(AgentBrowserError):
                 portal.open("http://x")
 
@@ -189,9 +185,7 @@ class TestIsLoggedIn(unittest.TestCase):
         portal = self._portal()
         with (
             mock.patch.object(portal, "open"),
-            mock.patch.object(
-                portal, "get_url", return_value="http://x/LoginFOrginal.asp"
-            ),
+            mock.patch.object(portal, "get_url", return_value="http://x/LoginFOrginal.asp"),
             mock.patch("time.sleep"),
         ):
             self.assertFalse(is_logged_in(portal, "http://x"))
@@ -253,9 +247,7 @@ class TestEnsureLogin(unittest.TestCase):
         with (
             mock.patch("lib.portal.client.is_logged_in", return_value=False),
             mock.patch.object(portal, "open"),
-            mock.patch.object(
-                portal, "get_url", return_value="http://x/LoginFOrginal.asp"
-            ),
+            mock.patch.object(portal, "get_url", return_value="http://x/LoginFOrginal.asp"),
             mock.patch("time.sleep"),
         ):
             with self.assertRaises(LoginTimeout):

--- a/test/test_portal_fetch_helpers.py
+++ b/test/test_portal_fetch_helpers.py
@@ -77,9 +77,7 @@ class TestResolveBaseUrl(unittest.TestCase):
 
     def test_arg_overrides_env(self):
         os.environ["EHR_URL"] = "http://from-env"
-        self.assertEqual(
-            _resolve_base_url(self._ns(base_url="http://from-arg")), "http://from-arg"
-        )
+        self.assertEqual(_resolve_base_url(self._ns(base_url="http://from-arg")), "http://from-arg")
 
     def test_env_used(self):
         os.environ["EHR_URL"] = "http://x.example/ehrPortal"

--- a/test/test_portal_fetch_helpers.py
+++ b/test/test_portal_fetch_helpers.py
@@ -1,4 +1,5 @@
 """Unit tests for `lib/commands/portal_fetch.py` helpers (Tier 1)."""
+
 import argparse
 import os
 import unittest
@@ -76,8 +77,9 @@ class TestResolveBaseUrl(unittest.TestCase):
 
     def test_arg_overrides_env(self):
         os.environ["EHR_URL"] = "http://from-env"
-        self.assertEqual(_resolve_base_url(self._ns(base_url="http://from-arg")),
-                         "http://from-arg")
+        self.assertEqual(
+            _resolve_base_url(self._ns(base_url="http://from-arg")), "http://from-arg"
+        )
 
     def test_env_used(self):
         os.environ["EHR_URL"] = "http://x.example/ehrPortal"

--- a/test/test_reasons.py
+++ b/test/test_reasons.py
@@ -1,4 +1,5 @@
 """Tests for `lib/reasons.py`."""
+
 import os
 import subprocess
 import tempfile
@@ -22,19 +23,29 @@ def _make_repo(path: Path) -> None:
     subprocess.run(["git", "init", "-q"], cwd=path, check=True)
 
 
-def _commit(path: Path, subject: str, when: str, *,
-            author_name: str = "Tester McTest",
-            author_email: str = "tester@example.com") -> None:
+def _commit(
+    path: Path,
+    subject: str,
+    when: str,
+    *,
+    author_name: str = "Tester McTest",
+    author_email: str = "tester@example.com",
+) -> None:
     f = path / "x"
     f.write_text(subject)
     subprocess.run(["git", "add", "x"], cwd=path, check=True)
     env = {
         **os.environ,
-        "GIT_AUTHOR_NAME": author_name, "GIT_AUTHOR_EMAIL": author_email,
-        "GIT_COMMITTER_NAME": author_name, "GIT_COMMITTER_EMAIL": author_email,
-        "GIT_AUTHOR_DATE": when, "GIT_COMMITTER_DATE": when,
+        "GIT_AUTHOR_NAME": author_name,
+        "GIT_AUTHOR_EMAIL": author_email,
+        "GIT_COMMITTER_NAME": author_name,
+        "GIT_COMMITTER_EMAIL": author_email,
+        "GIT_AUTHOR_DATE": when,
+        "GIT_COMMITTER_DATE": when,
     }
-    subprocess.run(["git", "commit", "-q", "-m", subject], cwd=path, env=env, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", subject], cwd=path, env=env, check=True
+    )
 
 
 class TestDiscoverRepos(unittest.TestCase):
@@ -50,6 +61,16 @@ class TestDiscoverRepos(unittest.TestCase):
     def test_missing_root_is_skipped(self):
         self.assertEqual(discover_repos(["/no/such/path/__missing__"]), [])
 
+    def test_exclude_skips_named_repos_case_insensitive(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _make_repo(root / "deployer-tf")
+            _make_repo(root / "hackthon")
+            _make_repo(root / "owner" / "Film-Brain")
+            repos = discover_repos([str(root)], exclude=["hackthon", "film-brain"])
+            names = sorted(r.name for r in repos)
+            self.assertEqual(names, ["deployer-tf"])
+
 
 class TestCommitsOn(unittest.TestCase):
     def test_returns_matching_author_only(self):
@@ -58,8 +79,13 @@ class TestCommitsOn(unittest.TestCase):
             _make_repo(repo)
             _commit(repo, "mine", "2026-04-20T18:50:00")
             # Change author for the next commit
-            _commit(repo, "not mine", "2026-04-20T19:00:00",
-                    author_name="Other Person", author_email="other@example.com")
+            _commit(
+                repo,
+                "not mine",
+                "2026-04-20T19:00:00",
+                author_name="Other Person",
+                author_email="other@example.com",
+            )
 
             rows = commits_on(repo, date(2026, 4, 20), authors=["Tester McTest"])
             self.assertEqual(len(rows), 1)
@@ -84,8 +110,9 @@ class TestCommitsOn(unittest.TestCase):
 
 class TestCommitMinutesLocal(unittest.TestCase):
     def test_parses_iso(self):
-        self.assertEqual(_commit_minutes_local({"time": "2026-04-20T18:30:00"}),
-                         18 * 60 + 30)
+        self.assertEqual(
+            _commit_minutes_local({"time": "2026-04-20T18:30:00"}), 18 * 60 + 30
+        )
 
     def test_handles_garbage(self):
         self.assertEqual(_commit_minutes_local({"time": "bad"}), -1)
@@ -96,23 +123,43 @@ class TestEvidenceForAnalysis(unittest.TestCase):
     def test_split_by_schedule_end(self):
         analysis = {
             "schema_version": "attendance-analysis/v1",
-            "overtime": [{
-                "date": "2026/04/20", "start_time": "1830",
-                "end_time": "2030", "hours": 2,
-                "location": "在辦公室", "reason": "x",
-            }],
-            "leave": [{
-                "date": "2026/04/20", "start_time": "0930",
-                "end_time": "1130", "hours": 2,
-                "type_hint": "late", "reason": "x",
-            }],
+            "overtime": [
+                {
+                    "date": "2026/04/20",
+                    "start_time": "1830",
+                    "end_time": "2030",
+                    "hours": 2,
+                    "location": "在辦公室",
+                    "reason": "x",
+                }
+            ],
+            "leave": [
+                {
+                    "date": "2026/04/20",
+                    "start_time": "0930",
+                    "end_time": "1130",
+                    "hours": 2,
+                    "type_hint": "late",
+                    "reason": "x",
+                }
+            ],
         }
-        fake = {"2026-04-20": [
-            {"repo": "x", "sha": "abc", "time": "2026-04-20T10:36:00",
-             "subject": "睡過頭 — should land in leave bucket"},
-            {"repo": "y", "sha": "def", "time": "2026-04-20T19:00:00",
-             "subject": "DO-2562 remove geo block — should land in overtime"},
-        ]}
+        fake = {
+            "2026-04-20": [
+                {
+                    "repo": "x",
+                    "sha": "abc",
+                    "time": "2026-04-20T10:36:00",
+                    "subject": "睡過頭 — should land in leave bucket",
+                },
+                {
+                    "repo": "y",
+                    "sha": "def",
+                    "time": "2026-04-20T19:00:00",
+                    "subject": "DO-2562 remove geo block — should land in overtime",
+                },
+            ]
+        }
         with mock.patch("lib.reasons.harvest_dates", return_value=fake):
             out = evidence_for_analysis(analysis, ["Tester"], schedule_end="18:30")
         e = out["2026/04/20"]

--- a/test/test_reasons.py
+++ b/test/test_reasons.py
@@ -43,9 +43,7 @@ def _commit(
         "GIT_AUTHOR_DATE": when,
         "GIT_COMMITTER_DATE": when,
     }
-    subprocess.run(
-        ["git", "commit", "-q", "-m", subject], cwd=path, env=env, check=True
-    )
+    subprocess.run(["git", "commit", "-q", "-m", subject], cwd=path, env=env, check=True)
 
 
 class TestDiscoverRepos(unittest.TestCase):
@@ -110,9 +108,7 @@ class TestCommitsOn(unittest.TestCase):
 
 class TestCommitMinutesLocal(unittest.TestCase):
     def test_parses_iso(self):
-        self.assertEqual(
-            _commit_minutes_local({"time": "2026-04-20T18:30:00"}), 18 * 60 + 30
-        )
+        self.assertEqual(_commit_minutes_local({"time": "2026-04-20T18:30:00"}), 18 * 60 + 30)
 
     def test_handles_garbage(self):
         self.assertEqual(_commit_minutes_local({"time": "bad"}), -1)

--- a/test/test_reasons_cmd_helpers.py
+++ b/test/test_reasons_cmd_helpers.py
@@ -4,19 +4,26 @@ The data-layer helpers (`lib/reasons.py`) are already covered in
 `test/test_reasons.py`. Here we focus on the CLI handler glue:
 default roots, required --author, --schedule-end passthrough.
 """
+
 import unittest
 
 
 class TestReasonsParserArgs(unittest.TestCase):
     def _parse(self, *argv):
         from lib.cli import build_parser
+
         parser = build_parser()
         return parser.parse_args(argv)
 
     def test_minimal(self):
         ns = self._parse(
-            "reasons", "--input", "tmp/analysis.json",
-            "--out", "tmp/evidence.json", "--author", "Jimmy Chen",
+            "reasons",
+            "--input",
+            "tmp/analysis.json",
+            "--out",
+            "tmp/evidence.json",
+            "--author",
+            "Jimmy Chen",
         )
         self.assertEqual(ns.cmd, "reasons")
         self.assertEqual(ns.input, "tmp/analysis.json")
@@ -29,22 +36,45 @@ class TestReasonsParserArgs(unittest.TestCase):
 
     def test_multiple_authors(self):
         ns = self._parse(
-            "reasons", "--input", "x", "--out", "y",
-            "--author", "a", "--author", "b",
+            "reasons",
+            "--input",
+            "x",
+            "--out",
+            "y",
+            "--author",
+            "a",
+            "--author",
+            "b",
         )
         self.assertEqual(ns.author, ["a", "b"])
 
     def test_custom_roots(self):
         ns = self._parse(
-            "reasons", "--input", "x", "--out", "y", "--author", "a",
-            "--root", "/foo", "--root", "/bar",
+            "reasons",
+            "--input",
+            "x",
+            "--out",
+            "y",
+            "--author",
+            "a",
+            "--root",
+            "/foo",
+            "--root",
+            "/bar",
         )
         self.assertEqual(ns.roots, ["/foo", "/bar"])
 
     def test_custom_schedule_end(self):
         ns = self._parse(
-            "reasons", "--input", "x", "--out", "y", "--author", "a",
-            "--schedule-end", "19:00",
+            "reasons",
+            "--input",
+            "x",
+            "--out",
+            "y",
+            "--author",
+            "a",
+            "--schedule-end",
+            "19:00",
         )
         self.assertEqual(ns.schedule_end, "19:00")
 

--- a/test/test_report_builder.py
+++ b/test/test_report_builder.py
@@ -8,30 +8,30 @@ from lib import report
 class TestReportBuilder(unittest.TestCase):
     def test_incremental_preview_overflow(self):
         dates = [f"2025/07/{i:02d}" for i in range(1, 8)]
-        lines = report.build_incremental_lines('王小明', 20, 7, dates)
+        lines = report.build_incremental_lines("王小明", 20, 7, dates)
         text = "\n".join(lines)
-        self.assertIn('等 7 天', text)
+        self.assertIn("等 7 天", text)
 
     def test_issue_section_empty(self):
-        self.assertEqual(report.build_issue_section('## 節', 'x', []), [])
+        self.assertEqual(report.build_issue_section("## 節", "x", []), [])
 
     def test_issue_section_hide_calc(self):
         issues = [
             SimpleNamespace(
                 date=datetime(2025, 7, 1),
-                description='遲到2分鐘',
-                time_range='10:30~10:32',
-                calculation='…'
+                description="遲到2分鐘",
+                time_range="10:30~10:32",
+                calculation="…",
             )
         ]
-        lines = report.build_issue_section('## 測試', '😅', issues, show_calc=False)
+        lines = report.build_issue_section("## 測試", "😅", issues, show_calc=False)
         text = "\n".join(lines)
-        self.assertIn('遲到2分鐘', text)
-        self.assertIn('10:30~10:32', text)
-        self.assertNotIn('🧮', text)
+        self.assertIn("遲到2分鐘", text)
+        self.assertIn("10:30~10:32", text)
+        self.assertNotIn("🧮", text)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Report
 Purpose: Incremental section preview and issue sections rendering."""

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -16,9 +16,7 @@ from lib.schema import (
 
 class TestParseVersion(unittest.TestCase):
     def test_basic_major(self):
-        self.assertEqual(
-            parse_version("attendance-analysis/v1"), ("attendance-analysis", 1, 0)
-        )
+        self.assertEqual(parse_version("attendance-analysis/v1"), ("attendance-analysis", 1, 0))
 
     def test_major_minor(self):
         self.assertEqual(
@@ -58,9 +56,7 @@ class TestRequireSchemaVersion(unittest.TestCase):
 
     def test_wrong_name(self):
         with self.assertRaises(SchemaVersionError):
-            require_schema_version(
-                {"schema_version": "other-schema/v1"}, "attendance-analysis/v1"
-            )
+            require_schema_version({"schema_version": "other-schema/v1"}, "attendance-analysis/v1")
 
     def test_wrong_major(self):
         with self.assertRaises(SchemaVersionError):

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,4 +1,5 @@
 """Tests for lib.schema (version validation + parsing)."""
+
 import json
 import os
 import tempfile
@@ -15,11 +16,15 @@ from lib.schema import (
 
 class TestParseVersion(unittest.TestCase):
     def test_basic_major(self):
-        self.assertEqual(parse_version("attendance-analysis/v1"), ("attendance-analysis", 1, 0))
+        self.assertEqual(
+            parse_version("attendance-analysis/v1"), ("attendance-analysis", 1, 0)
+        )
 
     def test_major_minor(self):
-        self.assertEqual(parse_version("portal-attendance-snapshot/v2.3"),
-                         ("portal-attendance-snapshot", 2, 3))
+        self.assertEqual(
+            parse_version("portal-attendance-snapshot/v2.3"),
+            ("portal-attendance-snapshot", 2, 3),
+        )
 
     def test_malformed_no_slash(self):
         with self.assertRaises(SchemaVersionError):
@@ -36,13 +41,15 @@ class TestParseVersion(unittest.TestCase):
 
 class TestRequireSchemaVersion(unittest.TestCase):
     def test_matches_exact(self):
-        require_schema_version({"schema_version": "attendance-analysis/v1"},
-                               "attendance-analysis/v1")  # no raise
+        require_schema_version(
+            {"schema_version": "attendance-analysis/v1"}, "attendance-analysis/v1"
+        )  # no raise
 
     def test_matches_minor_diff(self):
         # major matches, minor differs — accepted
-        require_schema_version({"schema_version": "attendance-analysis/v1.2"},
-                               "attendance-analysis/v1")
+        require_schema_version(
+            {"schema_version": "attendance-analysis/v1.2"}, "attendance-analysis/v1"
+        )
 
     def test_missing_field(self):
         with self.assertRaises(SchemaVersionError) as cm:
@@ -51,13 +58,15 @@ class TestRequireSchemaVersion(unittest.TestCase):
 
     def test_wrong_name(self):
         with self.assertRaises(SchemaVersionError):
-            require_schema_version({"schema_version": "other-schema/v1"},
-                                   "attendance-analysis/v1")
+            require_schema_version(
+                {"schema_version": "other-schema/v1"}, "attendance-analysis/v1"
+            )
 
     def test_wrong_major(self):
         with self.assertRaises(SchemaVersionError):
-            require_schema_version({"schema_version": "attendance-analysis/v2"},
-                                   "attendance-analysis/v1")
+            require_schema_version(
+                {"schema_version": "attendance-analysis/v2"}, "attendance-analysis/v1"
+            )
 
     def test_non_dict_payload(self):
         with self.assertRaises(SchemaVersionError):

--- a/test/test_server_cleanup.py
+++ b/test/test_server_cleanup.py
@@ -71,7 +71,9 @@ class TestServerCleanup(unittest.TestCase):
         self.assertEqual(response.status_code, 200, response.text)
         return response.json()
 
-    def _analyze(self, *, file_path: str, cleanup_state: dict, snapshot: dict | None = None):
+    def _analyze(
+        self, *, file_path: str, cleanup_state: dict, snapshot: dict | None = None
+    ):
         with open(file_path, "rb") as fh:
             data = {
                 "mode": "incremental",
@@ -106,9 +108,15 @@ class TestServerCleanup(unittest.TestCase):
         )
 
         preview = self._preview(filename="sample-attendance-data.txt", output="csv")
-        backup_names = {item["name"] for item in preview["items"] if item["kind"] == "backup"}
-        self.assertIn("sample-attendance-data_analysis_20240101_000000.csv", backup_names)
-        canonical_entry = [item for item in preview["items"] if item["kind"] == "canonical"]
+        backup_names = {
+            item["name"] for item in preview["items"] if item["kind"] == "backup"
+        }
+        self.assertIn(
+            "sample-attendance-data_analysis_20240101_000000.csv", backup_names
+        )
+        canonical_entry = [
+            item for item in preview["items"] if item["kind"] == "canonical"
+        ]
         self.assertTrue(canonical_entry)
         self.assertFalse(canonical_entry[0]["delete"])
 
@@ -126,7 +134,9 @@ class TestServerCleanup(unittest.TestCase):
         self.assertEqual(response.status_code, 200, response.text)
         payload = response.json()
         self.assertEqual(payload["cleanup"]["status"], "performed")
-        backup_path = self.canonical_dir / "sample-attendance-data_analysis_20240101_000000.csv"
+        backup_path = (
+            self.canonical_dir / "sample-attendance-data_analysis_20240101_000000.csv"
+        )
         self.assertFalse(backup_path.exists())
         self.assertTrue(canonical.exists())
 

--- a/test/test_server_cleanup.py
+++ b/test/test_server_cleanup.py
@@ -71,9 +71,7 @@ class TestServerCleanup(unittest.TestCase):
         self.assertEqual(response.status_code, 200, response.text)
         return response.json()
 
-    def _analyze(
-        self, *, file_path: str, cleanup_state: dict, snapshot: dict | None = None
-    ):
+    def _analyze(self, *, file_path: str, cleanup_state: dict, snapshot: dict | None = None):
         with open(file_path, "rb") as fh:
             data = {
                 "mode": "incremental",
@@ -100,23 +98,15 @@ class TestServerCleanup(unittest.TestCase):
         return path
 
     def test_cleanup_preview_and_analyze_merges_backups(self):
-        canonical = self._write_canonical(
-            "sample-attendance-data_analysis.csv", "old,data\n"
-        )
+        canonical = self._write_canonical("sample-attendance-data_analysis.csv", "old,data\n")
         self._write_canonical(
             "sample-attendance-data_analysis_20240101_000000.csv", "backup,data\n"
         )
 
         preview = self._preview(filename="sample-attendance-data.txt", output="csv")
-        backup_names = {
-            item["name"] for item in preview["items"] if item["kind"] == "backup"
-        }
-        self.assertIn(
-            "sample-attendance-data_analysis_20240101_000000.csv", backup_names
-        )
-        canonical_entry = [
-            item for item in preview["items"] if item["kind"] == "canonical"
-        ]
+        backup_names = {item["name"] for item in preview["items"] if item["kind"] == "backup"}
+        self.assertIn("sample-attendance-data_analysis_20240101_000000.csv", backup_names)
+        canonical_entry = [item for item in preview["items"] if item["kind"] == "canonical"]
         self.assertTrue(canonical_entry)
         self.assertFalse(canonical_entry[0]["delete"])
 
@@ -134,9 +124,7 @@ class TestServerCleanup(unittest.TestCase):
         self.assertEqual(response.status_code, 200, response.text)
         payload = response.json()
         self.assertEqual(payload["cleanup"]["status"], "performed")
-        backup_path = (
-            self.canonical_dir / "sample-attendance-data_analysis_20240101_000000.csv"
-        )
+        backup_path = self.canonical_dir / "sample-attendance-data_analysis_20240101_000000.csv"
         self.assertFalse(backup_path.exists())
         self.assertTrue(canonical.exists())
 

--- a/test/test_state_applied_forms.py
+++ b/test/test_state_applied_forms.py
@@ -114,9 +114,7 @@ class TestAppliedForms(unittest.TestCase):
         self.sm.replace_applied_forms(
             "JimmyChen",
             {
-                "overtime": [
-                    {**self._ot("2026/04/20", "1830", "2030"), "synced_at": "earlier"}
-                ],
+                "overtime": [{**self._ot("2026/04/20", "1830", "2030"), "synced_at": "earlier"}],
                 "leave": [],
             },
             synced_at="now",

--- a/test/test_state_applied_forms.py
+++ b/test/test_state_applied_forms.py
@@ -114,7 +114,9 @@ class TestAppliedForms(unittest.TestCase):
         self.sm.replace_applied_forms(
             "JimmyChen",
             {
-                "overtime": [{**self._ot("2026/04/20", "1830", "2030"), "synced_at": "earlier"}],
+                "overtime": [
+                    {**self._ot("2026/04/20", "1830", "2030"), "synced_at": "earlier"}
+                ],
                 "leave": [],
             },
             synced_at="now",

--- a/test/test_state_edgecases.py
+++ b/test/test_state_edgecases.py
@@ -39,9 +39,7 @@ class TestStateEdgeCases(unittest.TestCase):
                 "source_file": "202507-小明-出勤資料.txt",
                 "last_analysis_time": "2025-09-13T10:00:00",
             }
-            r2 = dict(
-                r1, end_date="2025-08-31", last_analysis_time="2025-09-13T11:00:00"
-            )
+            r2 = dict(r1, end_date="2025-08-31", last_analysis_time="2025-09-13T11:00:00")
 
             m.update_user_state("小明", r1, {"2025-07": 1})
             self.assertEqual(len(m.get_user_processed_ranges("小明")), 1)

--- a/test/test_state_edgecases.py
+++ b/test/test_state_edgecases.py
@@ -9,61 +9,63 @@ from lib.state import AttendanceStateManager
 class TestStateEdgeCases(unittest.TestCase):
     def test_load_state_corrupt_json(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'attendance_state.json')
-            with open(path, 'w', encoding='utf-8') as f:
-                f.write('{ this is not json')
-            with self.assertLogs('lib.state', level='WARNING') as cm:
+            path = os.path.join(tmp, "attendance_state.json")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("{ this is not json")
+            with self.assertLogs("lib.state", level="WARNING") as cm:
                 m = AttendanceStateManager(path)
             self.assertEqual(m.state_data, {"users": {}})
             logs = "\n".join(cm.output)
-            self.assertIn('無法讀取狀態檔案', logs)
-            self.assertIn('將使用空白狀態', logs)
+            self.assertIn("無法讀取狀態檔案", logs)
+            self.assertIn("將使用空白狀態", logs)
 
     def test_save_state_write_failure_warns(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'attendance_state.json')
+            path = os.path.join(tmp, "attendance_state.json")
             m = AttendanceStateManager(path)
             m.state_data = {"users": {}}
-            with mock.patch('builtins.open', side_effect=OSError('disk full')):
-                with self.assertLogs('lib.state', level='WARNING') as cm:
+            with mock.patch("builtins.open", side_effect=OSError("disk full")):
+                with self.assertLogs("lib.state", level="WARNING") as cm:
                     m.save_state()
-            self.assertIn('無法儲存狀態檔案', "\n".join(cm.output))
+            self.assertIn("無法儲存狀態檔案", "\n".join(cm.output))
 
     def test_update_user_state_replace_and_merge_usage(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'attendance_state.json')
+            path = os.path.join(tmp, "attendance_state.json")
             m = AttendanceStateManager(path)
             r1 = {
-                'start_date': '2025-07-01',
-                'end_date': '2025-07-31',
-                'source_file': '202507-小明-出勤資料.txt',
-                'last_analysis_time': '2025-09-13T10:00:00'
+                "start_date": "2025-07-01",
+                "end_date": "2025-07-31",
+                "source_file": "202507-小明-出勤資料.txt",
+                "last_analysis_time": "2025-09-13T10:00:00",
             }
-            r2 = dict(r1, end_date='2025-08-31', last_analysis_time='2025-09-13T11:00:00')
+            r2 = dict(
+                r1, end_date="2025-08-31", last_analysis_time="2025-09-13T11:00:00"
+            )
 
-            m.update_user_state('小明', r1, {'2025-07': 1})
-            self.assertEqual(len(m.get_user_processed_ranges('小明')), 1)
-            self.assertEqual(m.get_forget_punch_usage('小明', '2025-07'), 1)
+            m.update_user_state("小明", r1, {"2025-07": 1})
+            self.assertEqual(len(m.get_user_processed_ranges("小明")), 1)
+            self.assertEqual(m.get_forget_punch_usage("小明", "2025-07"), 1)
 
             # same source_file should replace, not append
-            m.update_user_state('小明', r2, {'2025-08': 2})
-            ranges = m.get_user_processed_ranges('小明')
+            m.update_user_state("小明", r2, {"2025-08": 2})
+            ranges = m.get_user_processed_ranges("小明")
             self.assertEqual(len(ranges), 1)
-            self.assertEqual(ranges[0]['end_date'], '2025-08-31')
-            self.assertEqual(m.get_forget_punch_usage('小明', '2025-08'), 2)
+            self.assertEqual(ranges[0]["end_date"], "2025-08-31")
+            self.assertEqual(m.get_forget_punch_usage("小明", "2025-08"), 2)
 
     def test_read_only_mode_skips_write(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'attendance_state.json')
+            path = os.path.join(tmp, "attendance_state.json")
             m = AttendanceStateManager(path, read_only=True)
             m.state_data = {"users": {"tester": {}}}
-            with self.assertLogs('lib.state', level='DEBUG') as cm:
+            with self.assertLogs("lib.state", level="DEBUG") as cm:
                 m.save_state()
             self.assertFalse(os.path.exists(path))
-            self.assertIn('略過狀態寫入', "\n".join(cm.output))
+            self.assertIn("略過狀態寫入", "\n".join(cm.output))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: State
 Purpose: Corrupt state file, save failure warnings, and merge logic."""

--- a/test/test_state_exception_handling.py
+++ b/test/test_state_exception_handling.py
@@ -87,9 +87,7 @@ class TestStateExceptionHandling(unittest.TestCase):
         """Test get_last_analysis_time when user exists but no processed ranges."""
         manager = AttendanceStateManager(self.state_file)
         manager.state_data = {
-            "users": {
-                "test_user": {"processed_date_ranges": [], "forget_punch_usage": {}}
-            }
+            "users": {"test_user": {"processed_date_ranges": [], "forget_punch_usage": {}}}
         }
 
         last_time = manager.get_last_analysis_time("test_user")

--- a/test/test_state_exception_handling.py
+++ b/test/test_state_exception_handling.py
@@ -25,39 +25,39 @@ class TestStateExceptionHandling(unittest.TestCase):
     def test_load_state_json_decode_error(self):
         """Test handling of JSON decode error during state loading."""
         # Create a corrupted JSON file
-        with open(self.state_file, 'w', encoding='utf-8') as f:
+        with open(self.state_file, "w", encoding="utf-8") as f:
             f.write('{"invalid": json}')  # Invalid JSON
-        
+
         manager = AttendanceStateManager(self.state_file)
-        
+
         # Should return default state due to JSON decode error
         self.assertEqual(manager.state_data, {"users": {}})
 
     def test_load_state_os_error(self):
         """Test handling of OS error during state loading."""
         # Create file and make it unreadable
-        with open(self.state_file, 'w', encoding='utf-8') as f:
+        with open(self.state_file, "w", encoding="utf-8") as f:
             f.write('{"users": {}}')
-        
-        with patch('builtins.open', side_effect=OSError("Permission denied")):
+
+        with patch("builtins.open", side_effect=OSError("Permission denied")):
             manager = AttendanceStateManager(self.state_file)
-            
+
             # Should return default state due to OS error
             self.assertEqual(manager.state_data, {"users": {}})
 
     def test_save_state_os_error(self):
         """Test handling of OS error during state saving."""
         manager = AttendanceStateManager(self.state_file)
-        
+
         # Mock open to raise OSError during save
-        with patch('builtins.open', side_effect=OSError("Permission denied")):
+        with patch("builtins.open", side_effect=OSError("Permission denied")):
             # Should not raise exception, just log warning
             manager.save_state()
 
     def test_get_forget_punch_usage_user_not_exists(self):
         """Test get_forget_punch_usage when user doesn't exist."""
         manager = AttendanceStateManager(self.state_file)
-        
+
         usage = manager.get_forget_punch_usage("nonexistent_user", "2025-08")
         self.assertEqual(usage, 0)
 
@@ -72,14 +72,14 @@ class TestStateExceptionHandling(unittest.TestCase):
                 }
             }
         }
-        
+
         usage = manager.get_forget_punch_usage("test_user", "2025-08")
         self.assertEqual(usage, 0)
 
     def test_get_last_analysis_time_user_not_exists(self):
         """Test get_last_analysis_time when user doesn't exist."""
         manager = AttendanceStateManager(self.state_file)
-        
+
         last_time = manager.get_last_analysis_time("nonexistent_user")
         self.assertEqual(last_time, "")
 
@@ -88,13 +88,10 @@ class TestStateExceptionHandling(unittest.TestCase):
         manager = AttendanceStateManager(self.state_file)
         manager.state_data = {
             "users": {
-                "test_user": {
-                    "processed_date_ranges": [],
-                    "forget_punch_usage": {}
-                }
+                "test_user": {"processed_date_ranges": [], "forget_punch_usage": {}}
             }
         }
-        
+
         last_time = manager.get_last_analysis_time("test_user")
         self.assertEqual(last_time, "")
 
@@ -108,32 +105,32 @@ class TestStateExceptionHandling(unittest.TestCase):
                         {
                             "start_date": "2025-08-01",
                             "end_date": "2025-08-31",
-                            "source_file": "test.txt"
+                            "source_file": "test.txt",
                             # Missing last_analysis_time field
                         }
                     ],
-                    "forget_punch_usage": {}
+                    "forget_punch_usage": {},
                 }
             }
         }
-        
+
         last_time = manager.get_last_analysis_time("test_user")
         self.assertEqual(last_time, "")
 
     def test_update_user_state_new_user(self):
         """Test update_user_state when user doesn't exist in state."""
         manager = AttendanceStateManager(self.state_file)
-        
+
         new_range = {
             "start_date": "2025-08-01",
             "end_date": "2025-08-31",
             "source_file": "test.txt",
-            "last_analysis_time": "2025-08-27T14:30:00"
+            "last_analysis_time": "2025-08-27T14:30:00",
         }
         forget_punch_usage = {"2025-08": 1}
-        
+
         manager.update_user_state("new_user", new_range, forget_punch_usage)
-        
+
         # Verify user was created with correct structure
         self.assertIn("new_user", manager.state_data["users"])
         user_data = manager.state_data["users"]["new_user"]
@@ -151,23 +148,23 @@ class TestStateExceptionHandling(unittest.TestCase):
                             "start_date": "2025-08-01",
                             "end_date": "2025-08-15",
                             "source_file": "test.txt",
-                            "last_analysis_time": "2025-08-15T10:00:00"
+                            "last_analysis_time": "2025-08-15T10:00:00",
                         }
                     ],
-                    "forget_punch_usage": {"2025-08": 0}
+                    "forget_punch_usage": {"2025-08": 0},
                 }
             }
         }
-        
+
         updated_range = {
             "start_date": "2025-08-01",
             "end_date": "2025-08-31",
             "source_file": "test.txt",
-            "last_analysis_time": "2025-08-31T15:00:00"
+            "last_analysis_time": "2025-08-31T15:00:00",
         }
-        
+
         manager.update_user_state("test_user", updated_range, {"2025-08": 1})
-        
+
         # Verify existing range was updated, not appended
         user_data = manager.state_data["users"]["test_user"]
         self.assertEqual(len(user_data["processed_date_ranges"]), 1)
@@ -185,23 +182,23 @@ class TestStateExceptionHandling(unittest.TestCase):
                             "start_date": "2025-07-01",
                             "end_date": "2025-07-31",
                             "source_file": "july.txt",
-                            "last_analysis_time": "2025-07-31T10:00:00"
+                            "last_analysis_time": "2025-07-31T10:00:00",
                         }
                     ],
-                    "forget_punch_usage": {"2025-07": 2}
+                    "forget_punch_usage": {"2025-07": 2},
                 }
             }
         }
-        
+
         new_range = {
             "start_date": "2025-08-01",
             "end_date": "2025-08-31",
             "source_file": "august.txt",
-            "last_analysis_time": "2025-08-31T15:00:00"
+            "last_analysis_time": "2025-08-31T15:00:00",
         }
-        
+
         manager.update_user_state("test_user", new_range, {"2025-08": 1})
-        
+
         # Verify new range was appended
         user_data = manager.state_data["users"]["test_user"]
         self.assertEqual(len(user_data["processed_date_ranges"]), 2)
@@ -210,5 +207,5 @@ class TestStateExceptionHandling(unittest.TestCase):
         self.assertEqual(user_data["forget_punch_usage"]["2025-08"], 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_state_filter_unprocessed.py
+++ b/test/test_state_filter_unprocessed.py
@@ -38,7 +38,7 @@ class TestFilterUnprocessed(unittest.TestCase):
         self.assertEqual(out, days)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: State/Dates
 Purpose: Range merging and membership checks for unprocessed date filter."""

--- a/test/test_state_update_flow.py
+++ b/test/test_state_update_flow.py
@@ -19,7 +19,9 @@ class DummyState:
 
     def update_user_state(self, user, range_info, forget_punch_usage):
         self.updated = True
-        self.state_data.setdefault('users', {}).setdefault(user, {})['last'] = range_info
+        self.state_data.setdefault("users", {}).setdefault(user, {})[
+            "last"
+        ] = range_info
 
     def save_state(self):
         self.saved = True
@@ -30,15 +32,17 @@ class DummyState:
 
 class TestStateUpdateFlow(unittest.TestCase):
     def _write_minimal_file(self, path):
-        with open(path, 'w', encoding='utf-8') as f:
-            f.write('應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n')
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註\n"
+            )
             # 2025/07/01 checkin and checkout to form a complete day
-            f.write('2025/07/01 09:10\t2025/07/01 09:10\t上班\t123\t門禁\t\t\t\t\n')
-            f.write('2025/07/01 18:20\t2025/07/01 18:20\t下班\t123\t門禁\t\t\t\t\n')
+            f.write("2025/07/01 09:10\t2025/07/01 09:10\t上班\t123\t門禁\t\t\t\t\n")
+            f.write("2025/07/01 18:20\t2025/07/01 18:20\t下班\t123\t門禁\t\t\t\t\n")
 
     def test_update_processing_state_is_called(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, '202507-阿明-出勤資料.txt')
+            path = os.path.join(tmp, "202507-阿明-出勤資料.txt")
             self._write_minimal_file(path)
 
             an = AttendanceAnalyzer()
@@ -55,7 +59,7 @@ class TestStateUpdateFlow(unittest.TestCase):
             self.assertTrue(dummy.saved)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: State
 Purpose: Ensure update/save is invoked after analysis in incremental mode."""

--- a/test/test_state_update_flow.py
+++ b/test/test_state_update_flow.py
@@ -19,9 +19,7 @@ class DummyState:
 
     def update_user_state(self, user, range_info, forget_punch_usage):
         self.updated = True
-        self.state_data.setdefault("users", {}).setdefault(user, {})[
-            "last"
-        ] = range_info
+        self.state_data.setdefault("users", {}).setdefault(user, {})["last"] = range_info
 
     def save_state(self):
         self.saved = True

--- a/test/test_status_row_timestamp.py
+++ b/test/test_status_row_timestamp.py
@@ -8,7 +8,9 @@ from openpyxl import load_workbook
 from attendance_analyzer import AttendanceAnalyzer
 
 # Long header extracted to module level to avoid line length issues
-ATTENDANCE_HEADER = "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
+ATTENDANCE_HEADER = (
+    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
+)
 
 
 class TestStatusRowTimestamp(unittest.TestCase):

--- a/test/test_status_row_timestamp.py
+++ b/test/test_status_row_timestamp.py
@@ -8,9 +8,7 @@ from openpyxl import load_workbook
 from attendance_analyzer import AttendanceAnalyzer
 
 # Long header extracted to module level to avoid line length issues
-ATTENDANCE_HEADER = (
-    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
-)
+ATTENDANCE_HEADER = "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
 
 
 class TestStatusRowTimestamp(unittest.TestCase):
@@ -20,8 +18,8 @@ class TestStatusRowTimestamp(unittest.TestCase):
 2025/07/01 17:00	2025/07/01 18:00	下班	1	刷卡匯入				
 """
         tmpdir = tempfile.mkdtemp()
-        valid_named = os.path.join(tmpdir, '202507-王小明-出勤資料.txt')
-        with open(valid_named, 'w', encoding='utf-8') as f:
+        valid_named = os.path.join(tmpdir, "202507-王小明-出勤資料.txt")
+        with open(valid_named, "w", encoding="utf-8") as f:
             f.write(text)
         analyzer = AttendanceAnalyzer()
         analyzer.incremental_mode = True
@@ -32,15 +30,15 @@ class TestStatusRowTimestamp(unittest.TestCase):
 
     def test_csv_status_has_timestamp(self):
         analyzer, named_path = self._run_clean_case()
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             out_csv = f.name
         try:
             analyzer.export_csv(out_csv)
-            with open(out_csv, encoding='utf-8-sig') as f:
-                rows = list(csv.reader(f, delimiter=';'))
+            with open(out_csv, encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f, delimiter=";"))
             self.assertGreaterEqual(len(rows), 2)
             status_line = rows[1]
-            self.assertIn('上次分析時間:', status_line[3])
+            self.assertIn("上次分析時間:", status_line[3])
         finally:
             if os.path.exists(out_csv):
                 os.unlink(out_csv)
@@ -53,13 +51,13 @@ class TestStatusRowTimestamp(unittest.TestCase):
 
     def test_excel_status_has_timestamp(self):
         analyzer, named_path = self._run_clean_case()
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlsx', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xlsx", delete=False) as f:
             out_xlsx = f.name
         try:
             analyzer.export_excel(out_xlsx)
             wb = load_workbook(out_xlsx)
             ws = wb.active
-            self.assertIn('上次分析時間:', ws['D2'].value)
+            self.assertIn("上次分析時間:", ws["D2"].value)
         finally:
             if os.path.exists(out_xlsx):
                 os.unlink(out_xlsx)
@@ -71,7 +69,7 @@ class TestStatusRowTimestamp(unittest.TestCase):
                 pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Export/StatusRow
 Purpose: Status row includes last analysis timestamp for CSV/Excel."""

--- a/test/test_unprocessed_and_dates.py
+++ b/test/test_unprocessed_and_dates.py
@@ -14,14 +14,14 @@ class TestUnprocessedEarlyReturn(unittest.TestCase):
             datetime(2025, 7, 1),
             datetime(2025, 7, 2),
         ]
-        out = an._get_unprocessed_dates('任意', days)
+        out = an._get_unprocessed_dates("任意", days)
         self.assertEqual(out, days)
 
     def test_get_unprocessed_dates_full_mode_returns_all(self):
         an = AttendanceAnalyzer()
         an.incremental_mode = False
         days = [datetime(2025, 7, 1)]
-        out = an._get_unprocessed_dates('任意', days)
+        out = an._get_unprocessed_dates("任意", days)
         self.assertEqual(out, days)
 
 
@@ -34,15 +34,15 @@ class TestDatesHelperSkipsInvalid(unittest.TestCase):
     def test_identify_complete_skips_none_date(self):
         # One valid complete day + one record with no date should be ignored
         recs = [
-            self.Obj(datetime(2025, 7, 1).date(), 'CHECKIN'),
-            self.Obj(datetime(2025, 7, 1).date(), 'CHECKOUT'),
-            self.Obj(None, 'CHECKIN'),
+            self.Obj(datetime(2025, 7, 1).date(), "CHECKIN"),
+            self.Obj(datetime(2025, 7, 1).date(), "CHECKOUT"),
+            self.Obj(None, "CHECKIN"),
         ]
         out = identify_complete_work_days(recs)
         self.assertEqual([d.date() for d in out], [datetime(2025, 7, 1).date()])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: State/Dates
 Purpose: Analyzer exposure of unprocessed dates and complete-day id."""

--- a/test/test_weekend_ot.py
+++ b/test/test_weekend_ot.py
@@ -1,4 +1,5 @@
 """Tests for `lib/weekend_ot.py`."""
+
 import unittest
 from datetime import date
 from unittest import mock
@@ -20,7 +21,8 @@ class TestListWeekendHolidayDates(unittest.TestCase):
 
     def test_includes_explicit_holiday(self):
         out = list_weekend_holiday_dates(
-            date(2026, 5, 1), date(2026, 5, 3),
+            date(2026, 5, 1),
+            date(2026, 5, 3),
             holidays={date(2026, 5, 1)},  # Friday Labor Day
         )
         out_strs = sorted(d.strftime("%m/%d") for d in out)
@@ -32,10 +34,18 @@ class TestDetectCandidates(unittest.TestCase):
         # 2026/04/25 was a Saturday with two commits in the session
         fake_commits_by_date = {
             (date(2026, 4, 25)): [
-                {"repo": "kb-devops-raw", "sha": "abc", "subject": "note(aws-nuke)",
-                 "time": "2026-04-25T14:12:00"},
-                {"repo": "kb-devops-raw", "sha": "def", "subject": "follow up",
-                 "time": "2026-04-25T14:35:00"},
+                {
+                    "repo": "kb-devops-raw",
+                    "sha": "abc",
+                    "subject": "note(aws-nuke)",
+                    "time": "2026-04-25T14:12:00",
+                },
+                {
+                    "repo": "kb-devops-raw",
+                    "sha": "def",
+                    "subject": "follow up",
+                    "time": "2026-04-25T14:35:00",
+                },
             ],
             (date(2026, 4, 18)): [],  # quiet Saturday
         }
@@ -43,11 +53,13 @@ class TestDetectCandidates(unittest.TestCase):
         def fake_commits_on(repo, target, authors, **kw):
             return fake_commits_by_date.get(target, [])
 
-        with mock.patch("lib.weekend_ot.commits_on", side_effect=fake_commits_on), \
-                mock.patch("lib.weekend_ot.discover_repos",
-                           return_value=["fake-repo"]):
+        with (
+            mock.patch("lib.weekend_ot.commits_on", side_effect=fake_commits_on),
+            mock.patch("lib.weekend_ot.discover_repos", return_value=["fake-repo"]),
+        ):
             out = detect_candidates(
-                date(2026, 4, 1), date(2026, 4, 30),
+                date(2026, 4, 1),
+                date(2026, 4, 30),
                 authors=["Tester"],
             )
         self.assertEqual(len(out), 1)
@@ -60,25 +72,37 @@ class TestDetectCandidates(unittest.TestCase):
         self.assertEqual(len(cand["evidence"]["git"]), 2)
 
     def test_skips_days_with_no_commits(self):
-        with mock.patch("lib.weekend_ot.commits_on", return_value=[]), \
-                mock.patch("lib.weekend_ot.discover_repos",
-                           return_value=["fake"]):
+        with (
+            mock.patch("lib.weekend_ot.commits_on", return_value=[]),
+            mock.patch("lib.weekend_ot.discover_repos", return_value=["fake"]),
+        ):
             out = detect_candidates(
-                date(2026, 4, 1), date(2026, 4, 30), authors=["Tester"],
+                date(2026, 4, 1),
+                date(2026, 4, 30),
+                authors=["Tester"],
             )
         self.assertEqual(out, [])
 
     def test_holidays_picked_up(self):
         def fake_commits_on(repo, target, authors, **kw):
             if target == date(2026, 5, 1):
-                return [{"repo": "x", "sha": "1", "subject": "incident",
-                         "time": "2026-05-01T10:00:00"}]
+                return [
+                    {
+                        "repo": "x",
+                        "sha": "1",
+                        "subject": "incident",
+                        "time": "2026-05-01T10:00:00",
+                    }
+                ]
             return []
 
-        with mock.patch("lib.weekend_ot.commits_on", side_effect=fake_commits_on), \
-                mock.patch("lib.weekend_ot.discover_repos", return_value=["x"]):
+        with (
+            mock.patch("lib.weekend_ot.commits_on", side_effect=fake_commits_on),
+            mock.patch("lib.weekend_ot.discover_repos", return_value=["x"]),
+        ):
             out = detect_candidates(
-                date(2026, 5, 1), date(2026, 5, 1),
+                date(2026, 5, 1),
+                date(2026, 5, 1),
                 authors=["Tester"],
                 holidays={date(2026, 5, 1)},
             )
@@ -92,13 +116,22 @@ class TestMergeIntoAnalysis(unittest.TestCase):
             "schema_version": "attendance-analysis/v1",
             "overtime": [],
             "leave": [],
-            "summary": {"overtime_count": 0, "overtime_hours": 0,
-                        "leave_count": 0, "leave_hours": 0},
+            "summary": {
+                "overtime_count": 0,
+                "overtime_hours": 0,
+                "leave_count": 0,
+                "leave_hours": 0,
+            },
         }
-        candidates = [{
-            "date": "2026/04/25", "start_time": "1400", "end_time": "1500",
-            "hours": 1, "location": "在外地",
-        }]
+        candidates = [
+            {
+                "date": "2026/04/25",
+                "start_time": "1400",
+                "end_time": "1500",
+                "hours": 1,
+                "location": "在外地",
+            }
+        ]
         added = merge_into_analysis(analysis, candidates)
         self.assertEqual(added, 1)
         self.assertEqual(len(analysis["overtime"]), 1)
@@ -108,19 +141,36 @@ class TestMergeIntoAnalysis(unittest.TestCase):
     def test_skips_duplicate(self):
         analysis = {
             "schema_version": "attendance-analysis/v1",
-            "overtime": [{
-                "date": "2026/04/25", "start_time": "1400",
-                "end_time": "1500", "hours": 1, "location": "在外地",
-                "reason": "x",
-            }],
+            "overtime": [
+                {
+                    "date": "2026/04/25",
+                    "start_time": "1400",
+                    "end_time": "1500",
+                    "hours": 1,
+                    "location": "在外地",
+                    "reason": "x",
+                }
+            ],
             "leave": [],
-            "summary": {"overtime_count": 1, "overtime_hours": 1,
-                        "leave_count": 0, "leave_hours": 0},
+            "summary": {
+                "overtime_count": 1,
+                "overtime_hours": 1,
+                "leave_count": 0,
+                "leave_hours": 0,
+            },
         }
-        added = merge_into_analysis(analysis, [{
-            "date": "2026/04/25", "start_time": "1400", "end_time": "1500",
-            "hours": 1, "location": "在外地",
-        }])
+        added = merge_into_analysis(
+            analysis,
+            [
+                {
+                    "date": "2026/04/25",
+                    "start_time": "1400",
+                    "end_time": "1500",
+                    "hours": 1,
+                    "location": "在外地",
+                }
+            ],
+        )
         self.assertEqual(added, 0)
         self.assertEqual(len(analysis["overtime"]), 1)
 

--- a/test/test_wfh_holiday_edge.py
+++ b/test/test_wfh_holiday_edge.py
@@ -6,14 +6,12 @@ from datetime import datetime
 from attendance_analyzer import AttendanceAnalyzer, IssueType
 
 # Long header extracted to module level to avoid line length issues
-ATTENDANCE_HEADER = (
-    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
-)
+ATTENDANCE_HEADER = "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
 
 
 class TestWfhHolidayEdge(unittest.TestCase):
     def _run_analyze(self, text: str):
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
             f.write(text)
             path = f.name
         try:
@@ -32,9 +30,7 @@ class TestWfhHolidayEdge(unittest.TestCase):
 2025/10/10 17:00\t\t下班\t\t\t曠職\t未處理\t\t"""
         an = self._run_analyze(data)
         holiday_date = datetime(2025, 10, 10).date()
-        wfh_dates = {
-            i.date.date() for i in an.issues if i.type == IssueType.WFH
-        }
+        wfh_dates = {i.date.date() for i in an.issues if i.type == IssueType.WFH}
         self.assertNotIn(holiday_date, wfh_dates, "國定假日不應產生WFH建議")
 
     def test_friday_national_day_processed_skipped(self):
@@ -63,7 +59,7 @@ class TestWfhHolidayEdge(unittest.TestCase):
         self.assertEqual(len(an.issues), 0, "已處理的工作日應直接跳過")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 """Category: Policy/Holidays
 Purpose: WFH suggestion behavior on holidays vs normal Fridays."""

--- a/test/test_wfh_holiday_edge.py
+++ b/test/test_wfh_holiday_edge.py
@@ -6,7 +6,9 @@ from datetime import datetime
 from attendance_analyzer import AttendanceAnalyzer, IssueType
 
 # Long header extracted to module level to avoid line length issues
-ATTENDANCE_HEADER = "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
+ATTENDANCE_HEADER = (
+    "應刷卡時段\t當日卡鐘資料\t刷卡別\t卡鐘編號\t資料來源\t異常狀態\t處理狀態\t異常處理作業\t備註"
+)
 
 
 class TestWfhHolidayEdge(unittest.TestCase):

--- a/tools/check_coverage_threshold.py
+++ b/tools/check_coverage_threshold.py
@@ -15,6 +15,7 @@ Usage:
   python tools/check_coverage_threshold.py --min 90          # legacy mode
   python tools/check_coverage_threshold.py --baseline tools/coverage_baseline.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -72,21 +73,32 @@ def _summary(by_pkg: dict[str, tuple[int, int]]) -> tuple[float, dict[str, float
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--min", dest="legacy_min", type=float, default=None,
-                    help="Legacy mode — single overall threshold; "
-                    "skips per-package baseline check.")
-    ap.add_argument("--baseline", default="tools/coverage_baseline.json",
-                    help="Per-package baseline JSON (default: %(default)s)")
-    ap.add_argument("--dir", dest="coverdir", default="coverage_report",
-                    help="Coverage directory (default: %(default)s)")
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--min",
+        dest="legacy_min",
+        type=float,
+        default=None,
+        help="Legacy mode — single overall threshold; skips per-package baseline check.",
+    )
+    ap.add_argument(
+        "--baseline",
+        default="tools/coverage_baseline.json",
+        help="Per-package baseline JSON (default: %(default)s)",
+    )
+    ap.add_argument(
+        "--dir",
+        dest="coverdir",
+        default="coverage_report",
+        help="Coverage directory (default: %(default)s)",
+    )
     args = ap.parse_args()
 
     coverdir = Path(args.coverdir)
     if not coverdir.exists():
-        print("coverage_report/ not found. Run 'make coverage' first.",
-              file=sys.stderr)
+        print("coverage_report/ not found. Run 'make coverage' first.", file=sys.stderr)
         return 2
 
     by_pkg = compute_per_package(coverdir)
@@ -130,8 +142,10 @@ def main() -> int:
 
     print("-" * 56)
     overall_ok = overall + 1e-9 >= overall_min
-    print(f"{'OVERALL':<22} {overall:>7.2f}%  {overall_min:>8.2f}  "
-          f"{'✓ ok' if overall_ok else '❌ FAIL'}")
+    print(
+        f"{'OVERALL':<22} {overall:>7.2f}%  {overall_min:>8.2f}  "
+        f"{'✓ ok' if overall_ok else '❌ FAIL'}"
+    )
     if not overall_ok:
         failed.append(f"overall: {overall:.2f}% < min {overall_min:.2f}%")
 

--- a/tools/diff_screenshots.py
+++ b/tools/diff_screenshots.py
@@ -40,9 +40,7 @@ class DiffResult:
         return (not self.size_mismatch) and self.diff_ratio <= threshold
 
 
-def diff(
-    candidate: str | Path, baseline: str | Path, *, pixel_tolerance: int = 16
-) -> DiffResult:
+def diff(candidate: str | Path, baseline: str | Path, *, pixel_tolerance: int = 16) -> DiffResult:
     """Compare two PNGs. Lazy Pillow import keeps fhr's hard deps zero."""
     from PIL import Image, ImageChops  # type: ignore
 
@@ -74,11 +72,7 @@ def diff(
     # Tally pixels whose max RGB delta exceeds the tolerance.
     changed = 0
     for i in range(0, n_rgb, 3):
-        if (
-            raw[i] > pixel_tolerance
-            or raw[i + 1] > pixel_tolerance
-            or raw[i + 2] > pixel_tolerance
-        ):
+        if raw[i] > pixel_tolerance or raw[i + 1] > pixel_tolerance or raw[i + 2] > pixel_tolerance:
             changed += 1
     total_pixels = c.size[0] * c.size[1]
     return DiffResult(
@@ -127,9 +121,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         else:
             verdict = "✓" if ok else "❌"
-            print(
-                f"{verdict} diff_ratio={res.diff_ratio:.4f} (threshold {args.threshold})"
-            )
+            print(f"{verdict} diff_ratio={res.diff_ratio:.4f} (threshold {args.threshold})")
     return 0 if ok else 1
 
 

--- a/tools/diff_screenshots.py
+++ b/tools/diff_screenshots.py
@@ -20,6 +20,7 @@ Threshold defaults to 5% pixel difference, which absorbs Chromium
 anti-alias / font noise but flags structural changes (new fields,
 moved buttons, color theme swap).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -30,7 +31,7 @@ from pathlib import Path
 
 @dataclass
 class DiffResult:
-    diff_ratio: float            # 0.0 → identical, 1.0 → completely different
+    diff_ratio: float  # 0.0 → identical, 1.0 → completely different
     size_mismatch: bool
     candidate_size: tuple[int, int]
     baseline_size: tuple[int, int]
@@ -39,8 +40,9 @@ class DiffResult:
         return (not self.size_mismatch) and self.diff_ratio <= threshold
 
 
-def diff(candidate: str | Path, baseline: str | Path,
-         *, pixel_tolerance: int = 16) -> DiffResult:
+def diff(
+    candidate: str | Path, baseline: str | Path, *, pixel_tolerance: int = 16
+) -> DiffResult:
     """Compare two PNGs. Lazy Pillow import keeps fhr's hard deps zero."""
     from PIL import Image, ImageChops  # type: ignore
 
@@ -48,16 +50,20 @@ def diff(candidate: str | Path, baseline: str | Path,
     b = Image.open(baseline).convert("RGB")
     if c.size != b.size:
         return DiffResult(
-            diff_ratio=1.0, size_mismatch=True,
-            candidate_size=c.size, baseline_size=b.size,
+            diff_ratio=1.0,
+            size_mismatch=True,
+            candidate_size=c.size,
+            baseline_size=b.size,
         )
     delta = ImageChops.difference(c, b)
     bbox = delta.getbbox()
     if bbox is None:
         # Identical → fast path
         return DiffResult(
-            diff_ratio=0.0, size_mismatch=False,
-            candidate_size=c.size, baseline_size=b.size,
+            diff_ratio=0.0,
+            size_mismatch=False,
+            candidate_size=c.size,
+            baseline_size=b.size,
         )
     # Reduce the delta to the changed bounding box only (fewer pixels to walk)
     region = delta.crop(bbox)
@@ -68,34 +74,44 @@ def diff(candidate: str | Path, baseline: str | Path,
     # Tally pixels whose max RGB delta exceeds the tolerance.
     changed = 0
     for i in range(0, n_rgb, 3):
-        if (raw[i] > pixel_tolerance
-                or raw[i + 1] > pixel_tolerance
-                or raw[i + 2] > pixel_tolerance):
+        if (
+            raw[i] > pixel_tolerance
+            or raw[i + 1] > pixel_tolerance
+            or raw[i + 2] > pixel_tolerance
+        ):
             changed += 1
     total_pixels = c.size[0] * c.size[1]
     return DiffResult(
         diff_ratio=changed / total_pixels if total_pixels else 0.0,
         size_mismatch=False,
-        candidate_size=c.size, baseline_size=b.size,
+        candidate_size=c.size,
+        baseline_size=b.size,
     )
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("candidate", help="新截圖路徑")
     ap.add_argument("baseline", help="baseline 截圖路徑")
-    ap.add_argument("--threshold", type=float, default=0.05,
-                    help="可接受 pixel diff 比例 (預設 0.05 = 5%%)")
-    ap.add_argument("--pixel-tolerance", type=int, default=16,
-                    help="單像素 RGB 差 ≤ 此值視為相同 (預設 16/255)")
-    ap.add_argument("--quiet", action="store_true",
-                    help="只回 exit code,不印細節")
+    ap.add_argument(
+        "--threshold",
+        type=float,
+        default=0.05,
+        help="可接受 pixel diff 比例 (預設 0.05 = 5%%)",
+    )
+    ap.add_argument(
+        "--pixel-tolerance",
+        type=int,
+        default=16,
+        help="單像素 RGB 差 ≤ 此值視為相同 (預設 16/255)",
+    )
+    ap.add_argument("--quiet", action="store_true", help="只回 exit code,不印細節")
     args = ap.parse_args(argv)
 
     try:
-        res = diff(args.candidate, args.baseline,
-                   pixel_tolerance=args.pixel_tolerance)
+        res = diff(args.candidate, args.baseline, pixel_tolerance=args.pixel_tolerance)
     except FileNotFoundError as e:
         print(f"❌ 找不到檔案: {e.filename}", file=sys.stderr)
         return 2
@@ -106,12 +122,14 @@ def main(argv: list[str] | None = None) -> int:
     ok = res.is_within(args.threshold)
     if not args.quiet:
         if res.size_mismatch:
-            print(f"❌ size mismatch: candidate {res.candidate_size} "
-                  f"vs baseline {res.baseline_size}")
+            print(
+                f"❌ size mismatch: candidate {res.candidate_size} vs baseline {res.baseline_size}"
+            )
         else:
             verdict = "✓" if ok else "❌"
-            print(f"{verdict} diff_ratio={res.diff_ratio:.4f} "
-                  f"(threshold {args.threshold})")
+            print(
+                f"{verdict} diff_ratio={res.diff_ratio:.4f} (threshold {args.threshold})"
+            )
     return 0 if ok else 1
 
 

--- a/tools/fake_agent_browser.py
+++ b/tools/fake_agent_browser.py
@@ -26,6 +26,7 @@ Environment knobs:
   FHR_FAKE_AB_TRACE        if set, append each call to trace.log
   FHR_FAKE_AB_LOG_DIR      override log directory (default fixture_dir)
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -40,9 +41,7 @@ from pathlib import Path
 def _fixture_dir() -> Path:
     d = os.environ.get("FHR_FAKE_AB_FIXTURE_DIR")
     if not d:
-        sys.stderr.write(
-            "fake_agent_browser: FHR_FAKE_AB_FIXTURE_DIR not set\n"
-        )
+        sys.stderr.write("fake_agent_browser: FHR_FAKE_AB_FIXTURE_DIR not set\n")
         sys.exit(2)
     p = Path(d)
     if not p.is_dir():
@@ -68,8 +67,7 @@ def _load_state(path: Path) -> dict:
 
 
 def _save_state(path: Path, state: dict) -> None:
-    path.write_text(json.dumps(state, ensure_ascii=False, indent=2),
-                    encoding="utf-8")
+    path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def _trace(fixture_dir: Path, args: list[str]) -> None:
@@ -130,8 +128,7 @@ def _cmd_get(args: list[str], fixture_dir: Path, state: dict) -> int:
         return 0
     if target == "title":
         fixture = fixture_dir / "get" / "title.txt"
-        print(fixture.read_text(encoding="utf-8").rstrip()
-              if fixture.exists() else "")
+        print(fixture.read_text(encoding="utf-8").rstrip() if fixture.exists() else "")
         return 0
     # Unsupported sub — print empty.
     return 0
@@ -200,9 +197,7 @@ def _cmd_screenshot(args: list[str], fixture_dir: Path, state: dict) -> int:
     fallback = fixture_dir / "screenshot.png"
     src = override if override.exists() else fallback
     if not src.exists():
-        sys.stderr.write(
-            f"fake_agent_browser: no screenshot fixture at {src}\n"
-        )
+        sys.stderr.write(f"fake_agent_browser: no screenshot fixture at {src}\n")
         return 1
     shutil.copyfile(src, out_path)
     return 0

--- a/tools/gen_coverage_badge.py
+++ b/tools/gen_coverage_badge.py
@@ -5,18 +5,22 @@ This parses stdlib trace outputs to compute an overall percentage for
 project files (attendance_analyzer.py and lib/*.py), then writes an SVG badge
 to assets/coverage.svg.
 """
+
 import re
 from pathlib import Path
 
 
 def compute_percent(coverdir: Path) -> float:
-    files = [p for p in coverdir.glob('*.cover')
-             if p.name.startswith(('attendance_analyzer', 'lib.'))]
+    files = [
+        p
+        for p in coverdir.glob("*.cover")
+        if p.name.startswith(("attendance_analyzer", "lib."))
+    ]
     executed = missing = 0
     for p in files:
-        text = p.read_text(encoding='utf-8', errors='ignore').splitlines()
-        executed += sum(1 for line in text if re.match(r'^\s*\d+\s*:', line))
-        missing += sum(1 for line in text if line.strip().startswith('>>>>>>'))
+        text = p.read_text(encoding="utf-8", errors="ignore").splitlines()
+        executed += sum(1 for line in text if re.match(r"^\s*\d+\s*:", line))
+        missing += sum(1 for line in text if line.strip().startswith(">>>>>>"))
     total = executed + missing
     if total == 0:
         return 100.0
@@ -27,20 +31,20 @@ def render_svg(percent: float) -> str:
     pct = int(round(percent))
     # Choose color roughly following shields.io semantics
     if pct >= 90:
-        color = '#4c1'  # brightgreen
+        color = "#4c1"  # brightgreen
     elif pct >= 80:
-        color = '#97CA00'  # greenish
+        color = "#97CA00"  # greenish
     elif pct >= 70:
-        color = '#a4a61d'  # yellowgreen
+        color = "#a4a61d"  # yellowgreen
     elif pct >= 60:
-        color = '#dfb317'  # yellow
+        color = "#dfb317"  # yellow
     elif pct >= 50:
-        color = '#fe7d37'  # orange
+        color = "#fe7d37"  # orange
     else:
-        color = '#e05d44'  # red
+        color = "#e05d44"  # red
 
-    label = 'coverage'
-    value = f'{pct}%'
+    label = "coverage"
+    value = f"{pct}%"
 
     # Basic, self-contained SVG (no external fonts). Widths approximate.
     # Left (label) 78px, Right (value) depends on digits; fixed 54px works up to 100%.
@@ -50,7 +54,7 @@ def render_svg(percent: float) -> str:
     svg_ns = 'xmlns="http://www.w3.org/2000/svg"'
     aria = f'aria-label="{label}: {value}"'
     font = 'font-family="DejaVu Sans,Verdana,Geneva,sans-serif"'
-    return f'''<svg {svg_ns} width="{total_w}" height="20" role="img" {aria}>
+    return f"""<svg {svg_ns} width="{total_w}" height="20" role="img" {aria}>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -62,28 +66,27 @@ def render_svg(percent: float) -> str:
     <rect width="{total_w}" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" {font} font-size="11">
-    <text x="{left_w/2}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
-    <text x="{left_w/2}" y="14">{label}</text>
-    <text x="{left_w + right_w/2}" y="15" fill="#010101" fill-opacity=".3">{value}</text>
-    <text x="{left_w + right_w/2}" y="14">{value}</text>
+    <text x="{left_w / 2}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
+    <text x="{left_w / 2}" y="14">{label}</text>
+    <text x="{left_w + right_w / 2}" y="15" fill="#010101" fill-opacity=".3">{value}</text>
+    <text x="{left_w + right_w / 2}" y="14">{value}</text>
   </g>
-</svg>'''
+</svg>"""
 
 
 def main() -> None:
-    coverdir = Path('coverage_report')
+    coverdir = Path("coverage_report")
     if not coverdir.exists():
         raise SystemExit("coverage_report/ not found. Run 'make coverage' first.")
     percent = compute_percent(coverdir)
     svg = render_svg(percent)
 
-    assets = Path('assets')
+    assets = Path("assets")
     assets.mkdir(exist_ok=True)
-    out = assets / 'coverage.svg'
-    out.write_text(svg, encoding='utf-8')
-    print(f'Wrote badge to {out} ({percent:.1f}%).')
+    out = assets / "coverage.svg"
+    out.write_text(svg, encoding="utf-8")
+    print(f"Wrote badge to {out} ({percent:.1f}%).")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
-

--- a/tools/gen_coverage_badge.py
+++ b/tools/gen_coverage_badge.py
@@ -12,9 +12,7 @@ from pathlib import Path
 
 def compute_percent(coverdir: Path) -> float:
     files = [
-        p
-        for p in coverdir.glob("*.cover")
-        if p.name.startswith(("attendance_analyzer", "lib."))
+        p for p in coverdir.glob("*.cover") if p.name.startswith(("attendance_analyzer", "lib."))
     ]
     executed = missing = 0
     for p in files:

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -8,6 +8,7 @@ Checks:
 
 Exit code 0 if clean; 1 if issues found. Prints a brief report.
 """
+
 import os
 
 ROOT = os.path.dirname(os.path.dirname(__file__))

--- a/tools/run_coverage.py
+++ b/tools/run_coverage.py
@@ -5,14 +5,16 @@ from trace import Trace
 
 
 def main() -> None:
-    tr=Trace(count=True, trace=False, ignoredirs=[sys.prefix, sys.exec_prefix])
+    tr = Trace(count=True, trace=False, ignoredirs=[sys.prefix, sys.exec_prefix])
     try:
-        tr.runfunc(lambda: unittest.main(module=None, argv=['', '-q']))
+        tr.runfunc(lambda: unittest.main(module=None, argv=["", "-q"]))
     except SystemExit:
         pass
-    tr.results().write_results(show_missing=True, summary=True, coverdir='coverage_report')
-    print('Coverage report written to coverage_report/.')
+    tr.results().write_results(
+        show_missing=True, summary=True, coverdir="coverage_report"
+    )
+    print("Coverage report written to coverage_report/.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()
-

--- a/tools/run_coverage.py
+++ b/tools/run_coverage.py
@@ -10,9 +10,7 @@ def main() -> None:
         tr.runfunc(lambda: unittest.main(module=None, argv=["", "-q"]))
     except SystemExit:
         pass
-    tr.results().write_results(
-        show_missing=True, summary=True, coverdir="coverage_report"
-    )
+    tr.results().write_results(show_missing=True, summary=True, coverdir="coverage_report")
     print("Coverage report written to coverage_report/.")
 
 

--- a/tui/app.py
+++ b/tui/app.py
@@ -138,28 +138,18 @@ class AnalysisForm(Static):
             yield Label("分析設定", classes="section-label")
 
             # Show available .txt files in current directory
-            txt_files = sorted(
-                [f for f in glob.glob("*.txt") if not f.startswith("requirements")]
-            )
+            txt_files = sorted([f for f in glob.glob("*.txt") if not f.startswith("requirements")])
             if txt_files:
-                yield Label(
-                    f"📂 快速選擇檔案 ({len(txt_files)} 個)：", classes="section-label"
-                )
+                yield Label(f"📂 快速選擇檔案 ({len(txt_files)} 個)：", classes="section-label")
                 for fname in txt_files[:5]:  # Show first 5
-                    file_btn = Button(
-                        f"📄 {fname}", classes="file-button", id=f"file-{fname}"
-                    )
+                    file_btn = Button(f"📄 {fname}", classes="file-button", id=f"file-{fname}")
                     file_btn.variant = "default"
                     yield file_btn
                 if len(txt_files) > 5:
-                    yield Label(
-                        f"  ... 還有 {len(txt_files) - 5} 個檔案", classes="file-hint"
-                    )
+                    yield Label(f"  ... 還有 {len(txt_files) - 5} 個檔案", classes="file-hint")
 
             yield Label("或手動輸入路徑：", classes="section-label")
-            self.source_input = Input(
-                placeholder="輸入考勤TXT檔案路徑", id="source-path"
-            )
+            self.source_input = Input(placeholder="輸入考勤TXT檔案路徑", id="source-path")
             yield self.source_input
 
             self.output_input = Input(
@@ -199,9 +189,7 @@ class AnalysisForm(Static):
             yield self.mode_select
 
             yield Label("清除使用者既有狀態後再分析", classes="section-label")
-            self.reset_switch = Switch(
-                value=False, id="reset-state", name="reset-state"
-            )
+            self.reset_switch = Switch(value=False, id="reset-state", name="reset-state")
             yield self.reset_switch
 
             yield Label("Debug 模式（僅讀取、保留詳細日誌）", classes="section-label")
@@ -209,15 +197,11 @@ class AnalysisForm(Static):
             yield self.debug_switch
 
             yield Label("記住此檔案（下次快速選擇）", classes="section-label")
-            self.add_recent_switch = Switch(
-                value=True, id="add-recent", name="add-recent"
-            )
+            self.add_recent_switch = Switch(value=True, id="add-recent", name="add-recent")
             yield self.add_recent_switch
 
             yield Label("若為 Excel 同時輸出 CSV 副本", classes="section-label")
-            self.extra_csv_switch = Switch(
-                value=False, id="extra-csv", name="extra-csv"
-            )
+            self.extra_csv_switch = Switch(value=False, id="extra-csv", name="extra-csv")
             yield self.extra_csv_switch
 
             yield Label("預覽筆數上限", classes="section-label")
@@ -229,9 +213,7 @@ class AnalysisForm(Static):
             yield self.preview_input
 
             with Container(id="form-buttons"):
-                self.run_button = Button(
-                    "開始分析", id="run-analysis", variant="success"
-                )
+                self.run_button = Button("開始分析", id="run-analysis", variant="success")
                 self.cancel_button = Button(
                     "取消執行",
                     id="cancel-run",
@@ -322,9 +304,7 @@ class AnalysisForm(Static):
     def _on_input_submitted(self, _: Input.Submitted) -> None:
         """Handle Enter key in any input field"""
         if self.busy:
-            self.show_status(
-                "⚠️ 目前已有分析在進行中，請按 Ctrl+C 取消或等待完成。", "warning"
-            )
+            self.show_status("⚠️ 目前已有分析在進行中，請按 Ctrl+C 取消或等待完成。", "warning")
         elif not self._has_source_path:
             self.show_status("⚠️ 請先輸入考勤檔案路徑。", "warning")
         else:
@@ -523,13 +503,9 @@ class AttendanceAnalyzerApp(App[None]):
                 yield Label("執行進度", id="progress-header")
                 self.progress_bar = ProgressBar(total=4, id="progress-bar")
                 yield self.progress_bar
-                self.progress_stage = Static(
-                    self._translate(_WAITING_MESSAGE), id="progress-stage"
-                )
+                self.progress_stage = Static(self._translate(_WAITING_MESSAGE), id="progress-stage")
                 yield self.progress_stage
-                self.progress_log = Log(
-                    highlight=True, auto_scroll=True, id="progress-log"
-                )
+                self.progress_log = Log(highlight=True, auto_scroll=True, id="progress-log")
                 yield self.progress_log
 
                 yield Label("異常預覽", id="preview-header")
@@ -564,9 +540,7 @@ class AttendanceAnalyzerApp(App[None]):
         self._pending = pending
         self._start_analysis(pending)
 
-    def on_analysis_form_cancel_requested(
-        self, _: AnalysisForm.CancelRequested
-    ) -> None:
+    def on_analysis_form_cancel_requested(self, _: AnalysisForm.CancelRequested) -> None:
         self.action_cancel_analysis()
 
     def action_submit_form(self) -> None:
@@ -779,9 +753,7 @@ class AttendanceAnalyzerApp(App[None]):
 
     def action_toggle_language(self) -> None:
         self._language = "en" if self._language == "zh_TW" else "zh_TW"
-        message_id = (
-            _LANGUAGE_MESSAGE_ZH if self._language == "zh_TW" else _LANGUAGE_MESSAGE_EN
-        )
+        message_id = _LANGUAGE_MESSAGE_ZH if self._language == "zh_TW" else _LANGUAGE_MESSAGE_EN
         message = self._translate(message_id)
         self.progress_log.write_line(message)
         self._form.show_status(message)
@@ -822,9 +794,7 @@ def run_app(*, webview: bool = False, dark: bool | None = None) -> None:
         try:
             import textual_web  # noqa: F401
         except Exception as exc:  # pragma: no cover - optional dependency
-            raise SystemExit(
-                "textual-web 未安裝或初始化失敗，無法啟動瀏覽器模式。"
-            ) from exc
+            raise SystemExit("textual-web 未安裝或初始化失敗，無法啟動瀏覽器模式。") from exc
         command = [sys.executable, "-m", "tui", "--no-webview"]
         if dark:
             command.append("--dark")

--- a/tui/app.py
+++ b/tui/app.py
@@ -138,18 +138,28 @@ class AnalysisForm(Static):
             yield Label("分析設定", classes="section-label")
 
             # Show available .txt files in current directory
-            txt_files = sorted([f for f in glob.glob("*.txt") if not f.startswith("requirements")])
+            txt_files = sorted(
+                [f for f in glob.glob("*.txt") if not f.startswith("requirements")]
+            )
             if txt_files:
-                yield Label(f"📂 快速選擇檔案 ({len(txt_files)} 個)：", classes="section-label")
+                yield Label(
+                    f"📂 快速選擇檔案 ({len(txt_files)} 個)：", classes="section-label"
+                )
                 for fname in txt_files[:5]:  # Show first 5
-                    file_btn = Button(f"📄 {fname}", classes="file-button", id=f"file-{fname}")
+                    file_btn = Button(
+                        f"📄 {fname}", classes="file-button", id=f"file-{fname}"
+                    )
                     file_btn.variant = "default"
                     yield file_btn
                 if len(txt_files) > 5:
-                    yield Label(f"  ... 還有 {len(txt_files) - 5} 個檔案", classes="file-hint")
+                    yield Label(
+                        f"  ... 還有 {len(txt_files) - 5} 個檔案", classes="file-hint"
+                    )
 
             yield Label("或手動輸入路徑：", classes="section-label")
-            self.source_input = Input(placeholder="輸入考勤TXT檔案路徑", id="source-path")
+            self.source_input = Input(
+                placeholder="輸入考勤TXT檔案路徑", id="source-path"
+            )
             yield self.source_input
 
             self.output_input = Input(
@@ -189,7 +199,9 @@ class AnalysisForm(Static):
             yield self.mode_select
 
             yield Label("清除使用者既有狀態後再分析", classes="section-label")
-            self.reset_switch = Switch(value=False, id="reset-state", name="reset-state")
+            self.reset_switch = Switch(
+                value=False, id="reset-state", name="reset-state"
+            )
             yield self.reset_switch
 
             yield Label("Debug 模式（僅讀取、保留詳細日誌）", classes="section-label")
@@ -197,11 +209,15 @@ class AnalysisForm(Static):
             yield self.debug_switch
 
             yield Label("記住此檔案（下次快速選擇）", classes="section-label")
-            self.add_recent_switch = Switch(value=True, id="add-recent", name="add-recent")
+            self.add_recent_switch = Switch(
+                value=True, id="add-recent", name="add-recent"
+            )
             yield self.add_recent_switch
 
             yield Label("若為 Excel 同時輸出 CSV 副本", classes="section-label")
-            self.extra_csv_switch = Switch(value=False, id="extra-csv", name="extra-csv")
+            self.extra_csv_switch = Switch(
+                value=False, id="extra-csv", name="extra-csv"
+            )
             yield self.extra_csv_switch
 
             yield Label("預覽筆數上限", classes="section-label")
@@ -213,7 +229,9 @@ class AnalysisForm(Static):
             yield self.preview_input
 
             with Container(id="form-buttons"):
-                self.run_button = Button("開始分析", id="run-analysis", variant="success")
+                self.run_button = Button(
+                    "開始分析", id="run-analysis", variant="success"
+                )
                 self.cancel_button = Button(
                     "取消執行",
                     id="cancel-run",
@@ -304,7 +322,9 @@ class AnalysisForm(Static):
     def _on_input_submitted(self, _: Input.Submitted) -> None:
         """Handle Enter key in any input field"""
         if self.busy:
-            self.show_status("⚠️ 目前已有分析在進行中，請按 Ctrl+C 取消或等待完成。", "warning")
+            self.show_status(
+                "⚠️ 目前已有分析在進行中，請按 Ctrl+C 取消或等待完成。", "warning"
+            )
         elif not self._has_source_path:
             self.show_status("⚠️ 請先輸入考勤檔案路徑。", "warning")
         else:
@@ -507,7 +527,9 @@ class AttendanceAnalyzerApp(App[None]):
                     self._translate(_WAITING_MESSAGE), id="progress-stage"
                 )
                 yield self.progress_stage
-                self.progress_log = Log(highlight=True, auto_scroll=True, id="progress-log")
+                self.progress_log = Log(
+                    highlight=True, auto_scroll=True, id="progress-log"
+                )
                 yield self.progress_log
 
                 yield Label("異常預覽", id="preview-header")
@@ -542,7 +564,9 @@ class AttendanceAnalyzerApp(App[None]):
         self._pending = pending
         self._start_analysis(pending)
 
-    def on_analysis_form_cancel_requested(self, _: AnalysisForm.CancelRequested) -> None:
+    def on_analysis_form_cancel_requested(
+        self, _: AnalysisForm.CancelRequested
+    ) -> None:
         self.action_cancel_analysis()
 
     def action_submit_form(self) -> None:
@@ -685,9 +709,7 @@ class AttendanceAnalyzerApp(App[None]):
         for exported in result.outputs:
             prefix = "📝" if exported.actual_format == "csv" else "📄"
             fallback = " (CSV 回退)" if exported.fallback_applied else ""
-            self.progress_log.write_line(
-                f"{prefix} {exported.actual_path}{fallback}"
-            )
+            self.progress_log.write_line(f"{prefix} {exported.actual_path}{fallback}")
 
         self.summary_panel.update_result(result)
         self._render_preview(result)


### PR DESCRIPTION
## 摘要

整理出勤分析的請假/加班規則正確性,並把格式工具從 black 收斂到 ruff format。

### 行為修正
- **整日請假輸出**:平日整日缺勤 (WEEKDAY_LEAVE) 先前被 code-agent-hr exporter 直接忽略,從未進入 portal-apply;改輸出 `type_hint=full_day`(8h, 09:30–18:30)。
- **遲到請假扣午休**:遲到請假橫跨 12:30–13:30 午休時,午休非工時應扣除再進位(例:13:19 到班 4h → 3h)。
- **餘額解析器**:`parse_items_panel` 原假設第 0 列即表頭,實際 Portal 把網格包在巢狀 table、回傳含雜訊列 → 全部解析成 None,cascade 因而把補休/有薪病假當無上限亂配。改以 `r[0]=="加班"` 動態定位表頭、依序讀可休總/已休/剩餘。實測:補休 28h、有薪病假 0h。
- **portal-sync 翻頁**:請假單最多 25 頁,原本單一超長 eval 會把 agent-browser daemon 卡到逾時;改 Python 端逐頁短 eval。

### 新功能
- `fhr reasons --exclude-repo`:把個人側專案排除在工作理由證據之外(可重複,大小寫不敏感)。

### 工具/格式
- black → ruff format(pre-commit hook、CI、Taskfile、pyproject;移除 black 相依),並對全 repo 套用一次 ruff format。

### 文件
- 同步請假規則(遲到門檻 10:00、扣午休、整日請假、忘刷卡改每年 4 次且不自動套用)與 ruff 工具說明。

## 測試
- `python3 -m unittest -q`:406 passed
- `ruff check .` / `ruff format --check .`:clean
- lib.portal 覆蓋率拉回門檻(client.py 82%→98%)