### PR TITLE
chore: pin ruff invocation via python -m ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
           pip install openpyxl
       - name: Lint and format check (ruff)
         run: |
-          if command -v ruff >/dev/null 2>&1; then ruff --version && ruff check . && ruff format --check .; else echo 'ruff missing'; fi
+          # 用 `python -m ruff`（= requirements-dev 釘的 ruff==0.15.18），避免抓到系統其他版本
+          python -m ruff --version && python -m ruff check . && python -m ruff format --check .
       - name: Run tests with coverage (stdlib trace)
         run: |
           make coverage

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ coverage-check: coverage
 	$(PY) tools/check_coverage_threshold.py
 
 .PHONY: lint
+# 用 `$(PY) -m ruff`（= requirements-dev 釘的 ruff==0.15.18），而非 PATH 上
+# 可能不同版本的 ruff，確保格式判定與 CI / pre-commit 一致。
 lint:
-	@if command -v ruff >/dev/null 2>&1; then \
-		ruff check . ; \
+	@if $(PY) -m ruff --version >/dev/null 2>&1; then \
+		$(PY) -m ruff check . && $(PY) -m ruff format --check . ; \
 	else \
 		$(PY) tools/lint.py ; \
 	fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,14 +26,15 @@ tasks:
   lint:
     desc: Run linting checks
     cmds:
-      - ruff check .
-      - ruff format --check .
+      # 用 `python3 -m ruff`（= 釘版 ruff==0.15.18），避免 PATH 上飄版本
+      - python3 -m ruff check .
+      - python3 -m ruff format --check .
 
   format:
     desc: Auto-format code
     cmds:
-      - ruff check --fix .
-      - ruff format .
+      - python3 -m ruff check --fix .
+      - python3 -m ruff format .
 
   # Changelog and release tasks
   changelog-preview:


### PR DESCRIPTION
## 摘要

讓 ruff 的 lint/format 判定在本機、pre-commit、CI 三方一致,避免格式 churn。

## 問題
PATH 上的 `ruff` 可能是系統/homebrew 安裝的另一個版本(本機實測 `ruff` = 0.14.8),與 `requirements-dev` 釘的 `ruff==0.15.18` 不同。不同 ruff 版本的 `ruff format` 輸出可能不同,導致本機格式化後與 CI 的 `ruff format --check` 對不上。

## 修正
Makefile、Taskfile、CI 一律改用 `python -m ruff`(= 已安裝在 venv 內、由 requirements-dev 釘的 `ruff==0.15.18`),而非 PATH 上飄動版本的 `ruff`。

## 測試
- `make lint`(經 `python3 -m ruff`):check + format --check 全乾淨
- 純 tooling 調整,無程式邏輯異動