### PR TITLE
feat(portal): add portal-check pre-flight for rejected/in-flow forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ python attendance_analyzer.py portal-fetch --user JimmyChen
 # 從 Portal 同步「已申請的加班/請假單」進本地 state cache (dedup)
 python attendance_analyzer.py portal-sync --user JimmyChen
 
+# 送單前先行確認:列出被駁回 / 仍在簽核中的單 (--since 可限縮月份)
+python attendance_analyzer.py portal-check --since 2026/05
+
 # 顯示假別餘額 (補休/特休/事假/有薪病假/半薪病假/異地辦公)
 python attendance_analyzer.py portal-balances
 
@@ -93,7 +96,7 @@ make coverage                                     # 檢查測試覆蓋率
 ```
 
 ## 📊 系統能力與特色
-- **🎯 精準度**: 90%+ 測試覆蓋率  
+- **🎯 精準度**: 90%+ 測試覆蓋率
 - **⚡ 效能**: 支援處理 10 萬筆記錄，增量分析避免重複處理
 - **🔒 安全性**: 本地處理，資料不上傳，支援企業隱私要求
 - **🌏 國際化**: 完整中英文介面，支援台灣國定假日
@@ -101,7 +104,7 @@ make coverage                                     # 檢查測試覆蓋率
 
 ## 🏢 企業級功能
 - **🌐 Web 介面**: FastAPI 後端 + 現代化前端，支援多人使用
-- **🐳 容器部署**: Docker 生產就緒，支援 Kubernetes 擴展  
+- **🐳 容器部署**: Docker 生產就緒，支援 Kubernetes 擴展
 - **🔗 API 整合**: REST API 支援與 HRIS/薪資系統整合
 - **👥 多租戶**: 支援多部門、多公司資料隔離
 - **📈 監控**: 內建健康檢查、日誌管理與效能監控
@@ -133,16 +136,16 @@ make coverage                                     # 檢查測試覆蓋率
 
 ## 📚 完整文件
 
-👉 **[文件導航中心](docs/index.md)** - 快速找到您需要的文件  
-🔍 **[命令速查手冊](docs/quick-reference.md)** - 常用命令與格式參考  
-🛠️ **[疑難排解指南](docs/troubleshooting.md)** - 問題診斷與解決方案  
+👉 **[文件導航中心](docs/index.md)** - 快速找到您需要的文件
+🔍 **[命令速查手冊](docs/quick-reference.md)** - 常用命令與格式參考
+🛠️ **[疑難排解指南](docs/troubleshooting.md)** - 問題診斷與解決方案
 📋 **[改進項目清單](todos/README.md)** - 待開發功能與文檔改進項目
 
 ## 延伸閱讀（docs/）
 
 **核心功能文件**:
 - [系統概覽](docs/overview.md) - 整體功能與企業級特色
-- [使用指南](docs/usage.md) - 詳細操作說明與最佳實務  
+- [使用指南](docs/usage.md) - 詳細操作說明與最佳實務
 - [檔案格式](docs/data-format.md) - 輸入檔案格式與命名規範
 - [增量分析](docs/incremental.md) - 智慧狀態管理與處理邏輯
 - [輸出格式](docs/output.md) - Excel/CSV 匯出與備份機制

--- a/assets/coverage.svg
+++ b/assets/coverage.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="132" height="20" role="img" aria-label="coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="132" height="20" role="img" aria-label="coverage: 85%">
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -6,13 +6,13 @@
   <mask id="m"><rect width="132" height="20" rx="3" fill="#fff"/></mask>
   <g mask="url(#m)">
     <rect width="78" height="20" fill="#555"/>
-    <rect x="78" width="54" height="20" fill="#4c1"/>
+    <rect x="78" width="54" height="20" fill="#97CA00"/>
     <rect width="132" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="39.0" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="39.0" y="14">coverage</text>
-    <text x="105.0" y="15" fill="#010101" fill-opacity=".3">98%</text>
-    <text x="105.0" y="14">98%</text>
+    <text x="105.0" y="15" fill="#010101" fill-opacity=".3">85%</text>
+    <text x="105.0" y="14">85%</text>
   </g>
 </svg>

--- a/docs/portal.md
+++ b/docs/portal.md
@@ -81,6 +81,9 @@ fhr portal-check                 # all history
 fhr portal-check --since 2026/05 # only work-dates >= 2026/05
 ```
 
+Exits `0` only when the report is clean; rejected / in-flow findings exit `1`,
+so scripted gating works: `fhr portal-check --since 2026/05 && fhr portal-apply …`.
+
 ## State cache
 
 Per-user data persists in `attendance_state.json` (or wherever `FHR_STATE_FILE` points):

--- a/docs/portal.md
+++ b/docs/portal.md
@@ -8,6 +8,7 @@ End-to-end Portal integration via the optional [`agent-browser`](https://github.
 |---------|---------|
 | `fhr portal-fetch`     | Scrape 全部刷卡資料 → fhr-native 9-column `.txt` |
 | `fhr portal-sync`      | Mirror Portal's already-submitted 加班 / 請假單 into the state cache |
+| `fhr portal-check`     | Pre-flight: list 已駁回 (rejected) + 未處理 (still in-flow) forms before a new batch |
 | `fhr portal-balances`  | Print 假別餘額 table (補休 / 特休 / 事假 / 病假 / 異地辦公) |
 | `fhr portal-apply`     | Interactive (or `--auto`) batch submission of OT + leave forms |
 
@@ -33,6 +34,9 @@ End-to-end Portal integration via the optional [`agent-browser`](https://github.
 ## End-to-end flow
 
 ```bash
+# 0. Pre-flight — nothing rejected / stuck in簽核 before a new batch
+fhr portal-check --since 2026/05
+
 # 1. Scrape this month's punches → .txt the analyzer can ingest
 fhr portal-fetch --user JimmyChen
 
@@ -50,6 +54,31 @@ fhr reasons --input tmp/analysis.json --author 'Jimmy Chen' \
 
 # 5. Submit. Pre-syncs already-applied forms from Portal automatically.
 fhr portal-apply --user JimmyChen --input tmp/analysis.json --proxy 賴菁甫
+```
+
+## Pre-flight check (`portal-check`)
+
+Run this **before** submitting a new wave of forms. It queries the eWorkFlow
+Search page's 狀態 dropdown for the two buckets that need attention and skips
+the terminal ones:
+
+- **已駁回** — a form was rejected; decide whether to re-submit.
+- **未處理** — still waiting on an approver (in-flow); avoid stacking new forms.
+
+Anything 已核准 or withdrawn is terminal and not surfaced. `--since YYYY/MM`
+scopes the report to a work-date window (lexical prefix match on `YYYY/MM/DD`);
+omit it to scan all history. Read-only — no Portal writes, no cache mutation.
+
+> Status taxonomy (validated against the live Portal): the 狀態 dropdown offers
+> `未處理 / 已處理 / 已核准 / 已駁回 / 全部`. `已處理` = every acted-on form
+> (= 全部 when nothing is pending); `未處理` is the in-flow bucket. The approval
+> status shown per row lives in the visible 狀態 column (`流程結束(完成/駁回)`),
+> **not** in `wsdinfotext` — `portal-sync` now stores it on each cached entry
+> (previously blank).
+
+```bash
+fhr portal-check                 # all history
+fhr portal-check --since 2026/05 # only work-dates >= 2026/05
 ```
 
 ## State cache

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -23,6 +23,8 @@ KNOWN_SUBCOMMANDS = {
     "portal_fetch",
     "portal-sync",
     "portal_sync",
+    "portal-check",
+    "portal_check",
     "portal-balances",
     "portal_balances",
     "portal-apply",
@@ -70,6 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
         import_ as import_cmd,
         portal_apply as portal_apply_cmd,
         portal_balances as portal_balances_cmd,
+        portal_check as portal_check_cmd,
         portal_fetch as portal_fetch_cmd,
         portal_sync as portal_sync_cmd,
         reasons as reasons_cmd,
@@ -80,6 +83,7 @@ def build_parser() -> argparse.ArgumentParser:
     import_cmd.add_parser(sub)
     portal_fetch_cmd.add_parser(sub)
     portal_sync_cmd.add_parser(sub)
+    portal_check_cmd.add_parser(sub)
     portal_balances_cmd.add_parser(sub)
     portal_apply_cmd.add_parser(sub)
     reasons_cmd.add_parser(sub)
@@ -114,6 +118,10 @@ def run(argv: list | None = None) -> None:
         from lib.commands import portal_sync as portal_sync_cmd
 
         portal_sync_cmd.run(args)
+    elif args.cmd in ("portal-check", "portal_check"):
+        from lib.commands import portal_check as portal_check_cmd
+
+        portal_check_cmd.run(args)
     elif args.cmd in ("portal-balances", "portal_balances"):
         from lib.commands import portal_balances as portal_balances_cmd
 

--- a/lib/commands/portal_check.py
+++ b/lib/commands/portal_check.py
@@ -176,6 +176,10 @@ def run(args: argparse.Namespace) -> None:
     rejected = {k: filter_since(v, args.since) for k, v in rejected_raw.items()}
     pending = {k: filter_since(v, args.since) for k, v in pending_raw.items()}
 
-    report, _clean = format_report(rejected, pending, args.since)
+    report, clean = format_report(rejected, pending, args.since)
     for line in report.splitlines():
         logger.info("%s", line)
+    if not clean:
+        # Non-zero exit so scripted use (`fhr portal-check && fhr portal-apply`)
+        # stops when rejected / in-flow forms need attention first.
+        sys.exit(1)

--- a/lib/commands/portal_check.py
+++ b/lib/commands/portal_check.py
@@ -1,0 +1,181 @@
+"""`fhr portal-check` — pre-flight before submitting a new batch of forms.
+
+Queries the Portal's eWorkFlow Search page for two states that need the
+user's attention **before** applying the next wave of 加班 / 請假 forms:
+
+  - 已駁回 (rejected)  → decide whether to re-submit
+  - 未處理 (in-flow)   → still waiting on an approver; don't pile new forms on top
+
+Anything else (已核准 / withdrawn) is terminal and irrelevant to the gate,
+so we only surface these two buckets. Read-only against the Portal — it
+never writes forms or mutates the state cache.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Portal 狀態 dropdown values we treat as "needs attention".
+REJECTED_STATUS = "已駁回"
+PENDING_STATUS = "未處理"
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(
+        "portal-check",
+        aliases=["portal_check"],
+        help="送單前先行確認:列出被駁回 / 仍在簽核中的加班・請假單 (需 agent-browser)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+範例:
+  # 檢查全部歷史
+  fhr portal-check
+
+  # 只看某月之後的單子 (下一波送單前的常用範圍)
+  fhr portal-check --since 2026/05
+
+送單流程建議先跑此指令,乾淨再 fhr portal-apply。需在 .env 設定 EHR_URL。
+        """,
+    )
+    parser.add_argument(
+        "--since",
+        help="只列出假勤日 >= 此日期的單 (YYYY/MM 或 YYYY/MM/DD);預設列出全部",
+    )
+    parser.add_argument(
+        "--kinds",
+        nargs="+",
+        default=["overtime", "leave"],
+        choices=["overtime", "leave"],
+        help="要檢查哪些表單種類 (預設全部)",
+    )
+    parser.add_argument("--base-url", help="EHR base URL (預設讀 env EHR_URL)")
+    parser.add_argument("--session", help="agent-browser session 名稱 (預設 'fhr')")
+    parser.add_argument("--debug", action="store_true", help="啟用 debug 日誌")
+    return parser
+
+
+def _resolve_base_url(args: argparse.Namespace) -> str:
+    if args.base_url:
+        return args.base_url.rstrip("/")
+    raw = os.environ.get("EHR_URL", "").rstrip("/")
+    if not raw:
+        raise RuntimeError("找不到 EHR_URL — 請在 .env 設定 `EHR_URL=...` 或傳 --base-url")
+    for suffix in ("/LoginFOrginal.asp", "/LoginFOpen.asp"):
+        if raw.endswith(suffix):
+            raw = raw[: -len(suffix)]
+            break
+    return raw
+
+
+def filter_since(entries: list[dict], since: str | None) -> list[dict]:
+    """Keep entries whose 假勤日 (`date`, YYYY/MM/DD) is >= `since`.
+
+    `since` may be a prefix like ``2026/05`` — lexical comparison on the
+    zero-padded YYYY/MM/DD format sorts correctly. ``None`` keeps all."""
+    if not since:
+        return list(entries)
+    return [e for e in entries if e.get("date", "") >= since]
+
+
+_KIND_ZH = {"overtime": "加班單", "leave": "請假單"}
+
+
+def _fmt_entry(kind: str, e: dict) -> str:
+    span = f"{e.get('start_time', '')}~{e.get('end_time', '')}".strip("~")
+    hours = e.get("hours")
+    hours_s = f"{hours}h" if hours is not None else "?h"
+    extra = e.get("leave_type") or e.get("location") or ""
+    reason = e.get("reason") or ""
+    status = e.get("status") or ""
+    bits = [f"[{_KIND_ZH.get(kind, kind)}]", e.get("date", "?"), span, hours_s]
+    if extra:
+        bits.append(extra)
+    if status:
+        bits.append(f"[{status}]")
+    line = "  ・" + " | ".join(b for b in bits if b)
+    if reason:
+        line += f"  — {reason}"
+    return line
+
+
+def format_report(
+    rejected: dict[str, list[dict]],
+    pending: dict[str, list[dict]],
+    since: str | None,
+) -> tuple[str, bool]:
+    """Build the human report. Returns (text, clean) where clean is True
+    when nothing needs attention."""
+    scope = f"(假勤日 >= {since})" if since else "(全部歷史)"
+    n_rej = sum(len(v) for v in rejected.values())
+    n_pen = sum(len(v) for v in pending.values())
+    lines = [f"# 🚦 送單前先行確認 {scope}", ""]
+
+    if n_rej == 0 and n_pen == 0:
+        lines.append("✅ 乾淨:沒有被駁回、也沒有仍在簽核中的單。可以進下一波送單。")
+        return "\n".join(lines), True
+
+    if n_rej:
+        lines.append(f"❌ 被駁回 {n_rej} 筆 — 請評估是否重新申請:")
+        for kind, items in rejected.items():
+            lines.extend(_fmt_entry(kind, e) for e in items)
+        lines.append("")
+    if n_pen:
+        lines.append(f"⏳ 仍在簽核中/未處理 {n_pen} 筆 — 建議等流程結束再疊新單:")
+        for kind, items in pending.items():
+            lines.extend(_fmt_entry(kind, e) for e in items)
+        lines.append("")
+    lines.append("⚠️ 有需要處理的項目,建議先解決再送下一波。")
+    return "\n".join(lines), False
+
+
+def run(args: argparse.Namespace) -> None:
+    from attendance_analyzer import logger
+    from lib.env import load as load_env
+    from lib.portal import approvals
+    from lib.portal.client import (
+        AgentBrowserMissing,
+        LoginTimeout,
+        PortalSession,
+        ensure_login,
+    )
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    load_env()
+
+    try:
+        base_url = _resolve_base_url(args)
+    except RuntimeError as e:
+        logger.error("❌ %s", e)
+        sys.exit(2)
+
+    kinds = tuple(args.kinds)
+    try:
+        with PortalSession(args.session) as portal:
+            ensure_login(portal, base_url)
+            rejected_raw = approvals.fetch_all_applied_forms(
+                portal, base_url, kinds=kinds, status_zh=REJECTED_STATUS
+            )
+            pending_raw = approvals.fetch_all_applied_forms(
+                portal, base_url, kinds=kinds, status_zh=PENDING_STATUS
+            )
+    except AgentBrowserMissing as e:
+        logger.error("❌ %s", e)
+        sys.exit(3)
+    except LoginTimeout as e:
+        logger.error("❌ %s", e)
+        sys.exit(4)
+    except Exception as e:
+        logger.error("❌ Portal check 失敗: %s", e)
+        sys.exit(1)
+
+    rejected = {k: filter_since(v, args.since) for k, v in rejected_raw.items()}
+    pending = {k: filter_since(v, args.since) for k, v in pending_raw.items()}
+
+    report, _clean = format_report(rejected, pending, args.since)
+    for line in report.splitlines():
+        logger.info("%s", line)

--- a/lib/portal/approvals.py
+++ b/lib/portal/approvals.py
@@ -74,7 +74,17 @@ _READ_PAGE_JS = """
 
   const rows = Array.from(
     doc.querySelectorAll('tr[id^="tbWorkSheetDataList_"]')
-  ).map(r => ({id: r.id || '', wsdinfotext: r.getAttribute('wsdinfotext') || ''}));
+  ).map(r => {
+    // Column 4 (index 3) is the 狀態 column, e.g. 「流程結束(完成)」/
+    // 「流程結束(駁回)」. wsdinfotext carries the form body but not the
+    // approval status, so we read the visible cell instead.
+    const cells = Array.from(r.querySelectorAll('td')).map(td => (td.innerText || '').trim());
+    return {
+      id: r.id || '',
+      wsdinfotext: r.getAttribute('wsdinfotext') || '',
+      status_cell: cells[3] || '',
+    };
+  });
   return {totalPages, page: target, rows};
 })()
 """
@@ -107,13 +117,17 @@ def parse_wsdinfotext(text: str) -> dict | None:
     }
 
 
-def _set_form_filter(portal: PortalSession, form_name_zh: str) -> None:
-    """Set 狀態=全部 + 表單名稱=<form_name_zh> + click 提交."""
+def _set_form_filter(portal: PortalSession, form_name_zh: str, status_zh: str = "全部") -> None:
+    """Set 狀態=<status_zh> + 表單名稱=<form_name_zh> + click 提交.
+
+    `status_zh` accepts any option offered by the Portal's 狀態 dropdown
+    (未處理 / 已處理 / 已核准 / 已駁回 / 全部). Defaults to 全部 so the
+    sync path mirrors every submitted form."""
     raw = portal._run(["snapshot", "-i"])  # noqa: SLF001
     refs = _extract_filter_refs(raw)
     if not refs:
         raise RuntimeError("找不到 eWorkFlow 查詢表單 refs — Portal 版本可能不相容")
-    portal.select_ref(refs["status"], "全部")
+    portal.select_ref(refs["status"], status_zh)
     portal.select_ref(refs["form"], form_name_zh)
     portal.click_ref(refs["submit"])
     portal.wait(3000)
@@ -149,14 +163,16 @@ def fetch_form_entries(
     portal: PortalSession,
     base_url: str,
     form_name_zh: str,
+    status_zh: str = "全部",
 ) -> list[dict]:
     """Return parsed entries for a single form type (e.g. "加班單").
 
-    Pages are read one short eval at a time (Python drives pagination) so a
-    long form list doesn't tie up the agent-browser daemon."""
+    `status_zh` filters by the Portal's 狀態 dropdown (預設 全部). Pages are
+    read one short eval at a time (Python drives pagination) so a long form
+    list doesn't tie up the agent-browser daemon."""
     portal.open(f"{base_url}{FORM_LIST_URL_PATH}")
     portal.wait(2500)
-    _set_form_filter(portal, form_name_zh)
+    _set_form_filter(portal, form_name_zh, status_zh)
 
     def _read_page(idx: int) -> dict:
         result = portal.eval_json(_READ_PAGE_JS.replace("__PAGE__", str(idx)))
@@ -182,6 +198,11 @@ def fetch_form_entries(
             parsed = parse_wsdinfotext(row.get("wsdinfotext", ""))
             if parsed is None:
                 continue
+            # The visible 狀態 column is the reliable approval status;
+            # wsdinfotext rarely carries it. Prefer the cell when present.
+            status_cell = row.get("status_cell", "")
+            if status_cell:
+                parsed["status"] = status_cell
             parsed["row_id"] = rid
             entries.append(parsed)
 
@@ -198,12 +219,15 @@ def fetch_all_applied_forms(
     base_url: str,
     *,
     kinds: Iterable[str] = ("overtime", "leave"),
+    status_zh: str = "全部",
 ) -> dict[str, list[dict]]:
-    """Scrape all requested form kinds. Returns dict keyed by english name."""
+    """Scrape all requested form kinds. Returns dict keyed by english name.
+
+    `status_zh` filters every kind by the Portal's 狀態 dropdown (預設 全部)."""
     out: dict[str, list[dict]] = {}
     for kind in kinds:
         zh = FORM_NAMES.get(kind)
         if not zh:
             raise ValueError(f"未知的 form kind: {kind!r}")
-        out[kind] = fetch_form_entries(portal, base_url, zh)
+        out[kind] = fetch_form_entries(portal, base_url, zh, status_zh)
     return out

--- a/test/test_portal_approvals.py
+++ b/test/test_portal_approvals.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from lib.portal.approvals import (
     _extract_filter_refs,
+    _set_form_filter,
     fetch_all_applied_forms,
     fetch_form_entries,
     parse_wsdinfotext,
@@ -152,6 +153,61 @@ class TestFetchFormEntries(unittest.TestCase):
             fetch_form_entries(portal, "http://x", "加班單")
 
 
+class TestSetFormFilter(unittest.TestCase):
+    def _portal(self):
+        portal = mock.Mock()
+        portal._run.return_value = FILTER_SNAPSHOT
+        return portal
+
+    def test_defaults_to_all(self):
+        portal = self._portal()
+        _set_form_filter(portal, "加班單")
+        # status combobox (@e4) selected with 全部
+        portal.select_ref.assert_any_call("@e4", "全部")
+        portal.select_ref.assert_any_call("@e5", "加班單")
+
+    def test_honours_status(self):
+        portal = self._portal()
+        _set_form_filter(portal, "請假單", "已駁回")
+        portal.select_ref.assert_any_call("@e4", "已駁回")
+        portal.select_ref.assert_any_call("@e5", "請假單")
+
+    def test_missing_refs_raises(self):
+        portal = mock.Mock()
+        portal._run.return_value = "- cell foo"
+        with self.assertRaises(RuntimeError):
+            _set_form_filter(portal, "加班單", "未處理")
+
+
+class TestStatusCellCapture(unittest.TestCase):
+    def test_status_cell_overrides_wsd_status(self):
+        portal = mock.Mock()
+        portal._run.return_value = FILTER_SNAPSHOT
+        portal.eval_json.return_value = {
+            "totalPages": 1,
+            "rows": [
+                {
+                    "id": "tbWorkSheetDataList_1",
+                    "wsdinfotext": SAMPLE_WSD_OT,  # 目前狀態：已核准
+                    "status_cell": "流程結束(駁回)",
+                }
+            ],
+        }
+        entries = fetch_form_entries(portal, "http://x", "加班單", "已駁回")
+        # The visible 狀態 cell wins over the wsdinfotext-embedded status.
+        self.assertEqual(entries[0]["status"], "流程結束(駁回)")
+
+    def test_missing_status_cell_keeps_wsd_status(self):
+        portal = mock.Mock()
+        portal._run.return_value = FILTER_SNAPSHOT
+        portal.eval_json.return_value = {
+            "totalPages": 1,
+            "rows": [{"id": "r1", "wsdinfotext": SAMPLE_WSD_OT}],  # no status_cell
+        }
+        entries = fetch_form_entries(portal, "http://x", "加班單")
+        self.assertEqual(entries[0]["status"], "已核准")
+
+
 class TestFetchAllAppliedForms(unittest.TestCase):
     def test_iterates_kinds(self):
         portal = mock.Mock()
@@ -170,6 +226,13 @@ class TestFetchAllAppliedForms(unittest.TestCase):
         portal = mock.Mock()
         with self.assertRaises(ValueError):
             fetch_all_applied_forms(portal, "http://x", kinds=("nope",))
+
+    def test_threads_status_zh(self):
+        portal = mock.Mock()
+        portal._run.return_value = FILTER_SNAPSHOT
+        portal.eval_json.return_value = {"totalPages": 1, "rows": []}
+        fetch_all_applied_forms(portal, "http://x", kinds=("overtime",), status_zh="未處理")
+        portal.select_ref.assert_any_call("@e4", "未處理")
 
 
 if __name__ == "__main__":

--- a/test/test_portal_check.py
+++ b/test/test_portal_check.py
@@ -103,12 +103,14 @@ class TestRun(unittest.TestCase):
     def _run_capture(self, args, rejected, pending):
         """Run portal_check.run() with the portal + approvals layer mocked.
 
-        Returns (joined_logs, fetch_mock). Patches the concrete symbols the
-        lazy imports resolve to (patching sys.modules would not intercept
-        `from lib.portal import approvals` once the real module is loaded)."""
+        Returns (joined_logs, fetch_mock, exit_code). Patches the concrete
+        symbols the lazy imports resolve to (patching sys.modules would not
+        intercept `from lib.portal import approvals` once the real module is
+        loaded). exit_code is None when run() returns normally."""
         session_cm = mock.MagicMock()
         session_cm.__enter__.return_value = mock.MagicMock()
         logs: list[str] = []
+        exit_code = None
 
         with (
             mock.patch(
@@ -120,35 +122,42 @@ class TestRun(unittest.TestCase):
             mock.patch("attendance_analyzer.logger") as logger,
         ):
             logger.info.side_effect = lambda fmt, *a: logs.append(fmt % a if a else fmt)
-            portal_check.run(args)
-        return "\n".join(logs), fetch
+            try:
+                portal_check.run(args)
+            except SystemExit as e:
+                exit_code = e.code
+        return "\n".join(logs), fetch, exit_code
 
     def test_run_clean(self):
-        joined, fetch = self._run_capture(
+        joined, fetch, code = self._run_capture(
             self._args(),
             {"overtime": [], "leave": []},
             {"overtime": [], "leave": []},
         )
         self.assertIn("乾淨", joined)
+        self.assertIsNone(code)
         # queried both 已駁回 + 未處理
         self.assertEqual(fetch.call_count, 2)
 
     def test_run_reports_rejected(self):
-        joined, _ = self._run_capture(
+        joined, _, code = self._run_capture(
             self._args(),
             {"overtime": [_entry("2026/07/01")], "leave": []},
             {"overtime": [], "leave": []},
         )
         self.assertIn("被駁回 1 筆", joined)
+        # blockers present → non-zero exit so `portal-check && portal-apply` stops
+        self.assertEqual(code, 1)
 
     def test_run_with_since_filters(self):
         # the 2024 rejection is filtered out by --since 2026/05 → clean
-        joined, _ = self._run_capture(
+        joined, _, code = self._run_capture(
             self._args(since="2026/05"),
             {"overtime": [_entry("2024/01/01")], "leave": []},
             {"overtime": [], "leave": []},
         )
         self.assertIn("乾淨", joined)
+        self.assertIsNone(code)
 
     def test_run_missing_base_url_exits(self):
         args = self._args(base_url=None)

--- a/test/test_portal_check.py
+++ b/test/test_portal_check.py
@@ -1,0 +1,166 @@
+"""Tests for `lib/commands/portal_check.py`."""
+
+import argparse
+import unittest
+from unittest import mock
+
+from lib.commands import portal_check
+
+
+def _entry(date, **kw):
+    base = {
+        "date": date,
+        "start_time": "0930",
+        "end_time": "1830",
+        "hours": 8,
+        "leave_type": None,
+        "location": None,
+        "reason": "",
+        "status": "流程結束(駁回)",
+    }
+    base.update(kw)
+    return base
+
+
+class TestFilterSince(unittest.TestCase):
+    def test_none_keeps_all(self):
+        entries = [_entry("2024/01/01"), _entry("2026/07/01")]
+        self.assertEqual(len(portal_check.filter_since(entries, None)), 2)
+
+    def test_month_prefix_boundary(self):
+        entries = [
+            _entry("2026/04/30"),
+            _entry("2026/05/01"),
+            _entry("2026/06/15"),
+        ]
+        kept = portal_check.filter_since(entries, "2026/05")
+        self.assertEqual([e["date"] for e in kept], ["2026/05/01", "2026/06/15"])
+
+    def test_full_date_since(self):
+        entries = [_entry("2026/05/01"), _entry("2026/05/20")]
+        kept = portal_check.filter_since(entries, "2026/05/10")
+        self.assertEqual([e["date"] for e in kept], ["2026/05/20"])
+
+
+class TestFormatReport(unittest.TestCase):
+    def test_clean(self):
+        text, clean = portal_check.format_report(
+            {"overtime": [], "leave": []}, {"overtime": [], "leave": []}, "2026/05"
+        )
+        self.assertTrue(clean)
+        self.assertIn("乾淨", text)
+        self.assertIn("2026/05", text)
+
+    def test_rejected_and_pending(self):
+        rejected = {"overtime": [_entry("2026/05/01", location="在辦公室", hours=2)], "leave": []}
+        pending = {"overtime": [], "leave": [_entry("2026/06/02", status="簽核中")]}
+        text, clean = portal_check.format_report(rejected, pending, None)
+        self.assertFalse(clean)
+        self.assertIn("被駁回 1 筆", text)
+        self.assertIn("簽核中/未處理 1 筆", text)
+        self.assertIn("[加班單]", text)
+        self.assertIn("[請假單]", text)
+        self.assertIn("全部歷史", text)
+
+    def test_only_rejected(self):
+        rejected = {"overtime": [], "leave": [_entry("2026/05/05")]}
+        pending = {"overtime": [], "leave": []}
+        text, clean = portal_check.format_report(rejected, pending, None)
+        self.assertFalse(clean)
+        self.assertIn("被駁回 1 筆", text)
+        self.assertNotIn("仍在簽核中/未處理", text)
+
+
+class TestResolveBaseUrl(unittest.TestCase):
+    def test_arg_wins(self):
+        args = argparse.Namespace(base_url="http://x/")
+        self.assertEqual(portal_check._resolve_base_url(args), "http://x")
+
+    def test_env_strips_login_page(self):
+        args = argparse.Namespace(base_url=None)
+        with mock.patch.dict("os.environ", {"EHR_URL": "http://ehr/portal/LoginFOrginal.asp"}):
+            self.assertEqual(portal_check._resolve_base_url(args), "http://ehr/portal")
+
+    def test_missing_raises(self):
+        args = argparse.Namespace(base_url=None)
+        with mock.patch.dict("os.environ", {"EHR_URL": ""}):
+            with self.assertRaises(RuntimeError):
+                portal_check._resolve_base_url(args)
+
+
+class TestRun(unittest.TestCase):
+    def _args(self, **kw):
+        base = dict(
+            since=None,
+            kinds=["overtime", "leave"],
+            base_url="http://x",
+            session=None,
+            debug=False,
+        )
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def _run_capture(self, args, rejected, pending):
+        """Run portal_check.run() with the portal + approvals layer mocked.
+
+        Returns (joined_logs, fetch_mock). Patches the concrete symbols the
+        lazy imports resolve to (patching sys.modules would not intercept
+        `from lib.portal import approvals` once the real module is loaded)."""
+        session_cm = mock.MagicMock()
+        session_cm.__enter__.return_value = mock.MagicMock()
+        logs: list[str] = []
+
+        with (
+            mock.patch(
+                "lib.portal.approvals.fetch_all_applied_forms",
+                side_effect=[rejected, pending],
+            ) as fetch,
+            mock.patch("lib.portal.client.PortalSession", return_value=session_cm),
+            mock.patch("lib.portal.client.ensure_login"),
+            mock.patch("attendance_analyzer.logger") as logger,
+        ):
+            logger.info.side_effect = lambda fmt, *a: logs.append(fmt % a if a else fmt)
+            portal_check.run(args)
+        return "\n".join(logs), fetch
+
+    def test_run_clean(self):
+        joined, fetch = self._run_capture(
+            self._args(),
+            {"overtime": [], "leave": []},
+            {"overtime": [], "leave": []},
+        )
+        self.assertIn("乾淨", joined)
+        # queried both 已駁回 + 未處理
+        self.assertEqual(fetch.call_count, 2)
+
+    def test_run_reports_rejected(self):
+        joined, _ = self._run_capture(
+            self._args(),
+            {"overtime": [_entry("2026/07/01")], "leave": []},
+            {"overtime": [], "leave": []},
+        )
+        self.assertIn("被駁回 1 筆", joined)
+
+    def test_run_with_since_filters(self):
+        # the 2024 rejection is filtered out by --since 2026/05 → clean
+        joined, _ = self._run_capture(
+            self._args(since="2026/05"),
+            {"overtime": [_entry("2024/01/01")], "leave": []},
+            {"overtime": [], "leave": []},
+        )
+        self.assertIn("乾淨", joined)
+
+    def test_run_missing_base_url_exits(self):
+        args = self._args(base_url=None)
+        with (
+            mock.patch.dict("os.environ", {"EHR_URL": ""}),
+            mock.patch("lib.env.load"),
+            mock.patch("attendance_analyzer.logger"),
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                portal_check.run(args)
+        self.assertEqual(cm.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

新增 `fhr portal-check`：送出下一波加班／請假單**之前**的先行確認，列出兩種需要處理的表單狀態：

- **已駁回**：評估是否重新申請
- **未處理**：仍在簽核中，避免在舊單跑完前疊新單

其餘（已核准／撤回）屬終結狀態，不列出。`--since YYYY/MM` 可限縮假勤日範圍；唯讀，不對 Portal 寫入、不改 state cache。

## 動機

以往送單前沒有制度化的檢查，容易重送已被駁回的單、或在流程未結束時疊單。此指令固定為 `portal-apply` 送單流程的第 0 步。

## 附帶修正

eWorkFlow scraper 現在會擷取查詢結果列的「狀態」欄（`流程結束(完成/駁回)`）並寫入每筆 entry —— 簽核狀態不在 `wsdinfotext` 裡，先前 `portal-sync` 這欄一律空白。`_set_form_filter` / `fetch_form_entries` / `fetch_all_applied_forms` 新增 `status_zh` 參數（預設 `全部`，向後相容）。

## 測試

- 新增 `test/test_portal_check.py`（filter/report/resolve/run 流程）與 `test/test_portal_approvals.py` 的 status 過濾與 status-cell 擷取案例
- 全套 426 測試通過；ruff check/format 乾淨；per-package 覆蓋率門檻通過
- 已對實際 Portal 跑過乾淨與非乾淨兩種情境