### PR TITLE
ci(pr): use shared repo-policy automerge workflow

### DIFF
--- a/.github/policies/pr-automerge.yml
+++ b/.github/policies/pr-automerge.yml
@@ -1,0 +1,7 @@
+# Repo-specific overrides (unioned with jimc1682000/repo-policy defaults).
+
+trusted_comment_authors:
+  - jimc1682000
+
+allowed_merge_actors:
+  - jimc1682000

--- a/.github/workflows/pr-merge-automation.yml
+++ b/.github/workflows/pr-merge-automation.yml
@@ -1,0 +1,45 @@
+name: PR merge automation
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [main]
+  workflow_run:
+    workflows:
+      - CI
+    types: [completed]
+  schedule:
+    - cron: "17,47 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Optional PR number (empty = all open PRs)
+        required: false
+        default: ""
+      dry_run:
+        description: Classify only; do not label/comment/merge
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+  actions: read
+  statuses: read
+
+jobs:
+  evaluate:
+    uses: jimc1682000/repo-policy/.github/workflows/pr-automerge.yml@v1
+    with:
+      default_branch: main
+      policy_ref: v1
+      pr_number: ${{ inputs.pr_number || github.event.pull_request.number || '' }}
+      policy_override_path: .github/policies/pr-automerge.yml
+      automation_comment_authors: github-actions[bot],jimc1682000
+      automation_workflow_name: PR merge automation
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets:
+      token: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>jimc1682000/repo-policy//renovate/default"]
+}


### PR DESCRIPTION
## Summary
- Thin wrapper → `jimc1682000/repo-policy/.github/workflows/pr-automerge.yml@v1`
- Override: `.github/policies/pr-automerge.yml`
- Secret `AUTOMERGE_TOKEN` already set

## Test plan
- [ ] After merge, Actions → PR merge automation → dry_run=true
